### PR TITLE
toolbar: reduce height, give title element more space, and add tooltips

### DIFF
--- a/src/components/toolbar/editor-mode-title.jsx
+++ b/src/components/toolbar/editor-mode-title.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 
 import { connect } from 'react-redux'
-import Tooltip from 'material-ui/Tooltip'
 
 import tasks from '../../task-definitions'
 

--- a/src/components/toolbar/editor-mode-title.jsx
+++ b/src/components/toolbar/editor-mode-title.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 
 import { connect } from 'react-redux'
+import Tooltip from 'material-ui/Tooltip'
 
 import tasks from '../../task-definitions'
 
@@ -39,9 +40,11 @@ export class TitleUnconnected extends React.Component {
 
   render() {
     const elem = (
+
       <div className="title-field">
         <div className={`title-field-contents ${this.props.pageMode !== 'title-edit' ? 'unselected-title-field' : ''}`}>
           <Helmet title={this.getTitle()} />
+
           <input
             onBlur={this.onBlur}
             onClick={this.onFocus}
@@ -55,6 +58,7 @@ export class TitleUnconnected extends React.Component {
           />
         </div>
       </div>
+
     )
     return elem
   }

--- a/src/components/toolbar/editor-mode-toolbar.jsx
+++ b/src/components/toolbar/editor-mode-toolbar.jsx
@@ -15,10 +15,10 @@ export class EditorModeToolbarUnconnected extends React.Component {
   render() {
     return (
       <div
-        className="notebook-menu"
-        style={{ backgroundColor: 'black', height: '64px', display: this.props.viewMode === 'editor' ? 'block' : 'none' }}
+        className="notebook-toolbar-container"
+        style={{ display: this.props.viewMode === 'editor' ? 'block' : 'none' }}
       >
-        <Toolbar>
+        <Toolbar classes={{ root: 'notebook-toolbar' }}>
           <EditorModeControls isFirstChild />
           <EditorModeTitle />
           <ViewControls />

--- a/src/components/toolbar/icon-menu.jsx
+++ b/src/components/toolbar/icon-menu.jsx
@@ -41,7 +41,7 @@ export default class NotebookIconMenu extends React.Component {
           open={Boolean(anchorElement)}
           onClose={this.handleIconButtonClose}
           anchorReference="anchorPosition"
-          anchorPosition={{ top: 62, left: 30 }}
+          anchorPosition={{ top: 50, left: 0 }}
         >
           {children}
         </Menu>

--- a/src/components/toolbar/icon-menu.jsx
+++ b/src/components/toolbar/icon-menu.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import IconButton from 'material-ui/IconButton'
 import Menu from 'material-ui/Menu'
 import MenuIcon from 'material-ui-icons/Menu'
+import Tooltip from 'material-ui/Tooltip'
 
 export default class NotebookIconMenu extends React.Component {
   constructor(props) {
@@ -27,26 +28,28 @@ export default class NotebookIconMenu extends React.Component {
     const children = React.Children.map(this.props.children, c =>
       React.cloneElement(c, { onClick: this.handleIconButtonClose }))
     return (
-      <IconButton
-        aria-label="more"
-        aria-owns={anchorElement ? 'main-menu' : null}
-        aria-haspopup="true"
-        onClick={this.handleClick}
-        style={{ color: 'white' }}
-      >
-        <MenuIcon />
-        <Menu
-          id="main-menu"
-          anchorEl={this.state.anchorElement}
-          open={Boolean(anchorElement)}
-          onClose={this.handleIconButtonClose}
-          anchorReference="anchorPosition"
-          anchorPosition={{ top: 50, left: 0 }}
-        >
-          {children}
-        </Menu>
-      </IconButton>
+      <Tooltip id="tooltip-icon" title="Menu">
 
+        <IconButton
+          aria-label="more"
+          aria-owns={anchorElement ? 'main-menu' : null}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+          style={{ color: 'white' }}
+        >
+          <MenuIcon />
+          <Menu
+            id="main-menu"
+            anchorEl={this.state.anchorElement}
+            open={Boolean(anchorElement)}
+            onClose={this.handleIconButtonClose}
+            anchorReference="anchorPosition"
+            anchorPosition={{ top: 50, left: 0 }}
+          >
+            {children}
+          </Menu>
+        </IconButton>
+      </Tooltip>
     )
   }
 }

--- a/src/components/toolbar/last-saved-text.jsx
+++ b/src/components/toolbar/last-saved-text.jsx
@@ -11,15 +11,9 @@ export class LastSavedTextUnconnected extends React.Component {
   render() {
     return (
       <Typography
-        style={{
-          fontSize: '13px',
-          color: 'lightgray',
-          fontStyle: 'italic',
-          width: '200px',
-          textAlign: 'right',
-}}
+        classes={{ root: 'last-saved-text' }}
       >
-        {this.props.lastSaved === undefined ? ' ' : `last saved: ${prettyDate(this.props.lastSaved)}`}
+        {this.props.lastSaved === undefined ? ' ' : `saved ${prettyDate(this.props.lastSaved)}`}
       </Typography>)
   }
 }

--- a/src/components/toolbar/notebook-task-button.jsx
+++ b/src/components/toolbar/notebook-task-button.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import IconButton from 'material-ui/IconButton'
-
+import Tooltip from 'material-ui/Tooltip'
 import UserTask from '../../user-task'
 import ExternalLinkTask from '../../external-link-task'
+
 
 // TODO - implement tooltip again
 export default class NotebookTaskFunction extends React.Component {
@@ -17,14 +18,18 @@ export default class NotebookTaskFunction extends React.Component {
   static muiName='IconButton'
   render() {
     return (
-      <IconButton
-        classes={{ root: 'menu-button' }}
-        className="menu-button"
-        style={this.props.style || { color: '#fafafa' }}
-        onClick={this.props.task.callback}
-      >
-        {this.props.children}
-      </IconButton>
+      <Tooltip id="tooltip-icon" title={this.props.task.menuTitle}>
+
+        <IconButton
+          classes={{ root: 'menu-button' }}
+          className="menu-button"
+          style={this.props.style || { color: '#fafafa' }}
+          onClick={this.props.task.callback}
+        >
+          {this.props.children}
+        </IconButton>
+      </Tooltip>
+
     )
   }
 }

--- a/src/components/toolbar/notebook-task-button.jsx
+++ b/src/components/toolbar/notebook-task-button.jsx
@@ -18,6 +18,7 @@ export default class NotebookTaskFunction extends React.Component {
   render() {
     return (
       <IconButton
+        classes={{ root: 'menu-button' }}
         className="menu-button"
         style={this.props.style || { color: '#fafafa' }}
         onClick={this.props.task.callback}

--- a/src/components/toolbar/view-mode-toggle-button.jsx
+++ b/src/components/toolbar/view-mode-toggle-button.jsx
@@ -26,7 +26,7 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
 
   render() {
     return (
-      <Tooltip id="tooltip-icon" title={this.props.viewMode === 'presentation' ? 'Edit This' : 'Presentation'}>
+      <Tooltip id="tooltip-icon" title={this.props.viewMode === 'presentation' ? 'Edit this page' : 'Presentation'}>
 
         <Button
           style={{ color: this.props.textColor || '#fafafa' }}

--- a/src/components/toolbar/view-mode-toggle-button.jsx
+++ b/src/components/toolbar/view-mode-toggle-button.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Button from 'material-ui/Button'
-
+import Tooltip from 'material-ui/Tooltip'
 import tasks from '../../task-definitions'
 
 export class ViewModeToggleButtonUnconnected extends React.Component {
@@ -26,14 +26,17 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
 
   render() {
     return (
-      <Button
-        style={{ color: this.props.textColor || '#fafafa' }}
-        onClick={this.toggleViewMode}
-        variant="flat"
-        mini
-      >
-        {this.props.viewMode === 'presentation' ? 'Edit' : 'View'}
-      </Button>
+      <Tooltip id="tooltip-icon" title={this.props.viewMode === 'presentation' ? 'Edit This' : 'Presentation'}>
+
+        <Button
+          style={{ color: this.props.textColor || '#fafafa' }}
+          onClick={this.toggleViewMode}
+          variant="flat"
+          mini
+        >
+          {this.props.viewMode === 'presentation' ? 'Edit' : 'View'}
+        </Button>
+      </Tooltip>
     )
   }
 }

--- a/src/page.css
+++ b/src/page.css
@@ -326,23 +326,60 @@ div.dom-cell-error {
 /************************************************/
 /* header bar styles */
 
+.notebook-toolbar-container {
+  background-color: black; 
+  height: 50px
+}
+
+.notebook-toolbar {
+  height:50px;
+  display: flex;
+  position: relative;
+  min-height: 56px;
+  align-items: center;
+  min-height:50px !important;
+}
+
 div.editor-mode-controls {
-  width: 400px; 
+  width: 260px; 
 }
 
 div.view-controls {
-  width: 400px;
+  width: 300px;
   display:flex;
   align-items:center;
 }
 
 div.title-field {
-  width: calc( 100% - 400px - 400px );
+  width: calc( 100% - 260px - 300px );
 }
 
 div.title-field-contents {
   display: flex;
-  width: 100%
+  width: 100%;
+}
+
+.last-saved-text {
+  font-size: 11px;
+  color: lightgray;
+  font-style: italic;
+  width: 125px;
+  text-align: right;
+}
+
+@media (max-width:1100px) {
+  
+  .last-saved-text {
+    display:none !important;
+  }
+
+  div.view-controls {
+    width:200px;
+  }
+
+  div.title-field {
+    width: calc( 100% - 260px - 200px)
+  }
 }
 
 div.display-title {
@@ -367,15 +404,15 @@ input.page-title {
   font-size: 14px;
   border: none;
   outline: none;
-  width: calc(100% - 20px);
+  width:100%;
   margin: auto;
   text-align: center;
   color: white;
-  background-color: black
+  background-color: black;
 }
 
 input.page-title:focus {
-  font-size: 25px
+  font-size: 20px
 }
 
 /* div.unselected-title-field:before {
@@ -408,6 +445,7 @@ ul.load-notebook-menu li {
 
 .load-notebook-menu span.menu-notebook-name {
   width: 300px;
+
   text-overflow: ellipsis;
   overflow-x: hidden;
   vertical-align: top;
@@ -464,7 +502,7 @@ div.last-saved {
 
 .side-pane {
   width:575px !important;
-  top: 64px !important;
+  top: 50px !important;
   border: none !important;
   border-left: 2px solid lightgray !important;
 }
@@ -480,8 +518,8 @@ div.last-saved {
 }
 
 .pane-title .menu-button {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   padding-bottom:0px
 }
 
@@ -657,7 +695,9 @@ table tr:nth-child(2n) {
 }
 
 .menu-button {
-  color: #fafafa
+  color: #fafafa;
+  width: 40px !important;
+  height:40px !important;
 }
 
 .menu-button:hover {

--- a/src/page.css
+++ b/src/page.css
@@ -35,15 +35,15 @@ div#headerbar {
 div.notebook-menu {
     position: fixed;
     width: 100%;
-    height: 64px
+    height: 50px;
 }
 
 div#cells {
     position: fixed;
-    top: 65px; /*move down by the header bar height*/
+    top: 50px; /*move down by the header bar height*/
     left: 0px;
     box-sizing: border-box;
-    height: calc(100% - 65px); /*subtract off the header bar height*/
+    height: calc(100% - 50px); /*subtract off the header bar height*/
     width: 100%;
     overflow-y: auto;
     padding-top: 20px;

--- a/test/toolbar/notebook-task-button.test.js
+++ b/test/toolbar/notebook-task-button.test.js
@@ -10,7 +10,7 @@ describe('NotebookTaskButton has one IconButton', () => {
   const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => {}, secondaryText: 'neat' })}>ok</NotebookTaskButton>)
   it('renders one NotebookTaskButton which contains an IconButton', () => {
     expect(nbTask.find(IconButton).length).toBe(1)
-    expect(nbTask.props().children).toBe('ok')
+    expect(nbTask.find(IconButton).props().children).toBe('ok')
   })
 })
 
@@ -18,7 +18,7 @@ describe('NotebookTaskButton onClick', () => {
   let sentinel = false
   const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => { sentinel = true }, secondaryText: 'neat' })}>ok</NotebookTaskButton>)
   it('uses callback via click to run sentinel', () => {
-    nbTask.simulate('click')
+    nbTask.find(IconButton).simulate('click')
     expect(sentinel).toBe(true)
   })
 })


### PR DESCRIPTION
Should close #454 / #124, and #455:

- height of toolbar is now 50px, and the buttons have been reduced in height / width
- the title now takes up more space by default. The toolbar is _not_ really responsive at this point, but it should work if you keep a browser window at half of your laptop screen width, more or less.
- tooltips everywhere.