### PR TITLE
Cell Submenu now receives onClick callback

### DIFF
--- a/src/components/toolbar/cell-menu-subsection.jsx
+++ b/src/components/toolbar/cell-menu-subsection.jsx
@@ -10,7 +10,7 @@ import tasks from '../../task-definitions'
 export default class CellMenuSubsection extends React.Component {
   render() {
     return (
-      <NotebookMenuSubsection className="medium-menu" title="cell ...">
+      <NotebookMenuSubsection onClick={this.props.onClick} className="medium-menu" title="cell ...">
 
         <NotebookMenuItem key={tasks.moveCellUp.title} task={tasks.moveCellUp} />
         <NotebookMenuItem key={tasks.moveCellDown.title} task={tasks.moveCellDown} />

--- a/src/components/toolbar/icon-menu.jsx
+++ b/src/components/toolbar/icon-menu.jsx
@@ -12,20 +12,20 @@ export default class NotebookIconMenu extends React.Component {
       anchorElement: null,
     }
     this.handleClick = this.handleClick.bind(this)
-    this.handleClose = this.handleClose.bind(this)
+    this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
   }
   handleClick(event) {
     this.setState({ anchorElement: event.currentTarget })
   }
 
-  handleClose() {
+  handleIconButtonClose() {
     this.setState({ anchorElement: null })
   }
 
   render() {
     const { anchorElement } = this.state
     const children = React.Children.map(this.props.children, c =>
-      React.cloneElement(c, { onClick: this.handleClose }))
+      React.cloneElement(c, { onClick: this.handleIconButtonClose }))
     return (
       <IconButton
         aria-label="more"
@@ -39,7 +39,7 @@ export default class NotebookIconMenu extends React.Component {
           id="main-menu"
           anchorEl={this.state.anchorElement}
           open={Boolean(anchorElement)}
-          onClose={this.handleClose}
+          onClose={this.handleIconButtonClose}
           anchorReference="anchorPosition"
           anchorPosition={{ top: 62, left: 30 }}
         >

--- a/src/components/toolbar/notebook-menu-subsection.jsx
+++ b/src/components/toolbar/notebook-menu-subsection.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-// import PropTypes from 'prop-types'
 import MenuItem from 'material-ui/Menu/MenuItem'
 import { ListItemText } from 'material-ui/List';
 import Menu from 'material-ui/Menu'

--- a/src/components/toolbar/notebook-menu-subsection.jsx
+++ b/src/components/toolbar/notebook-menu-subsection.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-
+// import PropTypes from 'prop-types'
 import MenuItem from 'material-ui/Menu/MenuItem'
 import { ListItemText } from 'material-ui/List';
 import Menu from 'material-ui/Menu'
@@ -29,8 +29,8 @@ export default class NotebookMenuSubsection extends React.Component {
         if (c === null || c === undefined) return undefined
         return React.cloneElement(c, {
           onClick: () => {
-            this.handleClose();
-            this.props.onClick()
+            this.handleClose()
+            if (this.props.onClick) this.props.onClick()
           },
         })
       },


### PR DESCRIPTION
This is a bug introduced by #408 that is fixed with this PR. This closes #423.

Steps to test:

1. take a new notebook
2. try any of the functions in the cell submenu that is not "add cell below" - for some reason that particular task is causing an issue that will be addressed in another PR
3. all the menus should disappear and there should be no console errors.

![mar-02-2018 13-38-48](https://user-images.githubusercontent.com/95735/36923136-2ca10b00-1e1f-11e8-8ff9-9e573716d5b8.gif)

