### PR TITLE
Automatically deploy tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,27 @@ before_deploy:
   - cp prod/iodide.${TRAVIS_BRANCH}.html prod/index.html
 
 deploy:
-  provider: pages
-  github-token: "$GITHUB_TOKEN"
-  skip-cleanup: true
-  keep-history: false
-  repo: iodide-project/master
-  verbose: false
-  local-dir: prod
-  target-branch: master
-  on:
-    branch: master
+  - provider: pages
+    github-token: "$GITHUB_TOKEN"
+    skip-cleanup: true
+    keep-history: false
+    repo: iodide-project/master
+    verbose: false
+    local-dir: prod
+    target-branch: master
+    on:
+      branch: master
+
+  - provider: pages
+    github-token: "$GITHUB_TOKEN"
+    skip-cleanup: true
+    keep-history: true
+    repo: iodide-project/dist
+    verbose: true
+    local-dir: prod
+    target-branch: master
+    on:
+      tags: true
 
 env:
   global:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (env) => {
     if (git_rev.isTagDirty()) {
       APP_PATH_STRING = 'https://iodide-project.github.io/master/'
     } else {
-      APP_PATH_STRING = 'https://iodide-project.github.io/iodide/dist/'
+      APP_PATH_STRING = 'https://iodide-project.github.io/dist/'
     }
     CSS_PATH_STRING = APP_PATH_STRING
   } else if (env === 'dev') {


### PR DESCRIPTION
This will automatically deploy git tags to the `iodide-project/dist` repo.  

Thereby making a release should be as simple as:

1. Checking out the commit in question
2. `git tag vX.X`
3. `git push origin --tags`

It's not easily possible to deploy to the same place as the existing 0.2.2 release in `docs/dist`, and even if it were, I'm not sure it's a great idea to let the main development repo expand in size too quickly.  This approach keeps things separate and should transition fairly smoothly to a basic web server or CDN down the road (though still probably requires a URL change).

I'm pretty sure this is working, but we can't really test until it's on master.  We could make an "alpha" release and then delete it in order to test.