### PR TITLE
Fix cell spacing in matrix table

### DIFF
--- a/src/page.css
+++ b/src/page.css
@@ -546,6 +546,7 @@ div.declared-variables {
 /* for Github-flavored Markdown */
 table {
     display: block;
+    border-spacing: 0;
     overflow: auto;
     width: 100%;
 }


### PR DESCRIPTION
Removes the extra cell spacing from the table matrix as mentioned in Issue #240 