### PR TITLE
418 scrolltocellifneeded css fixes

### DIFF
--- a/src/page.css
+++ b/src/page.css
@@ -106,15 +106,11 @@ div.cell-container {
   width: calc(100%);
 }
 
-div#cells.presentation {
-  padding-top:0px;
-  padding-bottom:0px;
-}
 
 div#cells.presentation div.cell-container {
+  width: 800px;
+  margin: 0 auto; /* centers the divs and sets top/bottom margins to 0*/
   outline: none;
-  margin-top: 0px;
-  margin-bottom: 0px;
   padding-top: 0px;
   padding-bottom: 0px;
 }


### PR DESCRIPTION
@hamilton, here are some teeny CSS tweaks here that fix #418 and #442 -- i implemented your suggestion of making the main `#cells` container and the `.notebook-menu` elts have fixed positions, widths and heights.

While i was in there, as a freebie i added set the pres mode cell width to 800px (centered) per your other earlier recommendation.

I just tweaked those couple things, seems ok, but of course i don't know all the intricacies of the menu stuff -- this does not appear to break any of that, but i could be missing something. Lmk if you have questions, concerns, etc.