### PR TITLE
fixes the row count issue with tables < 25 rows

### DIFF
--- a/src/components/output.jsx
+++ b/src/components/output.jsx
@@ -51,6 +51,7 @@ const dataFrameHandler = {
           showPaginationTop
           showPaginationBottom={false}
           pageSizeOptions={[5, 10, 25, 50, 100]}
+          minRows={0}
           defaultPageSize={25}
         />
       </div>


### PR DESCRIPTION
There are some weird formatting issues if your data table gets tweaked (for instance from using `.slice`). the output handler keeps the previous number of rows from the previous object that was fed into the component.

This is a pretty easy fix - just add `minRows={0}` and `ReactTable` knows exactly what to do. Demo below:

![feb-14-2018 14-22-39](https://user-images.githubusercontent.com/95735/36231464-f85fedd6-1192-11e8-94bf-a13d216b4041.gif)
