### PR TITLE
when using ?url= notebooks that were exported in presentation mode now evaluateAllCells

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -26,6 +26,13 @@ export function importNotebook(newState) {
   }
 }
 
+export function importFromURL(importedState) {
+  return (dispatch) => {
+    dispatch(importNotebook(importedState))
+    return Promise.resolve()
+  }
+}
+
 export function exportNotebook(exportAsReport = false) {
   return {
     type: 'EXPORT_NOTEBOOK',

--- a/src/tools/handle-url-query.js
+++ b/src/tools/handle-url-query.js
@@ -2,7 +2,8 @@ import queryString from 'query-string'
 
 import { stateFromJsmd } from './jsmd-tools'
 import { store } from '../store'
-import { importNotebook } from '../actions/actions'
+import { importFromURL } from '../actions/actions'
+import evaluateAllCells from '../actions/evaluate-all-cells'
 
 async function loadJsmdFromNotebookUrl(url) {
   try {
@@ -11,7 +12,9 @@ async function loadJsmdFromNotebookUrl(url) {
     const parser = new DOMParser()
     const doc = parser.parseFromString(notebookString, 'text/html');
     const jsmd = doc.querySelector('#jsmd').innerHTML
-    store.dispatch(importNotebook(stateFromJsmd(jsmd)))
+    store.dispatch(importFromURL(stateFromJsmd(jsmd))).then(() => {
+      if (store.getState().viewMode === 'presentation') { evaluateAllCells(store.getState().cells, store) }
+    })
   } catch (err) {
     console.log('failed to load notebook url', err);
   }


### PR DESCRIPTION
I've created a new action `importFromURL` which returns a promise so that once state is loaded and if `state.viewMode = 'presentation'`, it will run `evaluateAllCells`

![482](https://user-images.githubusercontent.com/17807743/38536023-69f066e2-3ca4-11e8-89ae-e9f4cd467853.gif)
