### PR TITLE
#497 solved clash of text with icon button

### DIFF
--- a/src/components/toolbar/last-saved-text.jsx
+++ b/src/components/toolbar/last-saved-text.jsx
@@ -12,6 +12,7 @@ export class LastSavedTextUnconnected extends React.Component {
     return (
       <Typography
         classes={{ root: 'last-saved-text' }}
+        style={{ marginRight: '10px' }}
       >
         {this.props.lastSaved === undefined ? ' ' : `saved ${prettyDate(this.props.lastSaved)}`}
       </Typography>)


### PR DESCRIPTION
On hover, the Declared Variables button had a border appear that overlapped with the "last saved" text. To fix this issue, we added a style attribute to the Typography component in last-saved-text.jsx and assigned it a right margin of 10px.

Before: 
<img width="331" alt="497-unsolved" src="https://user-images.githubusercontent.com/31316574/37684496-cf5a13a2-2c55-11e8-9930-2e7fce56781f.png">

After:
<img width="345" alt="497-solved" src="https://user-images.githubusercontent.com/31316574/37684521-e25f16be-2c55-11e8-8751-14732b423122.png">


Authors: 
@PreciseSlice 
@cbdallavalle 
@michellehoffman