### PR TITLE
lowered the transition time for menus

### DIFF
--- a/src/components/toolbar/icon-menu.jsx
+++ b/src/components/toolbar/icon-menu.jsx
@@ -44,6 +44,7 @@ export default class NotebookIconMenu extends React.Component {
             open={Boolean(anchorElement)}
             onClose={this.handleIconButtonClose}
             anchorReference="anchorPosition"
+            transitionDuration={70}
             anchorPosition={{ top: 50, left: 0 }}
           >
             {children}

--- a/src/components/toolbar/notebook-menu-subsection.jsx
+++ b/src/components/toolbar/notebook-menu-subsection.jsx
@@ -14,12 +14,16 @@ export default class NotebookMenuSubsection extends React.Component {
     this.handleClose = this.handleClose.bind(this)
   }
   handleClick(event) {
-    this.setState({ anchorElement: event.currentTarget })
+    if (this.state.anchorElement === null) {
+      this.setState({ anchorElement: event.currentTarget })
+    }
   }
 
-  handleClose() {
-    this.setState({ anchorElement: null })
-    if (this.props.onClick) this.props.onClick()
+  handleClose(tf) {
+    if (this.state.anchorElement !== null) {
+      this.setState({ anchorElement: null })
+    }
+    if (this.props.onClick && (tf !== undefined && tf)) this.props.onClick()
   }
   render() {
     const { anchorElement } = this.state
@@ -57,6 +61,7 @@ export default class NotebookMenuSubsection extends React.Component {
           anchorEl={this.state.anchorElement}
           open={Boolean(anchorElement)}
           onClose={this.handleClose}
+          transitionDuration={50}
           anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         >


### PR DESCRIPTION
As per one sub-issue in #475, fixes #486  - menus don't feel snappy because the transition time is just too high. I reduced the main menu to 70ms and the submenus to 50ms, down from whatever it was before (probably 200ms by default).

@bcolloran let me know if this feels better. I can also investigate removing the animation delay that happens on click.