### PR TITLE
Remove twoRowCell from cell-type-javascript

### DIFF
--- a/src/components/cell-type-javascript.jsx
+++ b/src/components/cell-type-javascript.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import TwoRowCell from './two-row-cell'
+import CellRow from './cell-row'
+import { CellContainer } from './cell-container'
 import CellOutput from './output'
 import CellEditor from './cell-editor'
 
@@ -17,17 +18,18 @@ export class JsCellUnconnected extends React.Component {
   }
 
   render() {
-    const row1 = <CellEditor cellId={this.props.cellId} />
-    const row2 = (<CellOutput
-      valueToRender={this.props.value}
-      render={this.props.rendered}
-    />)
     return (
-      <TwoRowCell
-        cellId={this.props.cellId}
-        row1={row1}
-        row2={row2}
-      />
+      <CellContainer cellId={this.props.cellId}>
+        <CellRow cellId={this.props.cellId} rowType="input">
+          <CellEditor cellId={this.props.cellId} />
+        </CellRow>
+        <CellRow cellId={this.props.cellId} rowType="output">
+          <CellOutput
+            valueToRender={this.props.value}
+            render={this.props.rendered}
+          />
+        </CellRow>
+      </CellContainer>
     )
   }
 }

--- a/test/cell-type-javascript.test.js
+++ b/test/cell-type-javascript.test.js
@@ -3,8 +3,9 @@ import { shallow } from 'enzyme'
 
 import { JsCellUnconnected as JsCell,
   mapStateToProps } from '../src/components/cell-type-javascript'
+import { CellContainer } from '../src/components/cell-container'
+import CellRow from '../src/components/cell-row'
 import CellEditor from '../src/components/cell-editor'
-import TwoRowCell from '../src/components/two-row-cell'
 import CellOutput from '../src/components/output'
 
 describe('JsCell_unconnected react component', () => {
@@ -26,40 +27,62 @@ describe('JsCell_unconnected react component', () => {
     mountedCell = undefined
   })
 
-  it('always renders one TwoRowCell', () => {
-    expect(cell().find(TwoRowCell).length).toBe(1)
+  it('always renders one CellContainer', () => {
+    expect(cell().find(CellContainer).length).toBe(1)
   })
 
-  it("sets the TwoRowCell cellId prop to be the JsCell's cellId prop", () => {
-    expect(cell().find(TwoRowCell).props().cellId)
+  it('always renders two CellRow inside CellContainer', () => {
+    expect(cell().wrap(cell().find(CellContainer))
+      .find(CellRow)).toHaveLength(2)
+  })
+
+  it('always renders one CellEditor inside first CellRow', () => {
+    expect(cell().wrap(cell().find(CellRow).at(0))
+      .find(CellEditor)).toHaveLength(1)
+  })
+
+  it('always renders one CellOutput inside second CellRow', () => {
+    expect(cell().wrap(cell().find(CellRow).at(1))
+      .find(CellOutput)).toHaveLength(1)
+  })
+
+  it("sets the CellContainer cellId prop to be the JsCell's cellId prop", () => {
+    expect(cell().find(CellContainer).props().cellId)
       .toBe(props.cellId)
   })
 
-  it('the TwoRowCell always has a row1 prop that is a CellEditor', () => {
-    expect(cell().wrap(cell().find(TwoRowCell)
-      .props().row1).find(CellEditor)).toHaveLength(1)
+  it("sets the first CellRow cellId prop to be the JsCell's cellId prop", () => {
+    expect(cell().find(CellRow).at(0).props().cellId)
+      .toBe(props.cellId)
+  })
+
+  it('sets the first CellRow rowType prop to be input', () => {
+    expect(cell().find(CellRow).at(0).props().rowType)
+      .toBe('input')
+  })
+
+  it("sets the second CellRow cellId prop to be the JsCell's cellId prop", () => {
+    expect(cell().find(CellRow).at(1).props().cellId)
+      .toBe(props.cellId)
+  })
+
+  it('sets the second CellRow rowType prop to be output', () => {
+    expect(cell().find(CellRow).at(1).props().rowType)
+      .toBe('output')
   })
 
   it("sets the CellEditor cellId prop to be the JsCell's cellId prop", () => {
-    expect(cell().wrap(cell().find(TwoRowCell)
-      .props().row1).props().cellId)
+    expect(cell().find(CellEditor).props().cellId)
       .toBe(props.cellId)
   })
 
-  it('the TwoRowCell always has a row2 prop that is a CellOutput', () => {
-    expect(cell().wrap(cell().find(TwoRowCell)
-      .props().row2).find(CellOutput)).toHaveLength(1)
-  })
-
   it("sets the CellOutput valueToRender prop to be the JsCell's value prop", () => {
-    expect(cell().wrap(cell().find(TwoRowCell)
-      .props().row2).props().valueToRender)
+    expect(cell().find(CellOutput).props().valueToRender)
       .toBe(props.value)
   })
 
   it("sets the CellOutput renderValue prop to be the JsCell's value prop", () => {
-    expect(cell().wrap(cell().find(TwoRowCell)
-      .props().row2).props().render)
+    expect(cell().find(CellOutput).props().render)
       .toBe(props.rendered)
   })
 })


### PR DESCRIPTION
This PR removes `twoRowCell ` from `cell-type-javascript` as mentioned in Issue #363 . Also, the corresponding test file has been updated accordingly. I haven't written a lot of test code in Enzyme so any review to make this code better would be appreciated :) 