### PR TITLE
CSS margin fix for presentation mode for :first-child

### DIFF
--- a/src/style/default-presentation.css
+++ b/src/style/default-presentation.css
@@ -32,18 +32,24 @@ div#cells.presentation div.cell-row-container {
 div#cells.presentation div.main-component {
   width: 100%;
 }
+ 
+ /* div#cells.presentation {
+  padding-top:30px;
+}  */
 
-#cells.presentation .user-markdown:first-child {
-  margin-top:30px;
-}
+#cells.presentation .cell-container:first-child {
+  padding-top:30px;
+} 
 
-#cells.presentation .user-markdown:last-child {
+ #cells.presentation .cell-container:last-child {
   margin-bottom:60px;
-}
+} 
 
 #cells.presentation .user-markdown {
   padding-bottom: 10px;
 }
+
+
 
 /* establish block-level elements to be a certain width. This
 lets us create full width divs using css if necessary, while still
@@ -239,6 +245,7 @@ div#cells.editor .user-markdown table {
 .user-markdown h1 {
   font-size: 36px;
   font-weight: 300;
+  margin-top:20px;
 }
 
 .user-markdown h2 {


### PR DESCRIPTION
I mis-selected the actual `:first-child`. This is a small fix that should patch things up for notebooks. @bcolloran I'm happy to just merge this if you don't think it is worth a review. It's a fairly minor css change.