### PR TITLE
add a middle "side-effect-target" row to JS cells

### DIFF
--- a/src/components/cell-type-javascript.jsx
+++ b/src/components/cell-type-javascript.jsx
@@ -23,6 +23,9 @@ export class JsCellUnconnected extends React.Component {
         <CellRow cellId={this.props.cellId} rowType="input">
           <CellEditor cellId={this.props.cellId} />
         </CellRow>
+        <CellRow cellId={this.props.cellId} rowType="sideeffect">
+          <div className="side-effect-target" />
+        </CellRow>
         <CellRow cellId={this.props.cellId} rowType="output">
           <CellOutput
             valueToRender={this.props.value}

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -98,10 +98,12 @@ function newCellRowSettings(cellType) {
       return {
         EXPLORE: {
           input: rowOverflowEnum.VISIBLE,
+          sideeffect: rowOverflowEnum.VISIBLE,
           output: rowOverflowEnum.VISIBLE,
         },
         REPORT: {
           input: rowOverflowEnum.HIDDEN,
+          sideeffect: rowOverflowEnum.HIDDEN,
           output: rowOverflowEnum.HIDDEN,
         },
       }

--- a/test/cell-type-javascript.test.js
+++ b/test/cell-type-javascript.test.js
@@ -33,7 +33,7 @@ describe('JsCell_unconnected react component', () => {
 
   it('always renders two CellRow inside CellContainer', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(2)
+      .find(CellRow)).toHaveLength(3)
   })
 
   it('always renders one CellEditor inside first CellRow', () => {
@@ -41,8 +41,13 @@ describe('JsCell_unconnected react component', () => {
       .find(CellEditor)).toHaveLength(1)
   })
 
-  it('always renders one CellOutput inside second CellRow', () => {
+  it('always renders one div inside second CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(1))
+      .find('div')).toHaveLength(1)
+  })
+
+  it('always renders one CellOutput inside third CellRow', () => {
+    expect(cell().wrap(cell().find(CellRow).at(2))
       .find(CellOutput)).toHaveLength(1)
   })
 
@@ -61,15 +66,31 @@ describe('JsCell_unconnected react component', () => {
       .toBe('input')
   })
 
-  it("sets the second CellRow cellId prop to be the JsCell's cellId prop", () => {
+  it("sets the 2nd CellRow cellId prop to be the JsCell's cellId prop", () => {
     expect(cell().find(CellRow).at(1).props().cellId)
       .toBe(props.cellId)
   })
 
-  it('sets the second CellRow rowType prop to be output', () => {
+  it('sets the second CellRow rowType prop to be sideeffect', () => {
     expect(cell().find(CellRow).at(1).props().rowType)
+      .toBe('sideeffect')
+  })
+
+  it('sets the div in the sideeffect row to have class side-effect-target', () => {
+    expect(cell().find('div').props().className)
+      .toBe('side-effect-target')
+  })
+
+  it("sets the third CellRow cellId prop to be the JsCell's cellId prop", () => {
+    expect(cell().find(CellRow).at(2).props().cellId)
+      .toBe(props.cellId)
+  })
+
+  it('sets the third CellRow rowType prop to be output', () => {
+    expect(cell().find(CellRow).at(2).props().rowType)
       .toBe('output')
   })
+
 
   it("sets the CellEditor cellId prop to be the JsCell's cellId prop", () => {
     expect(cell().find(CellEditor).props().cellId)


### PR DESCRIPTION
This will complete work on #363, adding a middle row to JS cell. The middle row contains a div with class "side-effect-target", which can be targeted by Iodide stdlib code with e.g.
`document.querySelector('div.selected-cell div.sideeffect div.side-effect-target')`

for a dumb example, try:
```
function print(str){
  let div = document.createElement('div')
  div.innerHTML = str
  document.querySelector('div.selected-cell div.sideeffect div.side-effect-target').append(div)
}
for (let i=0; i<10; i++){print(i)}
"return value"
```
for real usage, we'd need to be cleverer about clearing the side-effect target on each cell execution (but this won't be hard).

cell middle rows currently respect the "HIDDEN" overflow state but not the "SCROLL" overflow state, so there's a bit more CSS work to do