### PR TITLE
#508 Editor Mode On Blur Bug

### DIFF
--- a/src/components/toolbar/editor-mode-title.jsx
+++ b/src/components/toolbar/editor-mode-title.jsx
@@ -21,7 +21,7 @@ export class TitleUnconnected extends React.Component {
   }
 
   onBlur() {
-    if (this.props.pageMode === 'title-edit') tasks.changeMode('command')
+    if (this.props.pageMode === 'title-edit') tasks.changeMode.callback('command')
   }
 
   onFocus() {


### PR DESCRIPTION
When the title was changed and the user clicked out of that text area, a webpack error was thrown. 

We discovered that in the `editor-mode-title.jsx` component, line 24 caused the error, which stated that `tasks.changeMode` was not defined. `Tasks.changeMode` called an object instead of a function. 

Line 24 is now fixed with the addition of `.callback()` so that the object's method is called and subsequently executed. 

Solves #508

Authors: 
@PreciseSlice 
@michellehoffman 
@cbdallavalle