### PR TITLE
Fixes bugs in long menu

### DIFF
--- a/src/components/toolbar/notebook-menu-header.jsx
+++ b/src/components/toolbar/notebook-menu-header.jsx
@@ -4,5 +4,11 @@ import Subheader from 'material-ui/List/ListSubheader'
 
 export default class NotebookMenuHeader extends React.Component {
   static propTypes = { title: PropTypes.string, onClick: PropTypes.func }
-  render() { return <Subheader key={this.props.title}> {this.props.title} </Subheader> }
+  render() {
+    return (
+      <Subheader disableSticky={Boolean(true)} key={this.props.title}>
+        {this.props.title}
+      </Subheader>
+    )
+  }
 }

--- a/src/components/toolbar/notebook-menu-item.jsx
+++ b/src/components/toolbar/notebook-menu-item.jsx
@@ -33,7 +33,7 @@ export default class NotebookMenuItem extends React.Component {
           primary={this.props.task.menuTitle}
         />
         <ListItemText
-          style={{marginRight: 5}}
+          style={{ marginRight: 5 }}
           classes={{ root: 'secondary-menu-item' }}
           primary={this.props.task.displayKeybinding || this.props.task.secondaryText}
         />

--- a/src/components/toolbar/notebook-menu-item.jsx
+++ b/src/components/toolbar/notebook-menu-item.jsx
@@ -33,6 +33,7 @@ export default class NotebookMenuItem extends React.Component {
           primary={this.props.task.menuTitle}
         />
         <ListItemText
+          style={{marginRight: 5}}
           classes={{ root: 'secondary-menu-item' }}
           primary={this.props.task.displayKeybinding || this.props.task.secondaryText}
         />


### PR DESCRIPTION
Where the sub-menu becomes long (as the number of notebooks increases) two bugs were seen in general - 

![menu](https://user-images.githubusercontent.com/4402679/37492561-d115edec-28c7-11e8-80ce-edc61e217731.gif)

1. The headings are sticky and overlap on scrolling
2. The scrollbar blocks some of the text of `ListItemText` component

This PR fixes the above two bugs.