### PR TITLE
eval migrated out of cell-reducer and into actions

### DIFF
--- a/src/reducers/cell-reducer-utils.js
+++ b/src/reducers/cell-reducer-utils.js
@@ -168,11 +168,15 @@ function newStateWithSelectedCellPropertySet(state, cellPropToSet, newValue) {
   return Object.assign({}, state, { cells })
 }
 
-function newStateWithSelectedCellPropsAssigned(state, cellPropsToSet) {
+function newStateWithPropsAssignedForCell(state, cellId, cellPropsToSet) {
   const cells = state.cells.slice()
-  const index = cells.findIndex(c => c.selected)
+  const index = cells.findIndex(c => c.id === cellId)
   cells[index] = Object.assign({}, cells[index], cellPropsToSet)
   return Object.assign({}, state, { cells })
+}
+
+function newStateWithSelectedCellPropsAssigned(state, cellPropsToSet) {
+  return newStateWithPropsAssignedForCell(state, getSelectedCellId(state), cellPropsToSet)
 }
 
 function newStateWithRowOverflowSet(state, cellId, rowType, viewModeToSet, rowOverflow) {
@@ -204,9 +208,11 @@ export {
   moveCell,
   scrollToCellIfNeeded,
   addExternalDependency,
+  getSelectedCell,
   getSelectedCellId,
   getCellBelowSelectedId,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,
   newStateWithRowOverflowSet,
+  newStateWithPropsAssignedForCell,
 }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -161,6 +161,22 @@ This will update them to jsmd.
       return Object.assign({}, state, { sidePaneMode: action.mode })
     }
 
+    case 'INCREMENT_EXECUTION_NUMBER': {
+      let { executionNumber } = state
+      executionNumber += 1
+      return Object.assign({}, state, { executionNumber })
+    }
+
+    case 'APPEND_TO_EVAL_HISTORY': {
+      const history = [...state.history]
+      history.push({
+        cellID: action.cellId,
+        lastRan: new Date(),
+        content: action.content,
+      })
+      return Object.assign({}, state, { history })
+    }
+
     case 'UPDATE_APP_MESSAGES': {
       const appMessages = state.appMessages.slice()
       appMessages.push(action.message)


### PR DESCRIPTION
this PR pulls cell evaluation out of the reducers and into the actions, which will open the path for evaling plugin definition cells like any other cell and having that eval action dispatch other actions that update the global store. i've tested this on a number of example notebooks and everything seems to be working ok, but um since evaling is the core of the whole shebang, probably worth doing some more  thorough QA :-)

(also i messed up and left in a bit of gist code previously, so the removal of that code is in this PR too)