### PR TITLE
#475 Added insert cell above to cell-menu-subsection.jsx

### DIFF
--- a/src/components/toolbar/cell-menu-subsection.jsx
+++ b/src/components/toolbar/cell-menu-subsection.jsx
@@ -14,6 +14,7 @@ export default class CellMenuSubsection extends React.Component {
         <NotebookMenuItem key={tasks.moveCellUp.title} task={tasks.moveCellUp} />
         <NotebookMenuItem key={tasks.moveCellDown.title} task={tasks.moveCellDown} />
         <NotebookMenuItem key={tasks.addCellBelow.title} task={tasks.addCellBelow} />
+        <NotebookMenuItem key={tasks.addCellAbove.title} task={tasks.addCellAbove} />
         <NotebookMenuItem key={tasks.deleteCell.title} task={tasks.deleteCell} />
         <NotebookMenuDivider />
         <NotebookMenuHeader title="change cell to ..." />


### PR DESCRIPTION
Issue #475 mentions this addition. 

A quick one-liner 🥇. 

I wanted to use this feature frequently when I was having some fun creating an example notebook tonight and it would have been helpful if it was in the menu, so now it is. 