### PR TITLE
Lint jsx

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,13 @@
 module.exports = {
   "parser": "babel-eslint",
   "env": {
-      "browser": true,
-      "node": true
+    "browser": true,
+    "node": true,
+    "jest/globals": true,
   },
+  "plugins": [
+    "jest",
+  ],
   "extends": "airbnb",
   "rules": {
     "semi": ["off"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,8 @@ module.exports = {
     "no-restricted-syntax": ["off"],
     // Allow i++ in the final clause of a for loop
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }] ,
+    // Allow JSX in .js files
+    "react/jsx-filename-extension": ["off"],
     // ------------------------------------------------------------
     // TODO: The following lints are probably good to have in the long run,
     // but are disabled for now to get to zero lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -2989,6 +2989,12 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "21.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.12.1.tgz",
+      "integrity": "sha512-5r/PNtYtfYt5aPCGEO8OYncLHxpGv8A5gbqBx/q2bIDOBo9zr4adIA3+0MwI/9tHqllBePqoLiTgcxxyDaKxpg==",
+      "dev": true
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "jest --no-cache",
     "start": "webpack --watch --env dev",
     "build": "webpack  --env prod",
-    "lint": "eslint src/"
+    "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
@@ -61,6 +61,7 @@
     "eslint-config-google": "^0.9.1",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jest": "^21.12.1",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.6.1",
     "extract-text-webpack-plugin": "^3.0.2",

--- a/src/components/title.jsx
+++ b/src/components/title.jsx
@@ -36,7 +36,10 @@ class Title extends React.Component {
   }
 
   getTitle() {
-    if (this.props.pageMode !== 'title-edit') return (this.props.title || "New Notebook") + ' - Iodide'
+    if (this.props.pageMode !== 'title-edit') {
+      return `${this.props.title || 'New Notebook'} - Iodide`
+    }
+    return undefined
   }
 
   changeTitle(evt) {

--- a/test/cell-reducer.test.js
+++ b/test/cell-reducer.test.js
@@ -1,13 +1,12 @@
 import cellReducer from '../src/reducers/cell-reducer'
-import * as NB from '../src/notebook-utils'
 import { newNotebook } from './../src/state-prototypes'
 
-describe('add cells', ()=>{
-  let state = newNotebook()
-  let nextState = cellReducer(state, {type: 'ADD_CELL', cellType: 'javascript'})
-  it('should add a cell to the end of the current notebook', ()=> {
-    expect(nextState.cells.length).toEqual(newNotebook().cells.length+1)
-    expect(nextState.cells[nextState.cells.length-1].cellType).toEqual('javascript')
+describe('add cells', () => {
+  const state = newNotebook()
+  const nextState = cellReducer(state, { type: 'ADD_CELL', cellType: 'javascript' })
+  it('should add a cell to the end of the current notebook', () => {
+    expect(nextState.cells.length).toEqual(newNotebook().cells.length + 1)
+    expect(nextState.cells[nextState.cells.length - 1].cellType).toEqual('javascript')
   })
 })
 

--- a/test/cell-type-css.test.js
+++ b/test/cell-type-css.test.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { CSSCellUnconnected as CSSCell,
-  mapStateToProps } from '../src/components/cell-type-css.jsx'
-import CellEditor from '../src/components/cell-editor.jsx'
-import OneRowCell from '../src/components/one-row-cell.jsx'
+  mapStateToProps } from '../src/components/cell-type-css'
+import CellEditor from '../src/components/cell-editor'
+import OneRowCell from '../src/components/one-row-cell'
 
 
 describe('CSSCell_unconnected react component', () => {
@@ -12,7 +12,7 @@ describe('CSSCell_unconnected react component', () => {
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<CSSCell {...props} /> )
+      mountedCell = shallow(<CSSCell {...props} />)
     }
     return mountedCell
   }

--- a/test/cell-type-external.test.js
+++ b/test/cell-type-external.test.js
@@ -1,15 +1,11 @@
 import React from 'react'
-import { shallow, render } from 'enzyme'
-import { Provider } from 'react-redux'
-import configureStore from 'redux-mock-store'
+import { shallow } from 'enzyme'
 
 import { ExternalResourceCellUnconnected as ExternalResourceCell,
-  mapStateToProps } from '../src/components/cell-type-external-resource.jsx'
-import CellEditor from '../src/components/cell-editor.jsx'
-import TwoRowCell from '../src/components/two-row-cell.jsx'
-import ExternalResourceOutput from '../src/components/output-handler-external-resource.jsx'
-
-const mockStore = configureStore()
+  mapStateToProps } from '../src/components/cell-type-external-resource'
+import CellEditor from '../src/components/cell-editor'
+import TwoRowCell from '../src/components/two-row-cell'
+import ExternalResourceOutput from '../src/components/output-handler-external-resource'
 
 const STANDARD_NETWORK_ERROR = 'A network error occurred.'
 

--- a/test/cell-type-javascript.test.js
+++ b/test/cell-type-javascript.test.js
@@ -1,27 +1,18 @@
-import React from "react"
-import { shallow, render } from "enzyme"
+import React from 'react'
+import { shallow } from 'enzyme'
 
-import {JsCellUnconnected as JsCell,
-  mapStateToProps} from '../src/components/cell-type-javascript.jsx'
-import CellEditor from '../src/components/cell-editor.jsx'
-import TwoRowCell from '../src/components/two-row-cell.jsx'
-import CellOutput from '../src/components/output.jsx'
+import { JsCellUnconnected as JsCell,
+  mapStateToProps } from '../src/components/cell-type-javascript'
+import CellEditor from '../src/components/cell-editor'
+import TwoRowCell from '../src/components/two-row-cell'
+import CellOutput from '../src/components/output'
 
-
-import { Provider } from 'react-redux'
-
-
-import configureStore from 'redux-mock-store'
-const mockStore = configureStore()
-
-describe("JsCell_unconnected react component", () => {
+describe('JsCell_unconnected react component', () => {
   let props
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(
-        <JsCell {...props} />
-      )
+      mountedCell = shallow(<JsCell {...props} />)
     }
     return mountedCell
   }
@@ -35,7 +26,7 @@ describe("JsCell_unconnected react component", () => {
     mountedCell = undefined
   })
 
-  it("always renders one TwoRowCell", () => {
+  it('always renders one TwoRowCell', () => {
     expect(cell().find(TwoRowCell).length).toBe(1)
   })
 
@@ -44,54 +35,52 @@ describe("JsCell_unconnected react component", () => {
       .toBe(props.cellId)
   })
 
-  it("the TwoRowCell always has a row1 prop that is a CellEditor", () => {
+  it('the TwoRowCell always has a row1 prop that is a CellEditor', () => {
     expect(cell().wrap(cell().find(TwoRowCell)
       .props().row1).find(CellEditor)).toHaveLength(1)
   })
 
   it("sets the CellEditor cellId prop to be the JsCell's cellId prop", () => {
     expect(cell().wrap(cell().find(TwoRowCell)
-        .props().row1).props().cellId)
+      .props().row1).props().cellId)
       .toBe(props.cellId)
   })
 
-  it("the TwoRowCell always has a row2 prop that is a CellOutput", () => {
+  it('the TwoRowCell always has a row2 prop that is a CellOutput', () => {
     expect(cell().wrap(cell().find(TwoRowCell)
       .props().row2).find(CellOutput)).toHaveLength(1)
   })
 
   it("sets the CellOutput valueToRender prop to be the JsCell's value prop", () => {
     expect(cell().wrap(cell().find(TwoRowCell)
-        .props().row2).props().valueToRender)
+      .props().row2).props().valueToRender)
       .toBe(props.value)
   })
 
   it("sets the CellOutput renderValue prop to be the JsCell's value prop", () => {
     expect(cell().wrap(cell().find(TwoRowCell)
-        .props().row2).props().render)
+      .props().row2).props().render)
       .toBe(props.rendered)
   })
-
 })
 
 
-
-
-describe("JsCell mapStateToProps", () => {
-  const state = {cells:[
-    {id:5, rendered: false},
-    {id:3, value:3.14, rendered: true}]}
+describe('JsCell mapStateToProps', () => {
+  const state = {
+    cells: [
+      { id: 5, rendered: false },
+      { id: 3, value: 3.14, rendered: true }],
+  }
 
   it("should return the 'rendered' of the correct cell if value is undefined", () => {
-    let ownProps = {cellId:5}
+    const ownProps = { cellId: 5 }
     expect(mapStateToProps(state, ownProps))
-      .toEqual({rendered: false})
+      .toEqual({ rendered: false })
   })
 
   it("should return 'rendered' and 'value' of the correct cells", () => {
-    let ownProps = {cellId:3}
+    const ownProps = { cellId: 3 }
     expect(mapStateToProps(state, ownProps))
-      .toEqual({value:3.14, rendered: true})
+      .toEqual({ value: 3.14, rendered: true })
   })
-
 })

--- a/test/cell-type-markdown.test.js
+++ b/test/cell-type-markdown.test.js
@@ -1,25 +1,15 @@
-import React from "react"
-import { shallow, render, mount } from "enzyme"
+import { shallow } from 'enzyme'
+import React from 'react'
+import { MarkdownCellUnconnected, mapStateToProps } from '../src/components/cell-type-markdown'
+import CellEditor from '../src/components/cell-editor'
+import OneRowCell from '../src/components/one-row-cell'
 
-import MarkdownCell, {MarkdownCellUnconnected,
-  mapStateToProps} from '../src/components/cell-type-markdown.jsx'
-import CellEditor from '../src/components/cell-editor.jsx'
-import OneRowCell from '../src/components/one-row-cell.jsx'
-
-import { Provider } from 'react-redux'
-
-import configureStore from 'redux-mock-store'
-
-
-
-describe("MarkdownCell_unconnected react component", () => {
+describe('MarkdownCell_unconnected react component', () => {
   let props
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(
-        <MarkdownCellUnconnected {...props} />
-      )
+      mountedCell = shallow(<MarkdownCellUnconnected {...props} />)
     }
     return mountedCell
   }
@@ -36,7 +26,7 @@ describe("MarkdownCell_unconnected react component", () => {
     mountedCell = undefined
   })
 
-  it("always renders one OneRowCell", () => {
+  it('always renders one OneRowCell', () => {
     expect(cell().find(OneRowCell).length).toBe(1)
   })
 
@@ -45,109 +35,106 @@ describe("MarkdownCell_unconnected react component", () => {
       .toBe(props.cellId)
   })
 
-  it("the OneRowCell should have two children", () => {
+  it('the OneRowCell should have two children', () => {
     expect(cell().find(OneRowCell).props().children).toHaveLength(2)
   })
 
-  it("the OneRowCell always has a child that is a CellEditor", () => {
+  it('the OneRowCell always has a child that is a CellEditor', () => {
     expect(cell().wrap(cell().find(OneRowCell)
       .props().children).find(CellEditor)).toHaveLength(1)
   })
 
 
-  it("the OneRowCell always has a child that is is a div", () => {
+  it('the OneRowCell always has a child that is is a div', () => {
     expect(cell().wrap(cell().find(OneRowCell)
-      .props().children).find("div")).toHaveLength(1)
+      .props().children).find('div')).toHaveLength(1)
   })
 
-  it("editor shown if MD not rendered", () => {
+  it('editor shown if MD not rendered', () => {
     props.rendered = false
     props.pageMode = 'command'
     props.cellSelected = true
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'block'})
+      .toEqual({ display: 'block' })
 
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'none'})
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'none' })
   })
 
-  it("editor not shown if MD is rendered, and not editing", () => {
+  it('editor not shown if MD is rendered, and not editing', () => {
     props.rendered = true
     props.pageMode = 'command'
     props.cellSelected = true
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'none'})
+      .toEqual({ display: 'none' })
 
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'block'})
-      
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'block' })
   })
 
-  it("MD shown if rendered and in command mode, whether cell selected or not", () => {
+  it('MD shown if rendered and in command mode, whether cell selected or not', () => {
     props.rendered = true
     props.pageMode = 'command'
     props.cellSelected = true
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'none'})
+      .toEqual({ display: 'none' })
 
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'block'})
-      
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'block' })
   })
 
-  it("MD shown if rendered and in command mode, whether cell selected or not", () => {
+  it('MD shown if rendered and in command mode, whether cell selected or not', () => {
     props.rendered = true
     props.pageMode = 'command'
     props.cellSelected = false
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'none'})
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'block'})
+      .toEqual({ display: 'none' })
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'block' })
   })
 
-  it("MD shown if rendered and in command mode", () => {
+  it('MD shown if rendered and in command mode', () => {
     props.rendered = true
     props.pageMode = 'command'
     props.cellSelected = false
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'none'})
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'block'})
+      .toEqual({ display: 'none' })
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'block' })
   })
 
-  it("MD shown if rendered and in edit mode but another cell is selected", () => {
+  it('MD shown if rendered and in edit mode but another cell is selected', () => {
     props.rendered = true
     props.pageMode = 'edit'
     props.cellSelected = false
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'none'})
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'block'})
+      .toEqual({ display: 'none' })
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'block' })
   })
 
-  it("editor shown if in edit mode and cell selected", () => {
+  it('editor shown if in edit mode and cell selected', () => {
     props.rendered = true
     props.pageMode = 'edit'
     props.cellSelected = true
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({display: 'block'})
-    expect(cell().wrap(cell().find("div")).props().style)
-      .toEqual({display: 'none'})
+      .toEqual({ display: 'block' })
+    expect(cell().wrap(cell().find('div')).props().style)
+      .toEqual({ display: 'none' })
   })
 
-  it("div should have dangerouslySetInnerHTML", () => {
+  it('div should have dangerouslySetInnerHTML', () => {
     props.value = 'html string'
-    expect(cell().wrap(cell().find("div")).props().dangerouslySetInnerHTML)
-      .toEqual({__html: props.value})
+    expect(cell().wrap(cell().find('div')).props().dangerouslySetInnerHTML)
+      .toEqual({ __html: props.value })
   })
 
-  it("both the editor and output recieve enterEditMode() as props", () => {
+  it('both the editor and output recieve enterEditMode() as props', () => {
     expect(cell().wrap(cell().find(CellEditor)).props().onContainerClick)
       .toEqual(cell().instance().enterEditMode)
-    expect(cell().wrap(cell().find("div")).props().onDoubleClick)
+    expect(cell().wrap(cell().find('div')).props().onDoubleClick)
       .toEqual(cell().instance().enterEditMode)
   })
-
 })
 
 
@@ -195,27 +182,28 @@ describe("MarkdownCell_unconnected react component", () => {
 // })
 
 
-
-describe("MarkdownCell mapStateToProps", () => {
-  const state = {cells:[{
-    id: 5,
-    value: "#MD string",
-    rendered: true,
-    selected: true,},
+describe('MarkdownCell mapStateToProps', () => {
+  const state = {
+    cells: [{
+      id: 5,
+      value: '#MD string',
+      rendered: true,
+      selected: true,
+    },
     ],
-    mode: "edit",
-    viewMode: "presentation"
+    mode: 'edit',
+    viewMode: 'presentation',
   }
 
   it("should return the 'rendered' of the correct cell if value is undefined", () => {
-    let ownProps = {cellId:5}
+    const ownProps = { cellId: 5 }
     expect(mapStateToProps(state, ownProps))
       .toEqual({
-      value: "#MD string",
-      rendered: true,
-      cellSelected: true,
-      pageMode: 'edit',
-      viewMode: 'presentation',
-    })
+        value: '#MD string',
+        rendered: true,
+        cellSelected: true,
+        pageMode: 'edit',
+        viewMode: 'presentation',
+      })
   })
 })

--- a/test/cell-type-raw.test.js
+++ b/test/cell-type-raw.test.js
@@ -1,55 +1,51 @@
-import React from "react"
-import { shallow } from "enzyme"
+import React from 'react'
+import { shallow } from 'enzyme'
 
-import {RawCellUnconnected as RawCell} from '../src/components/cell-type-raw.jsx'
-import CellEditor from '../src/components/cell-editor.jsx'
-import OneRowCell from '../src/components/one-row-cell.jsx'
+import { RawCellUnconnected as RawCell } from '../src/components/cell-type-raw'
+import CellEditor from '../src/components/cell-editor'
+import OneRowCell from '../src/components/one-row-cell'
 
 
-
-describe("RawCellUnconnected react component", () => {
+describe('RawCellUnconnected react component', () => {
   let props
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(
-        <RawCell {...props} />
-      )
+      mountedCell = shallow(<RawCell {...props} />)
     }
     return mountedCell
   }
 
   beforeEach(() => {
     props = {
-      cellId: 5
+      cellId: 5,
     }
     mountedCell = undefined
   })
 
-  it("always renders one OneRowCell", () => {
+  it('always renders one OneRowCell', () => {
     expect(cell().find(OneRowCell).length).toBe(1)
   })
 
-  it("sets the OneRowCell cellId prop to be the RawCell cellId input prop", () => {
+  it('sets the OneRowCell cellId prop to be the RawCell cellId input prop', () => {
     expect(cell().find(OneRowCell).props().cellId)
       .toBe(props.cellId)
   })
 
-  it("is a OneRowCell with one child", () => {
+  it('is a OneRowCell with one child', () => {
     expect(cell().find(OneRowCell).children().length).toBe(1)
   })
 
-  it("has a cell CellEditor within its OneRowCell", () => {
+  it('has a cell CellEditor within its OneRowCell', () => {
     expect(cell().find(CellEditor).parent().is(OneRowCell)).toEqual(true)
   })
 
-  it("always renders one CellEditor", () => {
+  it('always renders one CellEditor', () => {
     expect(cell().find(CellEditor).length).toBe(1)
   })
 
-  it("sets the CellEditor cellId prop to be the RawCell cellId input prop", () => {
+  it('sets the CellEditor cellId prop to be the RawCell cellId input prop', () => {
     expect(cell().find(CellEditor).props().cellId)
       .toBe(props.cellId)
   })
-
 })

--- a/test/jsmd-tools.test.js
+++ b/test/jsmd-tools.test.js
@@ -1,10 +1,9 @@
-/*global it describe expect*/
+/* global it describe expect */
 import { parseJsmd,
   jsmdValidCellTypes,
-  jsmdValidCellSettings,
-  stringifyStateToJsmd} from './../src/jsmd-tools'
+  stringifyStateToJsmd } from './../src/jsmd-tools'
 
-import { newNotebook, blankState, newCell} from '../src/state-prototypes'
+import { newNotebook, newCell } from '../src/state-prototypes'
 
 
 let jsmdTestCase = `%% meta
@@ -42,41 +41,42 @@ the cell below allows you to load external scripts
 
 %% resource
 https://cdnjs.cloudflare.com/ajax/libs/three.js/88/three.min.js
- 
-%% js   
+
+%% js
 // above this is a DOM cell, which we can also target
 spinCubeInTarget("#dom-cell-2")`
 
-let jsmdEx1Meta = {title: "What a web notebook looks like",
-  viewMode: "editor",
-  lastExport: "2017-12-13T17:46:16.207Z",
-  jsmdVersionHash: "42-example_hash_1234567890",
-  jsmdPreviousVersionHash: "41-example_hash_prev_1234567890",
-  iodideAppVersion: "0.0.1",
-  iodideAppLocation: "https://some.cdn.com/path/version/iodideApp.js"
+const jsmdEx1Meta = {
+  title: 'What a web notebook looks like',
+  viewMode: 'editor',
+  lastExport: '2017-12-13T17:46:16.207Z',
+  jsmdVersionHash: '42-example_hash_1234567890',
+  jsmdPreviousVersionHash: '41-example_hash_prev_1234567890',
+  iodideAppVersion: '0.0.1',
+  iodideAppLocation: 'https://some.cdn.com/path/version/iodideApp.js',
 }
 
-describe('jsmd parser Ex 1', ()=>{
-  let jsmdParsed = parseJsmd(jsmdTestCase)
-  let cells = jsmdParsed.cells
-  let parseWarnings = jsmdParsed.parseWarnings
-  it('new cells should start with "\n%%" or "%%" at the start of the file. drop empty cells.', ()=> {
+describe('jsmd parser Ex 1', () => {
+  const jsmdParsed = parseJsmd(jsmdTestCase)
+  const { cells } = jsmdParsed
+  const { parseWarnings } = jsmdParsed
+  it('new cells should start with "\n%%" or "%%" at the start of the file. drop empty cells.', () => {
     expect(cells.length).toEqual(7)
   })
-  it('should have correct cell types', ()=> {
-    expect(cells.map(c => c.cellType)).toEqual(['meta','md','js','raw','md','resource','js'])
+  it('should have correct cell types', () => {
+    expect(cells.map(c => c.cellType)).toEqual(['meta', 'md', 'js', 'raw', 'md', 'resource', 'js'])
   })
-  it('should only have cell settings in the jsmdValidCellSettings list', ()=> {
+  it('should only have cell settings in the jsmdValidCellSettings list', () => {
     expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(jsmdValidCellTypes))
   })
-  it('should have zero parse warnings', ()=> {
+  it('should have zero parse warnings', () => {
     expect(parseWarnings.length).toEqual(0)
   })
-  it('cell 1 should have settings {"collapseEditViewInput": "SCROLLABLE", "collapseEditViewOutput": "COLLAPSED"}', ()=> {
-    expect(cells[1].settings).toEqual({collapseEditViewInput: 'SCROLLABLE', collapseEditViewOutput: 'COLLAPSED'})
+  it('cell 1 should have settings {"collapseEditViewInput": "SCROLLABLE", "collapseEditViewOutput": "COLLAPSED"}', () => {
+    expect(cells[1].settings).toEqual({ collapseEditViewInput: 'SCROLLABLE', collapseEditViewOutput: 'COLLAPSED' })
   })
-  it('should have correct meta settings', ()=> {
-    expect(cells.filter(c=>c.cellType==='meta')[0].content).toEqual(jsmdEx1Meta)
+  it('should have correct meta settings', () => {
+    expect(cells.filter(c => c.cellType === 'meta')[0].content).toEqual(jsmdEx1Meta)
   })
 })
 
@@ -96,17 +96,17 @@ foo
 
 `
 
-describe('jsmd parser test case 3', ()=>{
-  let jsmdParsed = parseJsmd(jsmdTestCase)
-  let cells = jsmdParsed.cells
-  let parseWarnings = jsmdParsed.parseWarnings
-  it('should have 4 cells and not trip up on caps or whitespace', ()=> {
+describe('jsmd parser test case 3', () => {
+  const jsmdParsed = parseJsmd(jsmdTestCase)
+  const { cells } = jsmdParsed
+  const { parseWarnings } = jsmdParsed
+  it('should have 4 cells and not trip up on caps or whitespace', () => {
     expect(cells.length).toEqual(4)
   })
-  it('should have zero parse warnings', ()=> {
+  it('should have zero parse warnings', () => {
     expect(parseWarnings.length).toEqual(0)
   })
-  it('all cells should have cellType==js', ()=> {
+  it('all cells should have cellType==js', () => {
     expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(['js']))
   })
 })
@@ -116,22 +116,20 @@ describe('jsmd parser test case 3', ()=>{
 jsmdTestCase = `
 %% js
 `
-describe('jsmd parser test case 4', ()=>{
-  let jsmdParsed = parseJsmd(jsmdTestCase)
-  let cells = jsmdParsed.cells
-  let parseWarnings = jsmdParsed.parseWarnings
-  it('should have 1 cell', ()=> {
+describe('jsmd parser test case 4', () => {
+  const jsmdParsed = parseJsmd(jsmdTestCase)
+  const { cells } = jsmdParsed
+  const { parseWarnings } = jsmdParsed
+  it('should have 1 cell', () => {
     expect(cells.length).toEqual(1)
   })
-  it('should have zero parse warnings', ()=> {
+  it('should have zero parse warnings', () => {
     expect(parseWarnings.length).toEqual(0)
   })
-  it('cell 0 should have no content', ()=> {
-    expect(cells[0].content).toEqual("")
+  it('cell 0 should have no content', () => {
+    expect(cells[0].content).toEqual('')
   })
 })
-
-
 
 
 // test error parsing and bad cell type conversion
@@ -145,63 +143,60 @@ foo
 %% meta
 invalid_json_content for meta setings
 `
-describe('jsmd parser test case 5', ()=>{
-  let jsmdParsed = parseJsmd(jsmdTestCase)
-  let cells = jsmdParsed.cells
-  let parseWarnings = jsmdParsed.parseWarnings
-  it('should have 4 cells', ()=> {
+describe('jsmd parser test case 5', () => {
+  const jsmdParsed = parseJsmd(jsmdTestCase)
+  const { cells } = jsmdParsed
+  const { parseWarnings } = jsmdParsed
+  it('should have 4 cells', () => {
     expect(cells.length).toEqual(4)
   })
-  it('should have four parse warnings', ()=> {
+  it('should have four parse warnings', () => {
     expect(parseWarnings.length).toEqual(4)
   })
-  it('all cells should have cellType==js (bad cellTypes should convert to js)', ()=> {
-    expect(cells.map(c => c.cellType)).toEqual(['js','js','js','meta'])
+  it('all cells should have cellType==js (bad cellTypes should convert to js)', () => {
+    expect(cells.map(c => c.cellType)).toEqual(['js', 'js', 'js', 'meta'])
   })
-  it('cell 1 should have "collapseEditViewInput"=="COLLAPSED"', ()=> {
-    expect(cells[1].settings.collapseEditViewInput).toEqual("COLLAPSED")
+  it('cell 1 should have "collapseEditViewInput"=="COLLAPSED"', () => {
+    expect(cells[1].settings.collapseEditViewInput).toEqual('COLLAPSED')
   })
-  it('cell 2 should have "collapseEditViewOutput"=="COLLAPSED"', ()=> {
-    expect(cells[2].settings.collapseEditViewOutput).toEqual("COLLAPSED")
+  it('cell 2 should have "collapseEditViewOutput"=="COLLAPSED"', () => {
+    expect(cells[2].settings.collapseEditViewOutput).toEqual('COLLAPSED')
   })
 })
 
 
-
-
-
-describe('jsmd stringifier test case 1', ()=>{
-  let state = newNotebook()
+describe('jsmd stringifier test case 1', () => {
+  const state = newNotebook()
   state.cells[0].content = 'foo'
-  let jsmd = stringifyStateToJsmd(state)
-  let jsmdExpected = `%% js
+  const jsmd = stringifyStateToJsmd(state)
+  const jsmdExpected = `%% js
 foo`
-  it('simple state with default global setting should serialize to jsmd correctly', ()=> {
+  it('simple state with default global setting should serialize to jsmd correctly', () => {
     expect(jsmd).toEqual(jsmdExpected)
   })
 })
 
-describe('jsmd stringifier test case 2', ()=>{
-  let state = newNotebook()
+describe('jsmd stringifier test case 2', () => {
+  const state = newNotebook()
   state.cells[0].content = 'foo'
   state.title = 'foo notebook'
-  let jsmd = stringifyStateToJsmd(state)
-  let jsmdExpected = `%% meta
+  const jsmd = stringifyStateToJsmd(state)
+  const jsmdExpected = `%% meta
 {
   "title": "foo notebook"
 }
 
 %% js
 foo`
-  it('simple state should serialize to jsmd correctly', ()=> {
+  it('simple state should serialize to jsmd correctly', () => {
     expect(jsmd).toEqual(jsmdExpected)
   })
 })
 
-describe('jsmd stringifier test case 3', ()=>{
-  let state = newNotebook()
+describe('jsmd stringifier test case 3', () => {
+  const state = newNotebook()
   state.title = 'foo notebook'
-  state.viewMode = "presentation"
+  state.viewMode = 'presentation'
 
   state.cells[0].content = 'foo'
   state.cells[0].collapseEditViewInput = 'COLLAPSED'
@@ -209,8 +204,8 @@ describe('jsmd stringifier test case 3', ()=>{
   state.cells.push(newCell(state.cells, 'markdown'))
   state.cells[1].content = 'foo'
 
-  let jsmd = stringifyStateToJsmd(state)
-  let jsmdExpected = `%% meta
+  const jsmd = stringifyStateToJsmd(state)
+  const jsmdExpected = `%% meta
 {
   "title": "foo notebook",
   "viewMode": "presentation"
@@ -221,27 +216,26 @@ foo
 
 %% md
 foo`
-  it('cell settings should serialize to jsmd correctly', ()=> {
+  it('cell settings should serialize to jsmd correctly', () => {
     expect(jsmd).toEqual(jsmdExpected)
   })
 })
 
-describe('jsmd stringifier test case 4', ()=>{
-  let state = newNotebook()
+describe('jsmd stringifier test case 4', () => {
+  const state = newNotebook()
   state.title = 'foo notebook'
 
   state.cells[0].content = 'foo'
   state.cells[0].collapseEditViewInput = 'COLLAPSED'
 
-  let cellTypes = ['markdown','external dependencies','raw']
-  cellTypes.forEach(
-    (cellType,i) => {
-      state.cells.push(newCell(state.cells, cellType))
-      state.cells[i+1].content = 'foo'
-    })
+  const cellTypes = ['markdown', 'external dependencies', 'raw']
+  cellTypes.forEach((cellType, i) => {
+    state.cells.push(newCell(state.cells, cellType))
+    state.cells[i + 1].content = 'foo'
+  })
 
-  let jsmd = stringifyStateToJsmd(state)
-  let jsmdExpected = `%% meta
+  const jsmd = stringifyStateToJsmd(state)
+  const jsmdExpected = `%% meta
 {
   "title": "foo notebook"
 }
@@ -257,7 +251,7 @@ foo
 
 %% raw
 foo`
-  it('all cell types should serialize to jsmd correctly', ()=> {
+  it('all cell types should serialize to jsmd correctly', () => {
     expect(jsmd).toEqual(jsmdExpected)
   })
 })

--- a/test/mockLocalStorage.js
+++ b/test/mockLocalStorage.js
@@ -1,8 +1,8 @@
-let localStorage = {}
+const localStorage = {}
 
-export default {  
+export default {
   setItem(key, value) {
-    return Object.assign(localStorage, {[key]: value})
+    return Object.assign(localStorage, { [key]: value })
   },
   getItem(key) {
     return localStorage[key]
@@ -12,11 +12,11 @@ export default {
     return localStorage
   },
   hasOwnProperty(key) {
-    return localStorage.hasOwnProperty(key)
+    return Object.prototype.hasOwnProperty.call(localStorage, key)
   },
   clear() {
-    localStorage = {}
-  }
+    Object.keys(localStorage).forEach(k => delete localStorage[k])
+  },
 }
 
-export {localStorage}
+export { localStorage }

--- a/test/notebook-reducer.test.js
+++ b/test/notebook-reducer.test.js
@@ -1,76 +1,70 @@
 import notebookReducer from '../src/reducers/notebook-reducer'
 import localStorageMock from './mockLocalStorage'
-import { newNotebook, blankState, newCell } from '../src/state-prototypes.js'
-import * as utils from '../src/state-prototypes'
+import { newNotebook, blankState, newCell } from '../src/state-prototypes'
 
 
 window.localStorage = localStorageMock
 
 const EXAMPLE_NOTEBOOK_1 = 'example notebook with content'
 
-function exampleNotebookWithContent(title=EXAMPLE_NOTEBOOK_1) {
-  let state = utils.newNotebook()
+function exampleNotebookWithContent(title = EXAMPLE_NOTEBOOK_1) {
+  const state = newNotebook()
   state.cells.push(newCell(state.cells, 'javascript'))
   state.cells.push(newCell(state.cells, 'markdown'))
   state.cells[0].selected = true
   state.title = title
-  // utils.addCell(state.cells, 'javascript')
-  // utils.addCell(state.cells, 'markdown')
-  // utils.selectCell(state.cells, state.cells[0].id)
-  // utils.changeTitle(state, title)
   return state
 }
 
 
-describe('blank-state-reducer', ()=>{
-  it('should return the initial state', ()=>{
+describe('blank-state-reducer', () => {
+  it('should return the initial state', () => {
     expect(notebookReducer(blankState(), {})).toEqual(blankState())
   })
 })
 
-describe('new notebooks', ()=>{
-  let nextState = utils.newNotebook()
+describe('new notebooks', () => {
+  const nextState = newNotebook()
 
-  it('should create newNotebook() on NEW_NOTEBOOK', ()=>{
-    expect(notebookReducer(nextState, {type:'NEW_NOTEBOOK'})).toEqual(newNotebook())
-  })
-
-})
-
-describe('misc. notebook operations that don\'t belong elsewhere', ()=> {
-  let state = exampleNotebookWithContent()
-  let NEW_NAME = 'changed notebook name'
-  it('should change title', ()=>{
-    expect(notebookReducer(state, {type:'CHANGE_PAGE_TITLE', title: NEW_NAME}).title).toEqual(NEW_NAME)
+  it('should create newNotebook() on NEW_NOTEBOOK', () => {
+    expect(notebookReducer(nextState, { type: 'NEW_NOTEBOOK' })).toEqual(newNotebook())
   })
 })
 
-describe('importing a notebook via state', ()=> {
-  let state = newNotebook()
-  let nextState = exampleNotebookWithContent()
-
-  it('should import a notebook correctly on IMPORT_NOTEBOOK', ()=>{
-    expect(notebookReducer(state, {type: 'IMPORT_NOTEBOOK', newState: nextState})).toEqual(nextState)
+describe('misc. notebook operations that don\'t belong elsewhere', () => {
+  const state = exampleNotebookWithContent()
+  const NEW_NAME = 'changed notebook name'
+  it('should change title', () => {
+    expect(notebookReducer(state, { type: 'CHANGE_PAGE_TITLE', title: NEW_NAME }).title).toEqual(NEW_NAME)
   })
 })
 
-describe('saving / deleting localStorage-saved notebooks', ()=>{
+describe('importing a notebook via state', () => {
+  const state = newNotebook()
+  const nextState = exampleNotebookWithContent()
+
+  it('should import a notebook correctly on IMPORT_NOTEBOOK', () => {
+    expect(notebookReducer(state, { type: 'IMPORT_NOTEBOOK', newState: nextState })).toEqual(nextState)
+  })
+})
+
+describe('saving / deleting localStorage-saved notebooks', () => {
   // this will do enough for now.
 
-  let SAVE_DELETE_NOTEBOOK_NAME = 'save-delete-notebook-tests'
-  let state = exampleNotebookWithContent(SAVE_DELETE_NOTEBOOK_NAME)
+  const SAVE_DELETE_NOTEBOOK_NAME = 'save-delete-notebook-tests'
+  const state = exampleNotebookWithContent(SAVE_DELETE_NOTEBOOK_NAME)
 
-  it('should save via SAVE_NOTEBOOK',()=>{
-    notebookReducer(state, {type: 'SAVE_NOTEBOOK'})
+  it('should save via SAVE_NOTEBOOK', () => {
+    notebookReducer(state, { type: 'SAVE_NOTEBOOK' })
 
-    let savedNotebook = JSON.parse(window.localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME))
+    const savedNotebook = JSON.parse(window.localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME))
     expect(savedNotebook.title).toEqual(state.title)
     expect(savedNotebook.lastSaved).toBeDefined()
     expect(savedNotebook.cells).toEqual(state.cells)
   })
 
-  it('should delete via DELETE_NOTEBOOK', ()=> {
-    notebookReducer(state, {type: 'DELETE_NOTEBOOK', title: SAVE_DELETE_NOTEBOOK_NAME})
+  it('should delete via DELETE_NOTEBOOK', () => {
+    notebookReducer(state, { type: 'DELETE_NOTEBOOK', title: SAVE_DELETE_NOTEBOOK_NAME })
     expect(window.localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME)).toEqual(undefined)
   })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,13 +58,14 @@ module.exports = (env) => {
       rules: [
         {
           enforce: 'pre',
-          test: /\.js$/,
+          test: /\.jsx?$/,
           exclude: /node_modules/,
           loader: 'eslint-loader',
           options: {
             // eslint options (if necessary)
             emitWarning: true,
             emitError: true,
+            extensions: ['.jsx', '.js']
           },
         },
         {


### PR DESCRIPTION
Fixes #353.

eslint, by default, doesn't check `.jsx` files in a directory.  This fixes that.

I also added the test files to `npm run lint` (but not `npm run start` -- I couldn't figure out how to get it to lint on files that aren't part of the build...  Probably minor issue since Travis will perform linting of the tests now).

This also allows JSX syntax in .js files, thereby it fixes #278.

Lastly, this cleans up some lint errors that weren't being caught.