### PR TITLE
App info messages

### DIFF
--- a/src/components/toolbar/app-info-pane.jsx
+++ b/src/components/toolbar/app-info-pane.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import SidePane from './side-pane'
+
+// import DeclaredVariables from '../declared-variables'
+import tasks from '../../task-definitions'
+
+export class AppInfoPaneUnconnected extends React.Component {
+  static propTypes = {
+    appMessages: PropTypes.array,
+  }
+  render() {
+    // i think using index as key is ok here, but be careful!! see:
+    // https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318
+    const messageDivs = this.props.appMessages
+      .map((msg, i) => <div key={`msg-${i}`}>{msg}</div>) // eslint-disable-line
+    return (
+      <SidePane task={tasks.toggleAppInfoPane} title="App info" openOnMode="_APP_INFO">
+        {messageDivs}
+      </SidePane>
+    )
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    appMessages: state.appMessages,
+    sidePaneMode: state.sidePaneMode,
+  }
+}
+
+export default connect(mapStateToProps)(AppInfoPaneUnconnected)

--- a/src/components/toolbar/declared-variables-pane.jsx
+++ b/src/components/toolbar/declared-variables-pane.jsx
@@ -9,7 +9,6 @@ import tasks from '../../task-definitions'
 
 export class DeclaredVariablesPaneUnconnected extends React.Component {
   static propTypes = {
-    history: PropTypes.array,
     declaredVariables: PropTypes.object,
   }
   render() {

--- a/src/components/toolbar/view-controls.jsx
+++ b/src/components/toolbar/view-controls.jsx
@@ -3,12 +3,14 @@ import React from 'react'
 
 import HistoryIcon from 'material-ui-icons/History'
 import ArrowDropDown from 'material-ui-icons/ArrowDropDown'
+import InfoIcon from 'material-ui-icons/InfoOutline'
 
 import NotebookTaskButton from './notebook-task-button'
 import ViewModeToggleButton from './view-mode-toggle-button'
 import LastSavedText from './last-saved-text'
 import DeclaredVariablesPane from './declared-variables-pane'
 import HistoryPane from './history-pane'
+import AppInfoPane from './app-info-pane'
 
 import tasks from '../../task-definitions'
 
@@ -27,8 +29,15 @@ export default class ViewControls extends React.Component {
           <HistoryIcon />
         </NotebookTaskButton>
 
+        <NotebookTaskButton task={tasks.toggleAppInfoPane}>
+          <InfoIcon />
+        </NotebookTaskButton>
+
+
         <DeclaredVariablesPane />
         <HistoryPane />
+        <AppInfoPane />
+
         <ViewModeToggleButton />
 
       </div>

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -73,6 +73,10 @@ const stateSchema = {
     sidePaneMode: {}, // FIXME change to string ONLY
     externalDependencies: { type: 'array' },
     executionNumber: { type: 'integer', minimum: 0 },
+    appMessages: {
+      type: 'array',
+      items: { type: 'string' },
+    },
   },
   additionalProperties: false,
 }
@@ -174,6 +178,7 @@ function blankState() {
     history: [],
     externalDependencies: [],
     executionNumber: 0,
+    appMessages: [''],
   }
   return initialState
 }

--- a/src/task-definitions.js
+++ b/src/task-definitions.js
@@ -287,6 +287,22 @@ tasks.toggleHistoryPane = new UserTask({
   },
 })
 
+tasks.toggleAppInfoPane = new UserTask({
+  title: 'Toggle the Iodide Info Pane',
+  menuTitle: 'App Messages',
+  keybindings: ['ctrl+i', 'meta+i'],
+  displayKeybinding: `${commandKey()}+I`,
+  preventDefaultKeybinding: true,
+
+  callback() {
+    if (store.getState().sidePaneMode !== '_APP_INFO') {
+      dispatcher.changeSidePaneMode('_APP_INFO')
+    } else {
+      dispatcher.changeSidePaneMode()
+    }
+  },
+})
+
 tasks.setViewModeToEditor = new UserTask({
   title: 'Set View Mode to Editor',
   callback() {


### PR DESCRIPTION
@hamilton, this is a pretty light weight PR that adds a pane for making app info, warnings, and error messages recoverable after an alert.

In addition to the venerable #166 about app errors, i've realized that i need this making saving to gists sensible. it will also allow me to fix #448.

note that this is only part one of a full app error/warn/info solution; we'll also want the little snackbars that alert you when there are new messages, and that have a "more" link to pop the full info pane with the detailed message. but for saving anonymous gists, the alert is less important initially than the scrollback-- we need to be able to print out 
- the url of the gist
- as well as the sharable `iodide.html?gist=...` link,
and both in a location the user can get back to.

i think this is pretty simple, just followed your template. lmk if anything seems wrong.