### PR TITLE
Automatically deploy to Github pages from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
 
 before_deploy:
   - npm run build
-  - cp prod/iodide.${TRAVIS_COMMIT}.html prod/index.html
+  - cp prod/iodide.${TRAVIS_BRANCH}.html prod/index.html
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,32 @@
 language: node_js
+
 node_js:
   - "lts/*"
   - "8"
+
 install:
   - npm install
+
 script:
   - npm run lint
   - npm test
+
+before_deploy:
+  - npm run build
+  - cp prod/iodide.${TRAVIS_COMMIT}.html prod/index.html
+
+deploy:
+  provider: pages
+  github-token: "$GITHUB_TOKEN"
+  skip-cleanup: true
+  keep-history: false
+  repo: iodide-project/master
+  verbose: false
+  local-dir: prod
+  target-branch: master
+  on:
+    branch: master
+
+env:
+  global:
+    secure: "xdWpZfWZvPTzY25ayFaC/62vceytA3jT6RdQIlhp9QOKvNYe5qiD4eviP+LflJhvc7gTNysYIidtWLhYqSqWU7GRLeHtfplJ6hXsZrPnI9CJiG+Ng9OIp7VShPb+q1RurdHMY/33TEXTk95KhA+9tQ4s8hyri1boqX48xcPWoIWH/ozqwkz3H0rWjzc7HX02D+TcE19PEdpH8eJCQa7dwAygFqc/kx5B5PoBZB6R756614CjaaPiQft3OfI8k7R15lExinoMiHpTFLmcFODZ8UPm0t2AD6GqmzRrXyTRqPkRQNRYG2mAr8RMaPkYk26piPmlNFKoWanPnu+Iq+plT6Adc57P0VPYT/a2QyiGhD1+5n08Bflz5AdDrSN/Qb3PXJDCQscqDGUjwfMKT+Jigt2L6Q1jSe3BZrhikb2+koSRS6g+bCpfu23iS2fog2P3n8npGv90EnUp3Zdgj8XcARLXxxb6hfFDZYUq2H8dEasKvxrZFDGjDECA5m4olNkZHSgHsU2zqNgzvNBQcICQ6+rHn5CWmO8WD5er+BnJoUl+mARSxhmkqdtVF+oR0KOhAWzeRvCEwqjHJ2o33kd0/cifjjc3w3ODNi8kXcpFYW5rQVHvRTx9dPXbhvRT2TyeZViA/j6PUMAcqeLw0Lgy57dFmE/0M8oJzqM8sz+mJF4="

--- a/package-lock.json
+++ b/package-lock.json
@@ -4524,6 +4524,17 @@
         "assert-plus": "1.0.0"
       }
     },
+    "git-rev-sync": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz",
+      "integrity": "sha1-oMLj3TkqvPa3aWLif8dfsyI0Sc4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.11",
+        "shelljs": "0.7.7"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -9808,6 +9819,15 @@
         "util.promisify": "1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      }
+    },
     "recompose": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
@@ -10384,6 +10404,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-react": "^7.6.1",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",
+    "git-rev-sync": "^1.9.1",
     "jest": "^21.2.1",
     "jest-cli": "^22.1.4",
     "neutrino": "^8.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const git_rev = require('git-rev-sync')
 const htmlTemplate = require('./src/html-template.js')
 
 if (git_rev.isTagDirty()) {
-  APP_VERSION_STRING = git_rev.long()
+  APP_VERSION_STRING = git_rev.branch()
 } else {
   APP_VERSION_STRING = git_rev.tag()
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,15 @@ const path = require('path')
 const CreateFileWebpack = require('create-file-webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const _ = require('lodash')
+const git_rev = require('git-rev-sync')
 
 const htmlTemplate = require('./src/html-template.js')
 
-let APP_VERSION_STRING = require('./package.json').version
+if (git_rev.isTagDirty()) {
+  APP_VERSION_STRING = git_rev.long()
+} else {
+  APP_VERSION_STRING = git_rev.tag()
+}
 
 const APP_DIR = path.resolve(__dirname, 'src/')
 const EXAMPLE_DIR = path.resolve(__dirname, 'examples/')
@@ -21,8 +26,12 @@ const htmlTemplateCompiler = _.template(htmlTemplate)
 module.exports = (env) => {
   if (env === 'prod') {
     BUILD_DIR = path.resolve(__dirname, 'prod/')
-    APP_PATH_STRING = 'https://iodide-project.github.io/iodide/dist/'
-    CSS_PATH_STRING = 'https://iodide-project.github.io/iodide/dist/'
+    if (git_rev.isTagDirty()) {
+      APP_PATH_STRING = 'https://iodide-project.github.io/master/'
+    } else {
+      APP_PATH_STRING = 'https://iodide-project.github.io/iodide/dist/'
+    }
+    CSS_PATH_STRING = APP_PATH_STRING
   } else if (env === 'dev') {
     BUILD_DIR = path.resolve(__dirname, 'dev/')
     APP_VERSION_STRING = 'dev'


### PR DESCRIPTION
Fixes #334

This automatically deploys each commit on master to Github pages, to the URL:

https://iodide-project.github.io/master/

These are deployed to a separate repository at iodide-project/master, since filling up the main dev repo with build products for every commit would soon balloon in size.  Even in the `master` repo, the commit is "orphaned" so the history is not actually retained.

I did make one substantial change to what `npm build` does.  Rather than pulling the version from the `package.json` file, it queries the git repo.  If the current commit is a tag, it uses that for a version number, otherwise it uses the git commit hash.  This ensures that the version in the build product is always exactly what it says it is.  (Presently, it creates a 0.2.0 release from all commits leading up to the 0.2.0 release, which is sure to cause confusion).