### PR TITLE
Make document title dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "react-helmet": "^5.2.0",
     "react-json-tree": "^0.10.9",
     "react-redux": "^5.0.6",
     "react-table": "^6.6.0",

--- a/src/components/title.jsx
+++ b/src/components/title.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Helmet from 'react-helmet'
 
 class Title extends React.Component {
   constructor(props) {
@@ -6,6 +7,7 @@ class Title extends React.Component {
     this.state = { previousMode: props.pageMode }
     this.onBlur = this.onBlur.bind(this)
     this.onFocus = this.onFocus.bind(this)
+    this.getTitle = this.getTitle.bind(this)
     this.changeTitle = this.changeTitle.bind(this)
     this.enterTitleEditMode = this.enterTitleEditMode.bind(this)
   }
@@ -22,6 +24,10 @@ class Title extends React.Component {
     }
   }
 
+  getTitle() {
+    if (this.props.pageMode !== 'title-edit') return (this.props.title || "New Notebook") + ' - Iodide'
+  }
+
   changeTitle(evt) {
     // this.props.actions.changeMode('title-edit')
     this.props.actions.changePageTitle(evt.target.value)
@@ -35,6 +41,7 @@ class Title extends React.Component {
   render() {
     const elem = (
       <div className={`title-field-contents ${this.props.pageMode !== 'title-edit' ? 'unselected-title-field' : ''}`}>
+        <Helmet title={this.getTitle()} />
         <input
           ref="titleEditor" // eslint-disable-line
           onBlur={this.onBlur}


### PR DESCRIPTION
The document title now matches the notebook title ( along with '- Iodide' suffix). In absence of a title the document title is set to "New Notebook - Iodide".

Closes Issue #253 