### PR TITLE
Give the notebook a reasonable default page title

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -3,6 +3,6 @@
 module.exports = {
   use: [
     '@neutrinojs/jest',
-    ['@neutrinojs/react', { html: { appMountId: 'page' } }]
+    ['@neutrinojs/react', { html: { title: 'Iodide Notebook', appMountId: 'page' } }]
   ]
 };


### PR DESCRIPTION
Eventually we should probably use something like react-helmet to
set the title based on the notebook's contents. Until then, "Iodide
Notebook" is better than "Webpack App".