### PR TITLE
Updates localStorage save to use jsmd. Updated test.

### DIFF
--- a/src/jsmd-tools.js
+++ b/src/jsmd-tools.js
@@ -35,6 +35,7 @@ const cellTypeToJsmdMap = new Map([
 const jsmdValidNotebookSettings = [
   'title',
   'viewMode',
+  'lastSaved',
 ]
 
 function parseCellString(str, i, parseWarnings) {

--- a/src/menu-content.js
+++ b/src/menu-content.js
@@ -1,6 +1,8 @@
 import { prettyDate, formatDateString } from './notebook-utils'
 import exampleNotebooks from './example-notebooks'
 import settings from './settings'
+import { stateFromJsmd } from './jsmd-tools'
+
 
 const { AUTOSAVE } = settings.labels
 
@@ -17,6 +19,22 @@ function commandKey(key) {
     ctr = '⌘ '
   }
   return ctr + key
+}
+
+function jsonOrJsmdParse(string) {
+  let nextState
+  try {
+    nextState = JSON.parse(string)
+    console.log()
+    console.log(`"${nextState.title}"" is currently saved in localStorage as JSON.
+  --- Saving as JSON is deprecated!!! ---
+Please take a minute open any saved notebooks you care about and resave them with ctrl+s.
+This will update them to jsmd.
+`)
+  } catch (e) {
+    nextState = stateFromJsmd(string)
+  }
+  return nextState
 }
 
 function getSavedNotebooks(elem) {
@@ -42,7 +60,7 @@ function getSavedNotebooks(elem) {
 
   if (autosaves.length) {
     const [autosave] = autosaves
-    let { lastSaved } = JSON.parse(localStorage[autosave])
+    let { lastSaved } = jsonOrJsmdParse(localStorage[autosave])
     lastSaved = (lastSaved !== undefined) ? prettyDate(formatDateString(lastSaved)) : ' '
     const displayTitle = autosave.replace(AUTOSAVE, '')
     autosaveNBs = [
@@ -63,14 +81,14 @@ function getSavedNotebooks(elem) {
       .filter(n => !n.includes(AUTOSAVE))
       .filter((n) => {
         try {
-          JSON.parse(localStorage[n]).lastSaved // eslint-disable-line
+          jsonOrJsmdParse(localStorage[n]).lastSaved // eslint-disable-line
           return true
         } catch (err) {
           return false
         }
       })
       .map((n) => {
-        const { lastSaved } = JSON.parse(localStorage[n])
+        const { lastSaved } = jsonOrJsmdParse(localStorage[n])
         return {
           primaryText: n,
           secondaryText: prettyDate(formatDateString(lastSaved)),

--- a/test/notebook-reducer.test.js
+++ b/test/notebook-reducer.test.js
@@ -1,6 +1,11 @@
 import notebookReducer from '../src/reducers/notebook-reducer'
 import localStorageMock from './mockLocalStorage'
 import { newNotebook, blankState, newCell } from '../src/state-prototypes'
+import {
+  // exportJsmdBundle, we'll need to test this
+  // stringifyStateToJsmd, we'll need to test this
+  stateFromJsmd,
+} from '../src/jsmd-tools'
 
 
 window.localStorage = localStorageMock
@@ -48,16 +53,16 @@ describe('importing a notebook via state', () => {
   })
 })
 
+
 describe('saving / deleting localStorage-saved notebooks', () => {
   // this will do enough for now.
-
   const SAVE_DELETE_NOTEBOOK_NAME = 'save-delete-notebook-tests'
   const state = exampleNotebookWithContent(SAVE_DELETE_NOTEBOOK_NAME)
 
   it('should save via SAVE_NOTEBOOK', () => {
     notebookReducer(state, { type: 'SAVE_NOTEBOOK' })
 
-    const savedNotebook = JSON.parse(window.localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME))
+    const savedNotebook = stateFromJsmd(window.localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME))
     expect(savedNotebook.title).toEqual(state.title)
     expect(savedNotebook.lastSaved).toBeDefined()
     expect(savedNotebook.cells).toEqual(state.cells)


### PR DESCRIPTION
This will fix #401.

This PR blocks further work on row visibility updates, b.c something about saving states to JSON was breaking in my other branch (I think JSON didn't like the enums). Since this was on the list anyway, i figured I"d knock it out to unblock the other stuff.