### PR TITLE
Fix CSS cell proptype issue

### DIFF
--- a/src/components/cell-type-css.jsx
+++ b/src/components/cell-type-css.jsx
@@ -11,7 +11,7 @@ import { getCellById } from '../notebook-utils'
 export class CSSCellUnconnected extends React.Component {
   static propTypes = {
     cellId: PropTypes.number.isRequired,
-    value: PropTypes.any.isRequired,
+    value: PropTypes.any,
     rendered: PropTypes.bool.isRequired,
   }
 


### PR DESCRIPTION
Changing the `cell-type` of a newly created cell to `css` logs an error 
![cellproptype](https://user-images.githubusercontent.com/4402679/36994989-d73c08ba-20d8-11e8-8a56-38dc83110fb9.png)

This PR fixes the above issue.