### PR TITLE
fixes the CSSCell update bug and corrects the test cases

### DIFF
--- a/src/components/cell-type-css.jsx
+++ b/src/components/cell-type-css.jsx
@@ -30,6 +30,7 @@ export class CSSCellUnconnected extends React.Component {
 export function mapStateToProps(state, ownProps) {
   const cell = getCellById(state.cells, ownProps.cellId)
   return {
+    cellId: cell.id,
     value: cell.value,
     rendered: cell.rendered,
   }

--- a/test/cell-type-css.test.js
+++ b/test/cell-type-css.test.js
@@ -1,21 +1,18 @@
-import React from "react"
-import { shallow } from "enzyme"
+import React from 'react'
+import { shallow } from 'enzyme'
 
-import {CSSCellUnconnected as CSSCell,
-  mapStateToProps} from '../src/components/cell-type-css.jsx'
+import { CSSCellUnconnected as CSSCell,
+  mapStateToProps } from '../src/components/cell-type-css.jsx'
 import CellEditor from '../src/components/cell-editor.jsx'
 import OneRowCell from '../src/components/one-row-cell.jsx'
 
 
-
-describe("CSSCell_unconnected react component", () => {
+describe('CSSCell_unconnected react component', () => {
   let props
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(
-        <CSSCell {...props} />
-      )
+      mountedCell = shallow(<CSSCell {...props} /> )
     }
     return mountedCell
   }
@@ -24,75 +21,76 @@ describe("CSSCell_unconnected react component", () => {
     props = {
       cellId: 5,
       value: 'h1 {color:pink}',
-      rendered: false
+      rendered: false,
     }
     mountedCell = undefined
   })
 
-  it("always renders one style elt", () => {
-    const styleElts = cell().find("style")
+  it('always renders one style elt', () => {
+    const styleElts = cell().find('style')
     expect(styleElts.length).toBe(1)
   })
 
-  it("the style elt has the correct value if rendered===true", () => {
+  it('the style elt has the correct value if rendered===true', () => {
     props.rendered = true
-    const styleElts = cell().find("style")
+    const styleElts = cell().find('style')
     expect(styleElts.text()).toEqual('h1 {color:pink}')
   })
 
-  it("the style elt is empty if rendered==false", () => {
-    const styleElts = cell().find("style")
+  it('the style elt is empty if rendered==false', () => {
+    const styleElts = cell().find('style')
     expect(styleElts.text()).toEqual('')
   })
 
-  it("always renders one CellEditor", () => {
+  it('always renders one CellEditor', () => {
     expect(cell().find(CellEditor).length).toBe(1)
   })
 
-  it("sets the CellEditor cellId prop to be the CSSCell cellId input prop", () => {
+  it('sets the CellEditor cellId prop to be the CSSCell cellId input prop', () => {
     expect(cell().find(CellEditor).props().cellId)
       .toBe(props.cellId)
   })
 
-  it("always renders one OneRowCell", () => {
+  it('always renders one OneRowCell', () => {
     expect(cell().find(OneRowCell).length).toBe(1)
   })
 
-  it("sets the OneRowCell cellId prop to be the CSSCell cellId input prop", () => {
+  it('sets the OneRowCell cellId prop to be the CSSCell cellId input prop', () => {
     expect(cell().find(OneRowCell).props().cellId)
       .toBe(props.cellId)
   })
 
 
-  it("is a OneRowCell with two children", () => {
+  it('is a OneRowCell with two children', () => {
     expect(cell().find(OneRowCell).children().length).toBe(2)
   })
 
-  it("has a cell CellEditor within its OneRowCell", () => {
+  it('has a cell CellEditor within its OneRowCell', () => {
     expect(cell().find(CellEditor).parent().is(OneRowCell)).toEqual(true)
   })
 
-  it("has a cell style elt within its OneRowCell", () => {
-    expect(cell().find("style").parent().is(OneRowCell)).toEqual(true)
+  it('has a cell style elt within its OneRowCell', () => {
+    expect(cell().find('style').parent().is(OneRowCell)).toEqual(true)
   })
 })
 
 
+describe('CSSCell mapStateToProps', () => {
+  const state = {
+    cells: [
+      { id: 5, value: 'h1 {color:pink}', rendered: true },
+      { id: 3, value: 'h1 {color:blue}', rendered: false }],
+  }
 
-describe("CSSCell mapStateToProps", () => {
-  const state = {cells:[
-    {id:5, value:'h1 {color:pink}', rendered:true},
-    {id:3, value:'h1 {color:blue}', rendered:false}]}
-
-  it("should return the content of the correct cells", () => {
-    let ownProps = {cellId:5}
+  it('should return the content of the correct cells', () => {
+    const ownProps = { cellId: 5 }
     expect(mapStateToProps(state, ownProps))
-      .toEqual({value:'h1 {color:pink}', rendered:true})
+      .toEqual({ value: 'h1 {color:pink}', rendered: true, cellId: 5 })
   })
 
-  it("should return the content of the correct cells", () => {
-    let ownProps = {cellId:3}
+  it('should return the content of the correct cells', () => {
+    const ownProps = { cellId: 3 }
     expect(mapStateToProps(state, ownProps))
-      .toEqual({value:'h1 {color:blue}',rendered:false})
+      .toEqual({ value: 'h1 {color:blue}', rendered: false, cellId: 3 })
   })
 })


### PR DESCRIPTION
- fixes the bug described in #337 
- updates the cell tests

example below. Run the css cell, then change a value, then run the css cell again to see if the output style changes. I suggest changing `border-radius` from `10px` to `100px`.

```
# markdown cell:
<div id='test' />

# css cell:
div#test {
  width:300px;
  height:300px;
  background-color:tomato;
  border-radius:10px;
}

```

