### PR TITLE
Support dynamically adding new languages

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -63,10 +63,11 @@ const actions = {
       content: text,
     }
   },
-  changeCellType(cellType) {
+  changeCellType(cellType, language = undefined) {
     return {
       type: 'CHANGE_CELL_TYPE',
       cellType,
+      language,
     }
   },
   evaluateCell(cellId) {
@@ -111,10 +112,11 @@ const actions = {
       direction,
     }
   },
-  addCell(cellType) {
+  addCell(cellType, language = undefined) {
     return {
       type: 'ADD_CELL',
       cellType,
+      language,
     }
   },
   selectCell(cellID, scrollToCell = false) {

--- a/src/api.js
+++ b/src/api.js
@@ -1,10 +1,14 @@
 // The "Public API" for notebooks. This lets notebooks and third-party plugins
 // extend and manipulate the notebook
 
+import { addLanguage } from './language'
 import { addOutputHandler } from './components/output'
+import { addTask } from './task-definitions'
 
 export const iodide = {
+  addLanguage,
   addOutputHandler,
+  addTask,
 }
 
 export default iodide

--- a/src/components/cell-container.jsx
+++ b/src/components/cell-container.jsx
@@ -30,7 +30,7 @@ class CellContainer extends React.Component {
 
   render() {
     const cellClass = `cell-container ${
-      this.props.cellType
+      this.props.cellType === 'code' ? this.props.language : this.props.cellType
     } ${
       this.props.selected ? 'selected-cell' : ''
     } ${

--- a/src/components/cell-editor.jsx
+++ b/src/components/cell-editor.jsx
@@ -20,6 +20,7 @@ import 'codemirror/addon/hint/javascript-hint'
 /* eslint-enable */
 import { getCellById } from '../notebook-utils'
 import actions from '../actions'
+import { getLanguageByName } from '../language'
 
 class CellEditor extends React.Component {
   static propTypes = {
@@ -39,6 +40,7 @@ class CellEditor extends React.Component {
     onContainerClick: PropTypes.func,
     containerStyle: PropTypes.object,
     editorOptions: PropTypes.object,
+    language: PropTypes.string,
   }
 
   constructor(props) {
@@ -68,6 +70,17 @@ class CellEditor extends React.Component {
     if (this.props.pageMode !== 'edit' || this.props.viewMode !== 'editor') {
       this.editor.getCodeMirror().display.input.textarea.blur()
     }
+  }
+
+  getMode() {
+    let mode = this.props.cellType
+    if (mode === 'code') {
+      const language = getLanguageByName(this.props.language)
+      if (language !== undefined) {
+        mode = language.codeMirrorName
+      }
+    }
+    return mode
   }
 
   handleFocusChange(focused) {
@@ -111,8 +124,10 @@ class CellEditor extends React.Component {
   }
 
   render() {
+    const mode = this.getMode()
+
     const editorOptions = Object.assign({
-      mode: this.props.cellType,
+      mode,
       lineWrapping: false,
       matchBrackets: true,
       autoCloseBrackets: true,
@@ -121,9 +136,9 @@ class CellEditor extends React.Component {
       lineNumbers: true,
       keyMap: 'sublime',
       extraKeys: {
-        'Ctrl-Space': this.props.cellType === 'javascript' ? this.autoComplete : undefined,
+        'Ctrl-Space': this.props.language === 'js' ? this.autoComplete : undefined,
       },
-      comment: this.props.cellType === 'javascript',
+      comment: this.props.language === 'js',
       readOnly: this.props.viewMode === 'presentation',
     }, this.props.editorOptions)
 

--- a/src/components/cell-row.jsx
+++ b/src/components/cell-row.jsx
@@ -93,7 +93,7 @@ function mapStateToPropsCellRows(state, ownProps) {
   }
   const rowOverflow = cell.rowSettings[view][ownProps.rowType]
   const executionString = (ownProps.rowType === 'input'
-    && cell.cellType === 'javascript') ? `[${cell.executionStatus}]` : ''
+    && cell.cellType === 'code') ? `[${cell.executionStatus}]` : ''
   return {
     pageMode: state.mode,
     viewMode: state.viewMode,

--- a/src/components/cell-type-code.jsx
+++ b/src/components/cell-type-code.jsx
@@ -8,20 +8,25 @@ import CellOutput from './output'
 import CellEditor from './cell-editor'
 
 import { getCellById } from '../notebook-utils'
+import { getLanguageByName } from '../language'
 
-
-export class JsCellUnconnected extends React.Component {
+export class CodeCellUnconnected extends React.Component {
   static propTypes = {
     cellId: PropTypes.number.isRequired,
     value: PropTypes.any,
     rendered: PropTypes.bool.isRequired,
+    language: PropTypes.string.isRequired,
   }
 
   render() {
     return (
       <CellContainer cellId={this.props.cellId}>
-        <CellRow cellId={this.props.cellId} rowType="input">
-          <CellEditor cellId={this.props.cellId} />
+        <CellRow
+          cellId={this.props.cellId}
+          rowType="input"
+          class={getLanguageByName(this.props.language).name}
+        >
+          <CellEditor cellId={this.props.cellId} language={this.props.language} />
         </CellRow>
         <CellRow cellId={this.props.cellId} rowType="sideeffect">
           <div className="side-effect-target" />
@@ -43,8 +48,9 @@ export function mapStateToProps(state, ownProps) {
   return {
     value: cell.value,
     rendered: cell.rendered,
+    language: cell.language,
   }
 }
 
 
-export default connect(mapStateToProps)(JsCellUnconnected)
+export default connect(mapStateToProps)(CodeCellUnconnected)

--- a/src/components/page.jsx
+++ b/src/components/page.jsx
@@ -7,7 +7,7 @@ import deepEqual from 'deep-equal'
 import RawCell from './cell-type-raw'
 import ExternalDependencyCell from './cell-type-external-resource'
 import CSSCell from './cell-type-css'
-import JsCell from './cell-type-javascript'
+import CodeCell from './cell-type-code'
 import MarkdownCell from './cell-type-markdown'
 
 import NotebookHeader from './notebook-header'
@@ -71,9 +71,8 @@ class Page extends React.Component {
     const bodyContent = this.props.cellIds.map((id, i) => {
       // let id = cell.id
       switch (this.props.cellTypes[i]) {
-        case 'javascript':
-        // return <JavascriptCell cellId={id} key={id}/>
-          return <JsCell cellId={id} key={id} />
+        case 'code':
+          return <CodeCell cellId={id} key={id} />
         case 'markdown':
           return <MarkdownCell cellId={id} key={id} />
         case 'raw':

--- a/src/components/toolbar/cell-menu-subsection.jsx
+++ b/src/components/toolbar/cell-menu-subsection.jsx
@@ -6,9 +6,13 @@ import NotebookMenuHeader from './notebook-menu-header'
 import NotebookMenuSubsection from './notebook-menu-subsection'
 
 import tasks from '../../task-definitions'
+import { getLanguages } from '../../language'
 
 export default class CellMenuSubsection extends React.Component {
   render() {
+    const languages = getLanguages().map(language =>
+      <NotebookMenuItem key={language.name} task={language.task} />)
+
     return (
       <NotebookMenuSubsection className="medium-menu" title="cell ..." {...this.props} >
         <NotebookMenuItem key={tasks.moveCellUp.title} task={tasks.moveCellUp} />
@@ -17,10 +21,7 @@ export default class CellMenuSubsection extends React.Component {
         <NotebookMenuItem key={tasks.deleteCell.title} task={tasks.deleteCell} />
         <NotebookMenuDivider />
         <NotebookMenuHeader title="change cell to ..." />
-        <NotebookMenuItem
-          key={tasks.changeToJavascriptCell.title}
-          task={tasks.changeToJavascriptCell}
-        />
+        {languages}
         <NotebookMenuItem
           key={tasks.changeToMarkdownCell.title}
           task={tasks.changeToMarkdownCell}

--- a/src/keybindings.js
+++ b/src/keybindings.js
@@ -4,13 +4,16 @@ import tasks from './task-definitions'
 
 Mousetrap.prototype.stopCallback = () => false
 
+export function registerKeyBinding(task) {
+  if (task.hasKeybinding()) {
+    Mousetrap.bind(task.keybindings, task.keybindingCallback)
+  }
+}
 
 function keyBinding() {
   Object.keys(tasks).forEach((t) => {
     const task = tasks[t]
-    if (task.hasKeybinding()) {
-      Mousetrap.bind(task.keybindings, task.keybindingCallback)
-    }
+    registerKeyBinding(task)
   })
 }
 

--- a/src/language.jsx
+++ b/src/language.jsx
@@ -1,0 +1,47 @@
+import { isCommandMode } from './notebook-utils'
+import { addTask, dispatcher } from './task-definitions'
+
+const languages = []
+const langByName = {}
+
+function addLanguage(language) {
+  languages.push(language)
+  langByName[language.name] = language
+
+  // Create a task to change a cell to a given language
+  const task = addTask(`changeTo${language.name}Cell`, {
+    title: language.displayName,
+    keybindings: [language.keybinding],
+    displayKeybinding: [language.keybinding.toUpperCase()],
+    keybindingPrecondition: isCommandMode,
+    callback() {
+      dispatcher.changeCellType('code', language.name)
+    },
+  })
+
+  language.task = task // eslint-disable-line
+}
+
+function getLanguageByName(name) {
+  return langByName[name];
+}
+
+function getLanguages() {
+  return languages;
+}
+
+// Javascript, the 'built-in' language™
+
+addLanguage({
+  name: 'js',
+  displayName: 'Javascript',
+  codeMirrorName: 'javascript',
+  evaluate: code => window.eval(code),  // eslint-disable-line
+  keybinding: 'j',
+})
+
+export {
+  getLanguageByName,
+  getLanguages,
+  addLanguage,
+}

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -66,7 +66,6 @@ const cellReducer = (state = newNotebook(), action) => {
     }
     case 'ADD_CELL': {
       const language = getDefaultLanguage(action.language)
-      console.log(language) // eslint-disable-line
       nextState = Object.assign({}, state)
       const cells = nextState.cells.slice()
       const nextCell = newCell(newCellID(nextState.cells), action.cellType, language)

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -24,6 +24,17 @@ const evalStatuses = {}
 evalStatuses.SUCCESS = 'success'
 evalStatuses.ERROR = 'error'
 
+let defaultLanguage = 'js'
+
+function getDefaultLanguage(language) {
+  // Remember the last language cell created and create that by default if one
+  // isn't specified
+  if (language === undefined) {
+    return defaultLanguage
+  }
+  defaultLanguage = language
+  return language
+}
 
 const cellReducer = (state = newNotebook(), action) => {
   let nextState
@@ -44,18 +55,21 @@ const cellReducer = (state = newNotebook(), action) => {
       return nextState
     }
     case 'INSERT_CELL': {
+      const language = getDefaultLanguage()
       const cells = state.cells.slice()
       const index = cells.findIndex(c => c.id === getSelectedCellId(state))
       const direction = (action.direction === 'above') ? 0 : 1
-      const nextCell = newCell(newCellID(state.cells), 'javascript')
+      const nextCell = newCell(newCellID(state.cells), 'code', language)
       cells.splice(index + direction, 0, nextCell)
       nextState = Object.assign({}, state, { cells })
       return nextState
     }
     case 'ADD_CELL': {
+      const language = getDefaultLanguage(action.language)
+      console.log(language) // eslint-disable-line
       nextState = Object.assign({}, state)
       const cells = nextState.cells.slice()
-      const nextCell = newCell(newCellID(nextState.cells), action.cellType)
+      const nextCell = newCell(newCellID(nextState.cells), action.cellType, language)
       nextState = Object.assign({}, nextState, { cells: [...cells, nextCell] })
       return nextState
     }
@@ -97,11 +111,13 @@ const cellReducer = (state = newNotebook(), action) => {
     case 'CHANGE_CELL_TYPE': {
       // create a newCell of the given type to get the defaults that
       // will need to be updated for the new cell type
-      const { rowSettings } = newCell(-1, action.cellType)
+      const language = getDefaultLanguage(action.language)
+      const { rowSettings } = newCell(-1, action.cellType, language)
       return newStateWithSelectedCellPropsAssigned(
         state,
         {
           cellType: action.cellType,
+          language: action.language,
           value: undefined,
           rendered: false,
           rowSettings,
@@ -136,7 +152,7 @@ const cellReducer = (state = newNotebook(), action) => {
       const index = cells.findIndex(c => c.id === cellId)
       const thisCell = cells[index]
 
-      if (thisCell.cellType === 'javascript') {
+      if (thisCell.cellType === 'code') {
       // add to newState.history
         newState.history.push({
           cellID: thisCell.id,
@@ -145,6 +161,15 @@ const cellReducer = (state = newNotebook(), action) => {
         })
 
         thisCell.value = undefined
+
+        // Loaded dynamically to avoid circular dependency
+        const { getLanguageByName } = require('../language') // eslint-disable-line global-require
+
+        const language = getLanguageByName(thisCell.language)
+        if (language === undefined) {
+          // TODO: Display this properly
+          alert("Unknown language '" + thisCell.language + "'") // eslint-disable-line
+        }
 
         let output
         const code = thisCell.content
@@ -157,7 +182,7 @@ const cellReducer = (state = newNotebook(), action) => {
         //   }
         // }
         try {
-          output = window.eval(code)  // eslint-disable-line
+          output = language.evaluate(code)
           thisCell.evalStatus = evalStatuses.SUCCESS
         } catch (e) {
           const err = e.constructor(`Error in Evaled Script: ${e.message}`)

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -13,7 +13,7 @@ function clearHistory(loadedState) {
   loadedState.cells = [...loadedState.cells.slice()]
   loadedState.cells.forEach((cell) => {
     cell.evalStatus = undefined
-    if (cell.cellType === 'javascript' || cell.cellType === 'external dependencies') cell.value = undefined
+    if (cell.cellType === 'code' || cell.cellType === 'external dependencies') cell.value = undefined
   })
   /* eslint-enable */
 }
@@ -75,7 +75,7 @@ const notebookReducer = (state = newNotebook(), action) => {
         cells: state.cells.slice().map((c) => {
           const newC = Object.assign({}, c)
           newC.evalStatus = undefined
-          if (newC.cellType === 'javascript' || newC.cellType === 'external dependencies') {
+          if (newC.cellType === 'code' || newC.cellType === 'external dependencies') {
             newC.value = undefined
           }
           return newC

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -150,7 +150,6 @@ function newCellRowSettings(cellType) {
 }
 
 function newCell(cellId, cellType, language) {
-  console.log('newCell ' + language) // eslint-disable-line
   return {
     content: '',
     id: cellId,

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -17,7 +17,7 @@ const StringEnum = class {
 const rowOverflowEnum = new StringEnum('VISIBLE', 'SCROLL', 'HIDDEN')
 // const rowTypeEnum = new StringEnum('input', 'output')
 const cellTypeEnum = new StringEnum(
-  'javascript',
+  'code',
   'markdown',
   'raw',
   'css',
@@ -42,6 +42,7 @@ const cellSchema = {
     executionStatus: { type: 'string' },
     evalStatus: {}, // FIXME change to string ONLY
     rowSettings: { type: 'object' },
+    language: { type: 'string' },
   },
   additionalProperties: false,
 }
@@ -90,7 +91,7 @@ function nextOverflow(currentOverflow) {
 
 function newCellRowSettings(cellType) {
   switch (cellType) {
-    case 'javascript':
+    case 'code':
       return {
         EXPLORE: {
           input: rowOverflowEnum.VISIBLE,
@@ -148,7 +149,8 @@ function newCellRowSettings(cellType) {
   }
 }
 
-function newCell(cellId, cellType) {
+function newCell(cellId, cellType, language) {
+  console.log('newCell ' + language) // eslint-disable-line
   return {
     content: '',
     id: cellId,
@@ -159,6 +161,7 @@ function newCell(cellId, cellType) {
     executionStatus: ' ',
     evalStatus: undefined,
     rowSettings: newCellRowSettings(cellType),
+    language,
   }
 }
 
@@ -182,15 +185,15 @@ function newCellID(cells) {
   return Math.max(-1, ...cells.map(c => c.id)) + 1
 }
 
-function addNewCellToState(state, cellType) {
+function addNewCellToState(state, cellType, language) {
   const nextCellId = newCellID(state.cells)
-  state.cells.push(newCell(nextCellId, cellType))
+  state.cells.push(newCell(nextCellId, cellType, language))
   return state
 }
 
 function newNotebook() {
   // initialize a blank notebook and push a blank new cell into it
-  const initialState = addNewCellToState(blankState(), 'javascript')
+  const initialState = addNewCellToState(blankState(), 'code', 'js')
   // set the cell that was just pushed to be the selected cell
   initialState.cells[0].selected = true
   return initialState

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -6,10 +6,13 @@ import { isCommandMode,
   viewModeIsEditor,
   getCells,
   getCellBelowSelectedId,
-  getCellAboveSelectedId, prettyDate, formatDateString } from './notebook-utils'
+  getCellAboveSelectedId,
+  prettyDate,
+  formatDateString } from './notebook-utils'
 import { stateFromJsmd } from './jsmd-tools'
+import { registerKeyBinding } from './keybindings'
 
-const dispatcher = {}
+export const dispatcher = {}
 for (const action in actions) {
   if (Object.prototype.hasOwnProperty.call(actions, action)) {
     dispatcher[action] = (...params) => (store.dispatch(actions[action](...params)))
@@ -80,7 +83,7 @@ tasks.evaluateCellAndSelectBelow = new UserTask({
       dispatcher.selectCell(cellBelowId, true)
     } else {
     // if cellBelowId *is* null, need to add a new cell.
-      dispatcher.addCell('javascript')
+      dispatcher.addCell('code')
       dispatcher.selectCell(getCellBelowSelectedId(), true)
     }
   },
@@ -138,7 +141,7 @@ tasks.addCellAbove = new UserTask({
   displayKeybinding: 'a',
   keybindingPrecondition: isCommandMode,
   callback() {
-    dispatcher.insertCell('javascript', 'above')
+    dispatcher.insertCell('code', 'above')
     dispatcher.selectCell(getCellAboveSelectedId(), true)
   },
 })
@@ -150,7 +153,7 @@ tasks.addCellBelow = new UserTask({
   keybindingPrecondition: isCommandMode,
 
   callback() {
-    dispatcher.insertCell('javascript', 'below')
+    dispatcher.insertCell('code', 'below')
     dispatcher.selectCell(getCellBelowSelectedId(), true)
   },
 })
@@ -161,17 +164,6 @@ tasks.deleteCell = new UserTask({
   displayKeybinding: '\u21E7 \u232b',
   keybindingPrecondition: isCommandMode,
   callback() { dispatcher.deleteCell() },
-})
-
-tasks.changeToJavascriptCell = new UserTask({
-  title: 'Change to Javascript',
-  menuTitle: 'Javascript',
-  keybindings: ['j'],
-  displayKeybinding: 'J',
-  keybindingPrecondition: isCommandMode,
-  callback() {
-    dispatcher.changeCellType('javascript')
-  },
 })
 
 tasks.changeToMarkdownCell = new UserTask({
@@ -357,6 +349,13 @@ export function getLocalStorageNotebook(name) {
       dispatcher.loadNotebook(name)
     },
   })
+}
+
+export function addTask(name, obj) {
+  const task = new UserTask(obj)
+  tasks[name] = task
+  registerKeyBinding(task)
+  return task
 }
 
 export default tasks

--- a/test/cell-reducer.test.js
+++ b/test/cell-reducer.test.js
@@ -3,10 +3,10 @@ import { newNotebook } from './../src/state-prototypes'
 
 describe('add cells', () => {
   const state = newNotebook()
-  const nextState = cellReducer(state, { type: 'ADD_CELL', cellType: 'javascript' })
+  const nextState = cellReducer(state, { type: 'ADD_CELL', cellType: 'code' })
   it('should add a cell to the end of the current notebook', () => {
     expect(nextState.cells.length).toEqual(newNotebook().cells.length + 1)
-    expect(nextState.cells[nextState.cells.length - 1].cellType).toEqual('javascript')
+    expect(nextState.cells[nextState.cells.length - 1].cellType).toEqual('code')
   })
 })
 

--- a/test/cell-type-code.test.js
+++ b/test/cell-type-code.test.js
@@ -1,19 +1,19 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { JsCellUnconnected as JsCell,
-  mapStateToProps } from '../src/components/cell-type-javascript'
+import { CodeCellUnconnected as CodeCell,
+  mapStateToProps } from '../src/components/cell-type-code'
 import { CellContainer } from '../src/components/cell-container'
 import CellRow from '../src/components/cell-row'
 import CellEditor from '../src/components/cell-editor'
 import CellOutput from '../src/components/output'
 
-describe('JsCell_unconnected react component', () => {
+describe('CodeCell_unconnected react component', () => {
   let props
   let mountedCell
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<JsCell {...props} />)
+      mountedCell = shallow(<CodeCell {...props} />)
     }
     return mountedCell
   }
@@ -23,6 +23,7 @@ describe('JsCell_unconnected react component', () => {
       cellId: 5,
       value: 3.1415,
       rendered: true,
+      language: 'js',
     }
     mountedCell = undefined
   })
@@ -51,12 +52,12 @@ describe('JsCell_unconnected react component', () => {
       .find(CellOutput)).toHaveLength(1)
   })
 
-  it("sets the CellContainer cellId prop to be the JsCell's cellId prop", () => {
+  it("sets the CellContainer cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
       .toBe(props.cellId)
   })
 
-  it("sets the first CellRow cellId prop to be the JsCell's cellId prop", () => {
+  it("sets the first CellRow cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellRow).at(0).props().cellId)
       .toBe(props.cellId)
   })
@@ -66,7 +67,7 @@ describe('JsCell_unconnected react component', () => {
       .toBe('input')
   })
 
-  it("sets the 2nd CellRow cellId prop to be the JsCell's cellId prop", () => {
+  it("sets the 2nd CellRow cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellRow).at(1).props().cellId)
       .toBe(props.cellId)
   })
@@ -91,25 +92,24 @@ describe('JsCell_unconnected react component', () => {
       .toBe('output')
   })
 
-
-  it("sets the CellEditor cellId prop to be the JsCell's cellId prop", () => {
+  it("sets the CellEditor cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellEditor).props().cellId)
       .toBe(props.cellId)
   })
 
-  it("sets the CellOutput valueToRender prop to be the JsCell's value prop", () => {
+  it("sets the CellOutput valueToRender prop to be the CodeCell's value prop", () => {
     expect(cell().find(CellOutput).props().valueToRender)
       .toBe(props.value)
   })
 
-  it("sets the CellOutput renderValue prop to be the JsCell's value prop", () => {
+  it("sets the CellOutput renderValue prop to be the CodeCell's value prop", () => {
     expect(cell().find(CellOutput).props().render)
       .toBe(props.rendered)
   })
 })
 
 
-describe('JsCell mapStateToProps', () => {
+describe('CodeCell mapStateToProps', () => {
   const state = {
     cells: [
       { id: 5, rendered: false },

--- a/test/jsmd-tools_parse.test.js
+++ b/test/jsmd-tools_parse.test.js
@@ -58,7 +58,7 @@ describe('jsmd parser Ex 1', () => {
   })
   it('should have correct cell types', () => {
     expect(cells.map(c => c.cellType)).toEqual([
-      'markdown', 'javascript', 'raw', 'markdown', 'external dependencies', 'css', 'javascript',
+      'markdown', 'code', 'raw', 'markdown', 'external dependencies', 'css', 'code',
     ])
   })
   it('should have zero parse warnings', () => {
@@ -110,7 +110,7 @@ describe('jsmd parser test case 3', () => {
     expect(parseWarnings).toEqual([])
   })
   it('all cells should have cellType==js', () => {
-    expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(['javascript']))
+    expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(['code']))
   })
   it('all cells should have content=="foo"', () => {
     expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['foo']))
@@ -158,10 +158,10 @@ describe('jsmd parser test case 5', () => {
     expect(cells.length).toEqual(3)
   })
   it('should have 3 parse warnings', () => {
-    expect(parseWarnings.length).toEqual(3)
+    expect(parseWarnings.length).toEqual(2)
   })
   it('all cells should have cellType==js (bad cellTypes should convert to js)', () => {
-    expect(cells.map(c => c.cellType)).toEqual(['javascript', 'javascript', 'javascript'])
+    expect(cells.map(c => c.cellType)).toEqual(['code', 'code', 'code'])
   })
   it('cell 1 should have "rowSettings.REPORT.output":"VISIBLE"', () => {
     expect(cells[1].rowSettings.REPORT.output).toEqual('VISIBLE')
@@ -192,7 +192,7 @@ describe('jsmd parser test case 6', () => {
     expect(parseWarnings.length).toEqual(1)
   })
   it('the cells should have cellType==js (bad cellTypes should convert to js)', () => {
-    expect(cells.map(c => c.cellType)).toEqual(['javascript'])
+    expect(cells.map(c => c.cellType)).toEqual(['code'])
   })
   it('state should be a default notebook with no additions', () => {
     expect(state).toEqual(newNotebook())

--- a/test/notebook-reducer.test.js
+++ b/test/notebook-reducer.test.js
@@ -14,7 +14,7 @@ const EXAMPLE_NOTEBOOK_1 = 'example notebook with content'
 
 function exampleNotebookWithContent(title = EXAMPLE_NOTEBOOK_1) {
   let state = newNotebook()
-  state = addNewCellToState(state, 'javascript')
+  state = addNewCellToState(state, 'code', 'js')
   state = addNewCellToState(state, 'markdown')
   state.cells[0].selected = true
   state.title = title


### PR DESCRIPTION
This provides an API to add support for a new language.

The main design point I'm trying to maintain here is that just importing a library should be enough to add a new language.  That means we have to be as lazy as possible about new languages and not care about whether we know about them until the last minute at evaluation.  Therefore, the jsmd parser will basically take any block type it doesn't understand and create a code cell for that unknown language, and only when it actually tries to run it will it complain.

You can see what it takes to add a new language here: https://github.com/iodide-project/pyodide/blob/master/src/pyodide.js#L37

Still to do:
- [ ] Write new tests for the new functionality
- [ ] Get CodeMirror to dynamically load the language definition for syntax highlighting
- [ ] Add the ability to extend auto completion (right now it's just hardcoded for javascript only)