### PR TITLE
Import from url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,8 +2164,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-diff": {
       "version": "0.3.8",
@@ -8089,6 +8088,18 @@
         "prepend-http": "1.0.4",
         "query-string": "4.3.4",
         "sort-keys": "1.1.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -9481,11 +9492,11 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.0.tgz",
+      "integrity": "sha512-F3DkxxlY0AqD/rwe4YAwjRE2HjOkKW7TxsuteyrS/Jbwrxw887PqYBL4sWUJ9D/V1hmFns0SCD6FDyvlwo9RCQ==",
       "requires": {
+        "decode-uri-component": "0.2.0",
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
       }
@@ -10882,8 +10893,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mousetrap": "^1.6.1",
     "opensans-npm-webfont": "^1.0.0",
     "prop-types": "^15.6.0",
+    "query-string": "^5.1.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-helmet": "^5.2.0",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 ### early alpha - subject to breakage, changes, argument, refactors
 
-_Try it in your browser [right now](https://iodide-project.github.io/master/?iodide-example=what-a-web-notebook-looks-like.html)!_
+_Try it in your browser [right now](https://iodide-project.github.io/master/?url=https://raw.githubusercontent.com/iodide-project/iodide-examples/master/what-a-web-notebook-looks-like.html)!_
 
 The Iodide notebook seeks to answer one question: __can we do scientific computing without ever leaving the browser?__ We are building a modern, browser-first notebook-style IDE that utlilizes web technologies for interative / literate / inquisitive computing. The notebook borrows inspiration from RStudio, Jupyter, Carbide, and many other computing environments.
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 ### early alpha - subject to breakage, changes, argument, refactors
 
-_Try it in your browser [right now](https://iodide-project.github.io/master/)!_
+_Try it in your browser [right now](https://iodide-project.github.io/master/?iodide-example=what-a-web-notebook-looks-like.html)!_
 
 The Iodide notebook seeks to answer one question: __can we do scientific computing without ever leaving the browser?__ We are building a modern, browser-first notebook-style IDE that utlilizes web technologies for interative / literate / inquisitive computing. The notebook borrows inspiration from RStudio, Jupyter, Carbide, and many other computing environments.
 

--- a/src/handle-url-query.js
+++ b/src/handle-url-query.js
@@ -36,6 +36,8 @@ function handleUrlQuery() {
     loadJsmdFromNotebookUrl(queryParams.url)
   } else if ({}.hasOwnProperty.call(queryParams, 'iodide-example')) {
     loadJsmdFromNotebookUrl(`https://raw.githubusercontent.com/iodide-project/iodide-examples/master/${queryParams['iodide-example']}`)
+  } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {
+    loadJsmdFromNotebookUrl(`https://gist.githubusercontent.com/${queryParams.gist}/raw/`)
   }
 }
 

--- a/src/handle-url-query.js
+++ b/src/handle-url-query.js
@@ -34,8 +34,6 @@ function handleUrlQuery() {
   const queryParams = decodeQueryParams(window.location.search.substr(1).split('&'));
   if ({}.hasOwnProperty.call(queryParams, 'url')) {
     loadJsmdFromNotebookUrl(queryParams.url)
-  } else if ({}.hasOwnProperty.call(queryParams, 'iodide-example')) {
-    loadJsmdFromNotebookUrl(`https://raw.githubusercontent.com/iodide-project/iodide-examples/master/${queryParams['iodide-example']}`)
   } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {
     loadJsmdFromNotebookUrl(`https://gist.githubusercontent.com/${queryParams.gist}/raw/`)
   }

--- a/src/handle-url-query.js
+++ b/src/handle-url-query.js
@@ -1,0 +1,42 @@
+import { stateFromJsmd } from './jsmd-tools'
+import { store } from './store'
+import actions from './actions'
+
+function decodeQueryParams(a) {
+  if (a === '') return {};
+  const b = {};
+  for (let i = 0; i < a.length; ++i) {
+    const p = a[i].split('=', 2);
+    if (p.length === 1) {
+      b[p[0]] = ''
+    } else {
+      b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, ' '));
+    }
+  }
+  return b;
+}
+
+async function loadJsmdFromNotebookUrl(url) {
+  try {
+    const response = await fetch(url);
+    const notebookString = await response.text()
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(notebookString, 'text/html');
+    const jsmd = doc.querySelector('#jsmd').innerHTML
+    store.dispatch(actions.importNotebook(stateFromJsmd(jsmd)))
+  } catch (err) {
+    console.log('failed to load notebook url', err);
+  }
+}
+
+
+function handleUrlQuery() {
+  const queryParams = decodeQueryParams(window.location.search.substr(1).split('&'));
+  if ({}.hasOwnProperty.call(queryParams, 'url')) {
+    loadJsmdFromNotebookUrl(queryParams.url)
+  } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {
+    loadJsmdFromNotebookUrl(queryParams.url)
+  }
+}
+
+export default handleUrlQuery

--- a/src/handle-url-query.js
+++ b/src/handle-url-query.js
@@ -1,20 +1,8 @@
+import queryString from 'query-string'
+
 import { stateFromJsmd } from './jsmd-tools'
 import { store } from './store'
 import actions from './actions'
-
-function decodeQueryParams(a) {
-  if (a === '') return {};
-  const b = {};
-  for (let i = 0; i < a.length; ++i) {
-    const p = a[i].split('=', 2);
-    if (p.length === 1) {
-      b[p[0]] = ''
-    } else {
-      b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, ' '));
-    }
-  }
-  return b;
-}
 
 async function loadJsmdFromNotebookUrl(url) {
   try {
@@ -31,7 +19,7 @@ async function loadJsmdFromNotebookUrl(url) {
 
 
 function handleUrlQuery() {
-  const queryParams = decodeQueryParams(window.location.search.substr(1).split('&'));
+  const queryParams = queryString.parse(window.location.search);
   if ({}.hasOwnProperty.call(queryParams, 'url')) {
     loadJsmdFromNotebookUrl(queryParams.url)
   } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {

--- a/src/handle-url-query.js
+++ b/src/handle-url-query.js
@@ -34,8 +34,8 @@ function handleUrlQuery() {
   const queryParams = decodeQueryParams(window.location.search.substr(1).split('&'));
   if ({}.hasOwnProperty.call(queryParams, 'url')) {
     loadJsmdFromNotebookUrl(queryParams.url)
-  } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {
-    loadJsmdFromNotebookUrl(queryParams.url)
+  } else if ({}.hasOwnProperty.call(queryParams, 'iodide-example')) {
+    loadJsmdFromNotebookUrl(`https://raw.githubusercontent.com/iodide-project/iodide-examples/master/${queryParams['iodide-example']}`)
   }
 }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,7 @@ import './page.css'
 
 import Page from './components/page'
 import { store } from './store'
+import handleUrlQuery from './handle-url-query'
 
 import { iodide } from './api'
 
@@ -23,3 +24,5 @@ render(
   </Provider>,
   document.getElementById('page'),
 )
+
+handleUrlQuery()


### PR DESCRIPTION
This addresses half of #361, (the importing half) introducing the following url params:

(1) `?url=` loads any notebook from any fully specified url, pulls the jsmd out of the html at the url, and loads that jsmd over into the current notebook (overriding any jsmd bundled with the notebook)
test with:
?url=https://raw.githubusercontent.com/iodide-project/iodide-examples/master/what-a-web-notebook-looks-like.html

(2) `?iodide-example=` a special case of the above; loads a notebook from https://github.com/iodide-project/iodide-examples, requiring only the {notebook}.html filename.
test with:
?iodide-example=what-a-web-notebook-looks-like.html

(3) `?gist=` also a special case of (1) that loads from a notebook gist. requires "<user>/<gist number>"
test with:
?gist=bcolloran/1544ce920f8d35110f1d9c8b7cc872dc


This will also address #315 and #317 (closing the Feb 12 sprint milestone) by updating the readme to use the new url params to load an iodide-example notebook that features onboarding content--
https://iodide-project.github.io/master/?iodide-example=what-a-web-notebook-looks-like.html