### PR TITLE
fixes #462

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5,9 +5,10 @@ const actions = {
       newState,
     }
   },
-  exportNotebook() {
+  exportNotebook(exportAsReport = false) {
     return {
       type: 'EXPORT_NOTEBOOK',
+      exportAsReport,
     }
   },
   saveNotebook(title = undefined, autosave = false) {

--- a/src/components/toolbar/editor-toolbar-menu.jsx
+++ b/src/components/toolbar/editor-toolbar-menu.jsx
@@ -16,6 +16,7 @@ export default class EditorToolbarMenu extends React.Component {
         <NotebookMenuItem task={tasks.createNewNotebook} />
         <NotebookMenuItem task={tasks.saveNotebook} />
         <NotebookMenuItem task={tasks.exportNotebook} />
+        <NotebookMenuItem task={tasks.exportNotebookAsReport} />
         <NotebookMenuItem task={tasks.clearVariables} />
 
         <SavedNotebooksAndExamplesSubsection />

--- a/src/evaluate-all-cells.js
+++ b/src/evaluate-all-cells.js
@@ -2,6 +2,11 @@ import actions from './actions'
 
 export default function evaluateAllCells(cells, store) {
   cells.forEach((cell) => {
+    if (cell.cellType === 'css') {
+      store.dispatch(actions.evaluateCell(cell.id))
+    }
+  })
+  cells.forEach((cell) => {
     if (cell.cellType === 'markdown') {
       store.dispatch(actions.evaluateCell(cell.id))
     }
@@ -9,7 +14,7 @@ export default function evaluateAllCells(cells, store) {
   window.setTimeout(
     () => {
       cells.forEach((cell) => {
-        if (cell.cellType !== 'markdown') {
+        if (cell.cellType !== 'markdown' && cell.cellType !== 'markdown') {
           store.dispatch(actions.evaluateCell(cell.id))
         }
       })

--- a/src/evaluate-all-cells.js
+++ b/src/evaluate-all-cells.js
@@ -1,0 +1,19 @@
+import actions from './actions'
+
+export default function evaluateAllCells(cells, store) {
+  cells.forEach((cell) => {
+    if (cell.cellType === 'markdown') {
+      store.dispatch(actions.evaluateCell(cell.id))
+    }
+  })
+  window.setTimeout(
+    () => {
+      cells.forEach((cell) => {
+        if (cell.cellType !== 'markdown') {
+          store.dispatch(actions.evaluateCell(cell.id))
+        }
+      })
+    },
+    42, // wait a few milliseconds to let React DOM updates flush
+  )
+}

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -40,17 +40,21 @@ const notebookReducer = (state = newNotebook(), action) => {
       return newNotebook()
 
     case 'EXPORT_NOTEBOOK': {
-      nextState = Object.assign({}, state)
-      clearHistory(nextState)
-      const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(exportJsmdBundle(nextState))}`
+      const exportState = Object.assign(
+        {},
+        state,
+        { viewMode: action.exportAsReport ? 'presentation' : 'editor' },
+      )
+      console.log(exportState)
+      const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(exportJsmdBundle(exportState))}`
       const dlAnchorElem = document.getElementById('export-anchor')
       dlAnchorElem.setAttribute('href', dataStr)
-      title = nextState.title === undefined ? 'new-notebook' : nextState.title
+      title = exportState.title === undefined ? 'new-notebook' : exportState.title
       const filename = `${title.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.html`
       dlAnchorElem.setAttribute('download', filename)
       dlAnchorElem.click()
 
-      return Object.assign({}, state)
+      return state
     }
 
     case 'IMPORT_NOTEBOOK': {

--- a/src/store.js
+++ b/src/store.js
@@ -5,14 +5,19 @@ import createValidatedReducer from './create-validated-reducer'
 import reducer from './reducers/reducer'
 import { initializeNotebook } from './initialize-notebook'
 import { stateSchema } from './state-prototypes'
+import evaluateAllCells from './evaluate-all-cells'
+
+const initialState = initializeNotebook()
 
 const store = createStore(
   createValidatedReducer(reducer, stateSchema),
   // reducer,
-  initializeNotebook(),
+  initialState,
   compose(applyMiddleware(createLogger({
     predicate: (getState, action) => action.type !== 'UPDATE_INPUT_CONTENT',
   }))),
 )
+
+if (initialState.viewMode === 'presentation') { evaluateAllCells(store.getState().cells, store) }
 
 export { store }

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -8,6 +8,7 @@ import { isCommandMode,
   getCellBelowSelectedId,
   getCellAboveSelectedId, prettyDate, formatDateString } from './notebook-utils'
 import { stateFromJsmd } from './jsmd-tools'
+import evaluateAllCells from './evaluate-all-cells'
 
 const dispatcher = {}
 for (const action in actions) {
@@ -46,26 +47,7 @@ tasks.evaluateCell = new UserTask({
 tasks.evaluateAllCells = new UserTask({
   title: 'Evaluate All Cells',
   menuTitle: 'evaluate all cells',
-  callback() {
-    const cells = getCells()
-    cells.forEach((cell) => {
-      if (cell.cellType === 'markdown' ||
-          cell.cellType === 'dom') {
-        dispatcher.evaluateCell(cell.id)
-      }
-    })
-    window.setTimeout(
-      () => {
-        cells.forEach((cell) => {
-          if (cell.cellType !== 'markdown' &&
-              cell.cellType !== 'dom') {
-            dispatcher.evaluateCell(cell.id)
-          }
-        })
-      },
-      42, // wait a few milliseconds to let React DOM updates flush
-    )
-  },
+  callback() { evaluateAllCells(getCells(), store) },
 })
 
 tasks.evaluateCellAndSelectBelow = new UserTask({
@@ -265,6 +247,14 @@ tasks.exportNotebook = new UserTask({
   displayKeybinding: commandKey('E'),
   callback() { dispatcher.exportNotebook() },
 })
+
+tasks.exportNotebookAsReport = new UserTask({
+  title: 'Export Notebook as report',
+  keybindings: ['shift+e'],
+  displayKeybinding: 'Shift E',
+  callback() { dispatcher.exportNotebook(true) },
+})
+
 
 tasks.clearVariables = new UserTask({
   title: 'Clear Variables',

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -25,12 +25,6 @@ if (oscpu.indexOf('X11') !== -1) OSName = 'UNIX'
 if (oscpu.indexOf('Linux') !== -1) OSName = 'Linux'
 
 const commandKey = () => (OSName === 'MacOS' ? '⌘' : 'Ctrl')
-//   let ctr = 'Ctrl '
-//   if () {
-//     ctr = '⌘ '
-//   }
-//   return ctr + key
-// }
 
 const tasks = {}
 
@@ -140,7 +134,7 @@ tasks.addCellBelow = new UserTask({
 tasks.deleteCell = new UserTask({
   title: 'Delete Cell',
   keybindings: ['shift+backspace'],
-  displayKeybinding: 'Shift+Backspace', //'\u21E7 \u232b',
+  displayKeybinding: 'Shift+Backspace', // '\u21E7 \u232b',
   keybindingPrecondition: isCommandMode,
   callback() { dispatcher.deleteCell() },
 })

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -24,13 +24,13 @@ if (oscpu.indexOf('Mac') !== -1) OSName = 'MacOS'
 if (oscpu.indexOf('X11') !== -1) OSName = 'UNIX'
 if (oscpu.indexOf('Linux') !== -1) OSName = 'Linux'
 
-function commandKey(key) {
-  let ctr = 'Ctrl '
-  if (OSName === 'MacOS') {
-    ctr = '⌘ '
-  }
-  return ctr + key
-}
+const commandKey = () => (OSName === 'MacOS' ? '⌘' : 'Ctrl')
+//   let ctr = 'Ctrl '
+//   if () {
+//     ctr = '⌘ '
+//   }
+//   return ctr + key
+// }
 
 const tasks = {}
 
@@ -70,7 +70,7 @@ tasks.evaluateCellAndSelectBelow = new UserTask({
 
 tasks.moveCellUp = new UserTask({
   title: 'Move Cell Up',
-  displayKeybinding: '\u21E7 \u2191',
+  displayKeybinding: 'Shift+Up', // '\u21E7 \u2191',
   keybindings: ['shift+up'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
@@ -82,7 +82,7 @@ tasks.moveCellUp = new UserTask({
 
 tasks.moveCellDown = new UserTask({
   title: 'Move Cell Down',
-  displayKeybinding: '\u21E7 \u2193',
+  displayKeybinding: 'Shift+Down', // '\u21E7 \u2193',
   keybindings: ['shift+down'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
@@ -92,7 +92,7 @@ tasks.moveCellDown = new UserTask({
 
 tasks.selectUp = new UserTask({
   title: 'Select Cell Above',
-  displayKeybinding: '\u2191',
+  displayKeybinding: 'Up', // \u2191',
   keybindings: ['up'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
@@ -104,7 +104,7 @@ tasks.selectUp = new UserTask({
 
 tasks.selectDown = new UserTask({
   title: 'Select Cell Down',
-  displayKeybinding: '\u2193',
+  displayKeybinding: 'Down', // '\u2193',
   keybindings: ['down'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
@@ -117,7 +117,7 @@ tasks.selectDown = new UserTask({
 tasks.addCellAbove = new UserTask({
   title: 'Add Cell Above',
   keybindings: ['a'],
-  displayKeybinding: 'a',
+  displayKeybinding: 'A',
   keybindingPrecondition: isCommandMode,
   callback() {
     dispatcher.insertCell('javascript', 'above')
@@ -128,7 +128,7 @@ tasks.addCellAbove = new UserTask({
 tasks.addCellBelow = new UserTask({
   title: 'Add Cell Below',
   keybindings: ['b'],
-  displayKeybinding: 'b',
+  displayKeybinding: 'B',
   keybindingPrecondition: isCommandMode,
 
   callback() {
@@ -139,8 +139,8 @@ tasks.addCellBelow = new UserTask({
 
 tasks.deleteCell = new UserTask({
   title: 'Delete Cell',
-  keybindings: ['shift+del', 'shift+backspace'],
-  displayKeybinding: '\u21E7 \u232b',
+  keybindings: ['shift+backspace'],
+  displayKeybinding: 'Shift+Backspace', //'\u21E7 \u232b',
   keybindingPrecondition: isCommandMode,
   callback() { dispatcher.deleteCell() },
 })
@@ -209,7 +209,7 @@ tasks.changeToMenuMode = new UserTask({
 tasks.changeToEditMode = new UserTask({
   title: 'Change to Edit Mode',
   keybindings: ['enter', 'return'],
-  displayKeybinding: 'enter',
+  displayKeybinding: 'Enter',
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() { dispatcher.changeMode('edit') },
@@ -236,7 +236,7 @@ tasks.createNewNotebook = new UserTask({
 tasks.saveNotebook = new UserTask({
   title: 'Save Notebook',
   keybindings: ['ctrl+s', 'meta+s'],
-  displayKeybinding: commandKey('S'),
+  displayKeybinding: `${commandKey()}+S`,
   preventDefaultKeybinding: true,
   callback() { dispatcher.saveNotebook(store.getState().title) },
 })
@@ -244,14 +244,14 @@ tasks.saveNotebook = new UserTask({
 tasks.exportNotebook = new UserTask({
   title: 'Export Notebook',
   keybindings: ['ctrl+e', 'meta+e'],
-  displayKeybinding: commandKey('E'),
+  displayKeybinding: `${commandKey()}+E`,
   callback() { dispatcher.exportNotebook() },
 })
 
 tasks.exportNotebookAsReport = new UserTask({
-  title: 'Export Notebook as report',
-  keybindings: ['shift+e'],
-  displayKeybinding: 'Shift E',
+  title: 'Export Notebook as Report',
+  keybindings: ['ctrl+shift+e', 'meta+shift+e'],
+  displayKeybinding: `Shift+${commandKey()}+E`,
   callback() { dispatcher.exportNotebook(true) },
 })
 
@@ -266,7 +266,7 @@ tasks.toggleDeclaredVariablesPane = new UserTask({
   title: 'Toggle the Declared Variables Pane',
   menuTitle: 'Declared Variables',
   keybindings: ['ctrl+d', 'meta+d'],
-  displayKeybinding: commandKey('D'),
+  displayKeybinding: `${commandKey()}+D`,
   preventDefaultKeybinding: true,
   callback() {
     if (store.getState().sidePaneMode !== 'declared variables') {
@@ -281,7 +281,7 @@ tasks.toggleHistoryPane = new UserTask({
   title: 'Toggle the History Pane',
   menuTitle: 'History',
   keybindings: ['ctrl+h', 'meta+h'],
-  displayKeybinding: commandKey('H'),
+  displayKeybinding: `${commandKey()}+H`,
   preventDefaultKeybinding: true,
 
   callback() {


### PR DESCRIPTION
the run all on load is hacky, but run all has always been hacky and weird. Works on the "what a we NB looks like" example, but @hamilton please test on some of your notebooks. testing steps:
(1) get a notebook in exportable shape
(2) `shift+E` or use the menu to "export as report" (save file under a new name probably)
(3) open just saved file

expected:
- should open in report view
- should run all with the same results as if you pressed the "run all" button and switched to report mode

the run all stuff makes me nervous, and i'm sure there are racy bugs around it that we'll need to track down later, but i think this should work as well as run all ever does (in explore view)...