### PR TITLE
FOR DEMO ONLY: Use react-inspector instead of JSONTree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5357,6 +5357,11 @@
         }
       }
     },
+    "is-dom": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.0.9.tgz",
+      "integrity": "sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0="
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -9694,6 +9699,15 @@
         "object-assign": "4.1.1",
         "prop-types": "15.6.0",
         "react-side-effect": "1.1.3"
+      }
+    },
+    "react-inspector": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.2.2.tgz",
+      "integrity": "sha512-SzkmYvVUJEmUBuFwGgaGOTGucUBnKXH2wWFdzatkCrawm4P85eqgYvqevHE3DGWpfXqE1pJO4d98TYUANQGCrg==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "is-dom": "1.0.9"
       }
     },
     "react-json-tree": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-helmet": "^5.2.0",
+    "react-inspector": "^2.2.2",
     "react-json-tree": "^0.10.9",
     "react-redux": "^5.0.6",
     "react-table": "^6.6.0",

--- a/src/components/output.jsx
+++ b/src/components/output.jsx
@@ -4,8 +4,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import _ from 'lodash'
-import JSONTree from 'react-json-tree'
 import ReactTable from 'react-table'
+import { ObjectInspector } from 'react-inspector'
 
 import { SimpleTable, makeMatrixText } from './pretty-matrix'
 
@@ -23,25 +23,12 @@ function renderValue(value, inContainer = false) {
       } else if (resultElem.type !== undefined) {
         return resultElem
       } else {
-        console.log('Unknown output handler result type from ' + handler)
         // Fallback to other handlers if it's something invalid
       }
       /* eslint-enable */
     }
   }
   return undefined
-}
-
-const nullHandler = {
-  shouldHandle: value => (value === null),
-
-  render: () => <pre>null</pre>,
-}
-
-const undefinedHandler = {
-  shouldHandle: value => (value === undefined),
-
-  render: () => <pre>undefined</pre>,
 }
 
 const renderMethodHandler = {
@@ -138,67 +125,18 @@ const arrayHandler = {
   },
 }
 
-const dateHandler = {
-  shouldHandle: value => Object.prototype.toString.call(value) === '[object Date]',
-
-  render: value => value.toString(),
-}
-
-const scalarHandler = {
-  scalarTypes: {
-    string: true,
-    number: true,
-  },
-
-  shouldHandle: value => (typeof (value) in scalarHandler.scalarTypes),
-
-  render: value =>
-  // TODO: This probably needs a new CSS class
-    <span className="array-output">{value}</span>,
-
-}
-
 const defaultHandler = {
   shouldHandle: () => true,
 
-  render: value => (
-    <JSONTree
-      data={value}
-      shouldExpandNode={() => false}
-      hideRoot={false}
-      theme={{
-        scheme: 'bright',
-        author: 'chris kempson (http://chriskempson.com)',
-        base00: '#000000',
-        base01: '#303030',
-        base02: '#505050',
-        base03: '#b0b0b0',
-        base04: '#d0d0d0',
-        base05: '#e0e0e0',
-        base06: '#f5f5f5',
-        base07: '#ffffff',
-        base08: '#fb0120',
-        base09: '#fc6d24',
-        base0A: '#fda331',
-        base0B: '#a1c659',
-        base0C: '#76c7b7',
-        base0D: '#6fb3d2',
-        base0E: '#d381c3',
-        base0F: '#be643c',
-      }}
-    />
-  ),
+  render: value => <div><ObjectInspector data={value} /></div>,
+  // render: value => value,
 }
 
 const handlers = [
-  nullHandler,
-  undefinedHandler,
   renderMethodHandler,
   dataFrameHandler,
   matrixHandler,
   arrayHandler,
-  dateHandler,
-  scalarHandler,
   defaultHandler,
 ]
 


### PR DESCRIPTION
With confirmation that Firefox devtools' [devtools-reps](https://github.com/devtools-html/devtools-core/tree/master/packages/devtools-reps) isn't really meant to be used standalone, I did a little Googling for similar, and found [react-inspector](https://github.com/xyc/react-inspector).  It claims to be "the power of [Chromium's] DevTools inspectors right inside your React app", but it doesn't look like it's actually based on the Chromium DevTools code, just inspired by it.  It doesn't do a lot of the nice things that `devtools-reps` does (like the different length reps) or have as much coverage of object types (such as `Error` objects and tracebacks).  It doesn't have the extensible architecture of Chromium DevTools, our thing, or that Firefox devtools apparently has planned either.

tl;dr: I don't think this really advances the ball, but I'm posting this here in case in playing with it others may see an advantage to this that I don't.