### PR TITLE
updated the ReactTable implementation to JSON.stringify other objects…

### DIFF
--- a/src/components/output.jsx
+++ b/src/components/output.jsx
@@ -27,7 +27,20 @@ const dataFrameHandler = {
   shouldHandle: value => nb.isRowDf(value),
 
   render: (value) => {
-    const columns = Object.keys(value[0]).map(k => ({ Header: k, accessor: k }))
+    const columns = Object.keys(value[0])
+      .map(k => ({
+        Header: k,
+        accessor: k,
+        Cell: (cell) => {
+          if (Object.prototype.toString.call(cell.value) === '[object Date]') {
+            return cell.value.toString()
+          }
+          if (Object.prototype.toString.call(cell.value) === '[object Object]') {
+            return JSON.stringify(cell.value)
+          }
+          return cell.value
+        },
+      }))
     const dataSetInfo = `array of objects: ${value.length} rows, ${columns.length} columns`
     return (
       <div>


### PR DESCRIPTION
…, and .toString any Date objects

To test, try putting this into a `JSCell`:

```javascript
var x = [
    {date: new Date(), obj: {a:10,b:20}, test: 'hello', test2: 1, test3: null},
    {date: new Date(), obj: {a:30,b:40}, test: 'goodbye', test2: 39394394, test3: null},
]
x
```

Tests forthcoming, but I wanted to fix this bug before we had too many dogfooders blocked by it.