### PR TITLE
Presentation Mode: z-index of button, padding problems pushing content off page

### DIFF
--- a/src/components/toolbar/view-mode-toggle-button.jsx
+++ b/src/components/toolbar/view-mode-toggle-button.jsx
@@ -29,6 +29,7 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
       <Button
         style={{ color: this.props.textColor || '#fafafa' }}
         onClick={this.toggleViewMode}
+        variant="flat"
         mini
       >
         {this.props.viewMode === 'presentation' ? 'Edit' : 'View'}

--- a/src/page.css
+++ b/src/page.css
@@ -663,11 +663,10 @@ table tr:nth-child(2n) {
   position: fixed;
   right: 20px;
   top: 10px;
+  z-index:100;
 }
 
 .presentation-header {
-  margin-bottom: 20px;
-  margin-top: 40px;
 }
 
 .presentation-title {

--- a/src/page.css
+++ b/src/page.css
@@ -94,6 +94,8 @@ div.cell-container {
 }
 
 div#cells.presentation {
+  padding-top:0px;
+  padding-bottom:0px;
 }
 
 div#cells.presentation div.cell-container {


### PR DESCRIPTION
This is the first of a number of PRs centered on getting the presentation view more usable out the box and more extensible generally. It:

- removes the white space that came at the top of the mode, which was there to let the "edit" button be visible re: z-indexing
- changes the z-index of the "edit" button so it is not covered by CodeMirror instances (visible when a markdown cell has not been rendered atm, and in the future will be an issue when we can set JS cell inputs as visible)
- temporarily removes the strange padding issues that caused content to go off the bottom part of the page.

The css for presentation view is fairly broken. We are going to have to reorganize how we do that so we can make this environment more useful for a wide variety of circumstances. But this should make things usable right now, at the very least.