### PR TITLE
Correct prop types for PageMode

### DIFF
--- a/src/components/cell-container.jsx
+++ b/src/components/cell-container.jsx
@@ -13,7 +13,7 @@ class CellContainer extends React.Component {
     cellId: PropTypes.number.isRequired,
     // cellClass: PropTypes.string,
     children: PropTypes.node,
-    pageMode: PropTypes.oneOf(['command', 'edit']),
+    pageMode: PropTypes.oneOf(['command', 'edit', 'title-edit']),
     viewMode: PropTypes.oneOf(['editor', 'presentation']),
     actions: PropTypes.shape({
       selectCell: PropTypes.func.isRequired,

--- a/src/components/cell-editor.jsx
+++ b/src/components/cell-editor.jsx
@@ -26,7 +26,7 @@ class CellEditor extends React.Component {
     cellId: PropTypes.number.isRequired,
     cellType: PropTypes.string,
     content: PropTypes.string,
-    pageMode: PropTypes.oneOf(['command', 'edit']),
+    pageMode: PropTypes.oneOf(['command', 'edit', 'title-edit']),
     viewMode: PropTypes.oneOf(['editor', 'presentation']),
     actions: PropTypes.shape({
       selectCell: PropTypes.func.isRequired,

--- a/src/components/cell-row.jsx
+++ b/src/components/cell-row.jsx
@@ -9,7 +9,7 @@ import actions from '../actions'
 class CellRow extends React.Component {
   static propTypes = {
     executionString: PropTypes.string,
-    pageMode: PropTypes.oneOf(['command', 'edit']),
+    pageMode: PropTypes.oneOf(['command', 'edit', 'title-edit']),
     viewMode: PropTypes.oneOf(['editor', 'presentation']),
     collapsedState: PropTypes.string,
     rowType: PropTypes.string,


### PR DESCRIPTION
![screenshot from 2018-02-18 01-02-40](https://user-images.githubusercontent.com/21259802/36344925-a653b11e-1447-11e8-909a-be5174b143c0.png)

CellContainer, CellRow and CellEditor have `title-edit` option missing from PageMode prop.