### PR TITLE
392 fix

### DIFF
--- a/src/codemirror-keymap-sublime.js
+++ b/src/codemirror-keymap-sublime.js
@@ -136,7 +136,7 @@
   }
 
 
-// these shortcuts conflict with notebook shortcuts
+// these shorcuts conflict with notebook shortcuts
   // cmds[map[ctrl + "Enter"] = "insertLineAfter"] = function(cm) { return insertLine(cm, false); };
   // cmds[map["Shift-" + ctrl + "Enter"] = "insertLineBefore"] = function(cm) { return insertLine(cm, true); };
 
@@ -146,35 +146,31 @@
     while (end < line.length && CodeMirror.isWordChar(line.charAt(end))) ++end;
     return {from: Pos(pos.line, start), to: Pos(pos.line, end), word: line.slice(start, end)};
   }
-  
-// this shortcut conflicts with a notebook shortcut
-// simply not defining it here would lead to codemirror using the default key binding (which is deleteLine).
-// instead, overwrite the default ctrl-D key binding with an empty function.
-  cmds[map[ctrl + "D"] = "doNothing"] = function(cm) {};
-  // cmds[map[ctrl + "D"] = "selectNextOccurrence"] = function(cm) {
-  //   var from = cm.getCursor("from"), to = cm.getCursor("to");
-  //   var fullWord = cm.state.sublimeFindFullWord == cm.doc.sel;
-  //   if (CodeMirror.cmpPos(from, to) == 0) {
-  //     var word = wordAt(cm, from);
-  //     if (!word.word) return;
-  //     cm.setSelection(word.from, word.to);
-  //     fullWord = true;
-  //   } else {
-  //     var text = cm.getRange(from, to);
-  //     var query = fullWord ? new RegExp("\\b" + text + "\\b") : text;
-  //     var cur = cm.getSearchCursor(query, to);
-  //     var found = cur.findNext();
-  //     if (!found) {
-  //       cur = cm.getSearchCursor(query, Pos(cm.firstLine(), 0));
-  //       found = cur.findNext();
-  //     }
-  //     if (!found || isSelectedRange(cm.listSelections(), cur.from(), cur.to()))
-  //       return CodeMirror.Pass
-  //     cm.addSelection(cur.from(), cur.to());
-  //   }
-  //   if (fullWord)
-  //     cm.state.sublimeFindFullWord = cm.doc.sel;
-  // };
+
+  cmds[map[ctrl + "D"] = "selectNextOccurrence"] = function(cm) {
+    var from = cm.getCursor("from"), to = cm.getCursor("to");
+    var fullWord = cm.state.sublimeFindFullWord == cm.doc.sel;
+    if (CodeMirror.cmpPos(from, to) == 0) {
+      var word = wordAt(cm, from);
+      if (!word.word) return;
+      cm.setSelection(word.from, word.to);
+      fullWord = true;
+    } else {
+      var text = cm.getRange(from, to);
+      var query = fullWord ? new RegExp("\\b" + text + "\\b") : text;
+      var cur = cm.getSearchCursor(query, to);
+      var found = cur.findNext();
+      if (!found) {
+        cur = cm.getSearchCursor(query, Pos(cm.firstLine(), 0));
+        found = cur.findNext();
+      }
+      if (!found || isSelectedRange(cm.listSelections(), cur.from(), cur.to()))
+        return CodeMirror.Pass
+      cm.addSelection(cur.from(), cur.to());
+    }
+    if (fullWord)
+      cm.state.sublimeFindFullWord = cm.doc.sel;
+  };
 
   function addCursorToSelection(cm, dir) {
     var ranges = cm.listSelections(), newRanges = [];

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -217,6 +217,7 @@ tasks.toggleDeclaredVariablesPane = new UserTask({
   title: 'Toggle the Declared Variables Pane',
   keybindings: ['ctrl+d', 'meta+d'],
   displayKeybinding: commandKey('D'),
+  keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
     if (store.getState().sidePaneMode !== 'declared variables') {


### PR DESCRIPTION
this will fix #392 ... kind of...

@wlach , it turns out that the default ctrl-d keybinding in sublime text is to select other instances of the word under the  cursor. i'm not sure if we should single out ctrl-d as the one exception to the sublime keymap, or maybe just leave it until we can put in keymap selection?