### PR TITLE
Revert "Closed multiple windows on clicking outside menu"

### DIFF
--- a/src/components/toolbar/notebook-menu-subsection.jsx
+++ b/src/components/toolbar/notebook-menu-subsection.jsx
@@ -19,7 +19,6 @@ export default class NotebookMenuSubsection extends React.Component {
 
   handleClose() {
     this.setState({ anchorElement: null })
-    if (this.props.onClick) this.props.onClick()
   }
   render() {
     const { anchorElement } = this.state


### PR DESCRIPTION
regarding the behavior in #485-- if you want to switch menu subsections -- e.g., you first click on the "notebooks" heading, which opens that submenu, but you then wish to look in the "cells" submenu, clicking the "cells" heading does not open the cells submenu, it closes all the menus. so, to specify the behavior a little more:

- [ ] when a submenu is open, clicking outside the menus only closes the submenu; should close all menus. "clicking outside the menus" refers to clicks entirely outside of the menus and any submenus; clicking at menu higher in the heirarchy should only close menus lover in the heirarchy. clicking outside **all** menus should close all menus

i updated the original item and unchecked the box so that we can track it here.

i'm going to revert that PR; the current behavior is actually a bit less desirable than the previous behavior.