### PR TITLE
Skip during run all

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -424,11 +424,15 @@ export function changeSidePaneMode(mode) {
   }
 }
 
-export function setCellIncludeInRunAll(value) {
+export function setCellSkipInRunAll(value) {
   return (dispatch, getState) => {
+    let setValue = value
+    if (setValue === undefined) {
+      setValue = !getSelectedCell(getState()).skipInRunAll
+    }
     dispatch(updateCellProperties(
       getSelectedCell(getState()).id,
-      { includeInRunAll: value },
+      { skipInRunAll: setValue },
     ))
   }
 }

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -423,3 +423,12 @@ export function changeSidePaneMode(mode) {
     mode,
   }
 }
+
+export function setCellIncludeInRunAll(value) {
+  return (dispatch, getState) => {
+    dispatch(updateCellProperties(
+      getSelectedCell(getState()).id,
+      { includeInRunAll: value },
+    ))
+  }
+}

--- a/src/actions/evaluate-all-cells.js
+++ b/src/actions/evaluate-all-cells.js
@@ -2,19 +2,21 @@ import { evaluateCell } from './actions'
 
 export default function evaluateAllCells(cells, store) {
   cells.forEach((cell) => {
-    if (cell.cellType === 'css') {
+    if (cell.cellType === 'css' && !cell.skipInRunAll) {
       store.dispatch(evaluateCell(cell.id))
     }
   })
   cells.forEach((cell) => {
-    if (cell.cellType === 'markdown') {
+    if (cell.cellType === 'markdown' && !cell.skipInRunAll) {
       store.dispatch(evaluateCell(cell.id))
     }
   })
   window.setTimeout(
     () => {
       cells.forEach((cell) => {
-        if (cell.cellType !== 'markdown' && cell.cellType !== 'markdown') {
+        if (cell.cellType !== 'css'
+          && cell.cellType !== 'markdown'
+          && !cell.skipInRunAll) {
           store.dispatch(evaluateCell(cell.id))
         }
       })

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -198,20 +198,12 @@ tasks.changeToPluginCell = new UserTask({
   callback() { dispatcher.changeCellType('plugin') },
 })
 
-tasks.includeCellInRunAll = new UserTask({
-  title: 'Include Cell During Run All',
-  // keybindings: ['l'],
-  // displayKeybinding: 'L',
-  // keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.setCellIncludeInRunAll(true) },
-})
-
-tasks.skipCellInRunAll = new UserTask({
-  title: 'Skip Cell During Run All',
-  // keybindings: ['l'],
-  // displayKeybinding: 'L',
-  // keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.setCellIncludeInRunAll(false) },
+tasks.toggleSkipCellInRunAll = new UserTask({
+  title: 'Toggle Skipping Cell in Run All',
+  keybindings: ['s'],
+  displayKeybinding: 'S',
+  keybindingPrecondition: isCommandMode,
+  callback() { dispatcher.setCellSkipInRunAll() },
 })
 
 tasks.changeMode = new UserTask({

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -29,7 +29,7 @@ const commandKey = () => (OSName === 'MacOS' ? '⌘' : 'Ctrl')
 const tasks = {}
 
 tasks.evaluateCell = new UserTask({
-  title: 'Evaluate Cell',
+  title: 'Run Cell',
   keybindings: ['mod+enter'],
 
   callback() {
@@ -40,8 +40,8 @@ tasks.evaluateCell = new UserTask({
 })
 
 tasks.evaluateAllCells = new UserTask({
-  title: 'Evaluate All Cells',
-  menuTitle: 'Evaluate All Cells',
+  title: 'Run All Cells',
+  menuTitle: 'Run All Cells',
   callback() {
     dispatcher.saveNotebook(true)
     evaluateAllCells(getCells(), store)
@@ -196,6 +196,22 @@ tasks.changeToPluginCell = new UserTask({
   displayKeybinding: 'L',
   keybindingPrecondition: isCommandMode,
   callback() { dispatcher.changeCellType('plugin') },
+})
+
+tasks.includeCellInRunAll = new UserTask({
+  title: 'Include Cell During Run All',
+  // keybindings: ['l'],
+  // displayKeybinding: 'L',
+  // keybindingPrecondition: isCommandMode,
+  callback() { dispatcher.setCellIncludeInRunAll(true) },
+})
+
+tasks.skipCellInRunAll = new UserTask({
+  title: 'Skip Cell During Run All',
+  // keybindings: ['l'],
+  // displayKeybinding: 'L',
+  // keybindingPrecondition: isCommandMode,
+  callback() { dispatcher.setCellIncludeInRunAll(false) },
 })
 
 tasks.changeMode = new UserTask({

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
 import Tooltip from 'material-ui/Tooltip'
 import Menu from 'material-ui/Menu'
-// import LowPriority from 'material-ui-icons/LowPriority'
 
 import CellMenu from './cell-menu'
 
@@ -16,7 +15,7 @@ export class CellMenuContainerUnconnected extends React.Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
     cellId: PropTypes.number.isRequired,
-    includeInRunAll: PropTypes.bool.isRequired,
+    skipInRunAll: PropTypes.bool.isRequired,
   }
 
   constructor(props) {
@@ -38,9 +37,9 @@ export class CellMenuContainerUnconnected extends React.Component {
 
   render() {
     const { anchorElement } = this.state
-    const includeInRunAllIndicator = (
-      this.props.includeInRunAll ?
-        '' : (
+    const skipInRunAllIndicator = (
+      this.props.skipInRunAll ?
+        (
           <Tooltip
             classes={{ tooltip: 'iodide-tooltip' }}
             placement="bottom"
@@ -48,12 +47,12 @@ export class CellMenuContainerUnconnected extends React.Component {
             enterDelay={600}
           >
             {
-            // <LowPriority />
-            // <span>skipped</span>
               <div className="warning-pill">skip</div>
             }
           </Tooltip>
-        ))
+        ) :
+        ''
+    )
 
     return (
       <div className="cell-menu-container">
@@ -75,8 +74,6 @@ export class CellMenuContainerUnconnected extends React.Component {
               anchorEl={this.state.anchorElement}
               open={Boolean(anchorElement)}
               onClose={this.handleIconButtonClose}
-              // anchorReference="anchorPosition"
-              // anchorReference="anchorOrigin"
               anchorReference="anchorEl"
               transitionDuration={70}
               getContentAnchorEl={null}
@@ -87,7 +84,7 @@ export class CellMenuContainerUnconnected extends React.Component {
             </Menu>
           </div>
         </Tooltip>
-        <div className="cell-status-indicators">{includeInRunAllIndicator}</div>
+        <div className="cell-status-indicators">{skipInRunAllIndicator}</div>
       </div>
     )
   }
@@ -113,7 +110,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     label,
-    includeInRunAll: cell.includeInRunAll,
+    skipInRunAll: cell.skipInRunAll,
   }
 }
 

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -81,7 +81,7 @@ export class CellMenuContainerUnconnected extends React.Component {
               anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
               transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
-              <CellMenu cellId={this.props.cellId} menuLabel={this.props.label}/>
+              <CellMenu cellId={this.props.cellId} menuLabel={this.props.label} />
             </Menu>
           </div>
         </Tooltip>

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -15,6 +15,8 @@ import { getCellById } from '../../tools/notebook-utils'
 export class CellMenuContainerUnconnected extends React.Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
+    cellId: PropTypes.number.isRequired,
+    includeInRunAll: PropTypes.bool.isRequired,
   }
 
   constructor(props) {

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux'
 import PropTypes from 'prop-types'
 import Tooltip from 'material-ui/Tooltip'
 import Menu from 'material-ui/Menu'
+// import LowPriority from 'material-ui-icons/LowPriority'
 
 import CellMenu from './cell-menu'
 
@@ -35,6 +36,23 @@ export class CellMenuContainerUnconnected extends React.Component {
 
   render() {
     const { anchorElement } = this.state
+    const includeInRunAllIndicator = (
+      this.props.includeInRunAll ?
+        '' : (
+          <Tooltip
+            classes={{ tooltip: 'iodide-tooltip' }}
+            placement="bottom"
+            title="Cell skipped during run all"
+            enterDelay={600}
+          >
+            {
+            // <LowPriority />
+            // <span>skipped</span>
+              <div className="warning-pill">skip</div>
+            }
+          </Tooltip>
+        ))
+
     return (
       <div className="cell-menu-container">
         <Tooltip
@@ -45,28 +63,29 @@ export class CellMenuContainerUnconnected extends React.Component {
         >
           <div
             className="cell-type-label"
-            aria-label="more"
             aria-owns={anchorElement ? 'cell-menu' : null}
             aria-haspopup="true"
             onClick={this.handleClick}
           >
             {this.props.label}
             <Menu
-              dense={false}
               id="cell-menu"
               anchorEl={this.state.anchorElement}
               open={Boolean(anchorElement)}
               onClose={this.handleIconButtonClose}
               // anchorReference="anchorPosition"
-              anchorReference="anchorOrigin"
+              // anchorReference="anchorOrigin"
+              anchorReference="anchorEl"
               transitionDuration={70}
-              anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
-              // anchorPosition={{ top: 50, left: 0 }}
+              getContentAnchorEl={null}
+              anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
-              <CellMenu />
+              <CellMenu cellId={this.props.cellId} />
             </Menu>
           </div>
         </Tooltip>
+        <div className="cell-status-indicators">{includeInRunAllIndicator}</div>
       </div>
     )
   }
@@ -92,6 +111,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     label,
+    includeInRunAll: cell.includeInRunAll,
   }
 }
 

--- a/src/components/cells/cell-menu.jsx
+++ b/src/components/cells/cell-menu.jsx
@@ -1,12 +1,18 @@
 import React from 'react'
-// import Paper from 'material-ui/Paper'
+import { connect } from 'react-redux'
 import NotebookMenuItem from '../menu/notebook-menu-item'
-// import NotebookMenuDivider from '../menu/notebook-menu-divider'
+import NotebookMenuDivider from '../menu/notebook-menu-divider'
 
+import { getCellById } from '../../tools/notebook-utils'
 import tasks from '../../actions/task-definitions'
 
-export default class CellMenu extends React.Component {
+export class CellMenuUnconnected extends React.Component {
   render() {
+    const toggleRunAllTask = (
+      this.props.includeInRunAll ?
+        tasks.skipCellInRunAll :
+        tasks.includeCellInRunAll
+    )
     return (
       <div className="cell-menu-items-container">
         <NotebookMenuItem
@@ -33,7 +39,23 @@ export default class CellMenu extends React.Component {
           key={tasks.changeToPluginCell.title}
           task={tasks.changeToPluginCell}
         />
+
+        <NotebookMenuDivider />
+        <NotebookMenuItem
+          key={toggleRunAllTask.title}
+          task={toggleRunAllTask}
+        />
       </div>
     )
   }
 }
+
+
+function mapStateToProps(state, ownProps) {
+  const { cellId } = ownProps
+  const { includeInRunAll } = getCellById(state.cells, cellId)
+  console.log({ includeInRunAll })
+  return { includeInRunAll }
+}
+
+export default connect(mapStateToProps)(CellMenuUnconnected)

--- a/src/components/cells/cell-menu.jsx
+++ b/src/components/cells/cell-menu.jsx
@@ -1,12 +1,19 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+
 import NotebookMenuItem from '../menu/notebook-menu-item'
 import NotebookMenuDivider from '../menu/notebook-menu-divider'
-
 import { getCellById } from '../../tools/notebook-utils'
 import tasks from '../../actions/task-definitions'
 
 export class CellMenuUnconnected extends React.Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    cellId: PropTypes.number.isRequired,
+    includeInRunAll: PropTypes.bool.isRequired,
+  }
+
   render() {
     const toggleRunAllTask = (
       this.props.includeInRunAll ?

--- a/src/components/cells/cell-menu.jsx
+++ b/src/components/cells/cell-menu.jsx
@@ -9,17 +9,12 @@ import tasks from '../../actions/task-definitions'
 
 export class CellMenuUnconnected extends React.Component {
   static propTypes = {
-    label: PropTypes.string.isRequired,
+    menuLabel: PropTypes.string.isRequired,
     cellId: PropTypes.number.isRequired,
-    includeInRunAll: PropTypes.bool.isRequired,
+    skipInRunAll: PropTypes.bool.isRequired,
   }
 
   render() {
-    const toggleRunAllTask = (
-      this.props.includeInRunAll ?
-        tasks.skipCellInRunAll :
-        tasks.includeCellInRunAll
-    )
     return (
       <div className="cell-menu-items-container">
         <NotebookMenuItem
@@ -55,8 +50,8 @@ export class CellMenuUnconnected extends React.Component {
 
         <NotebookMenuDivider />
         <NotebookMenuItem
-          key={toggleRunAllTask.title}
-          task={toggleRunAllTask}
+          key={tasks.toggleSkipCellInRunAll.title}
+          task={tasks.toggleSkipCellInRunAll}
         />
       </div>
     )
@@ -66,8 +61,8 @@ export class CellMenuUnconnected extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { cellId } = ownProps
-  const { includeInRunAll } = getCellById(state.cells, cellId)
-  return { includeInRunAll }
+  const { skipInRunAll } = getCellById(state.cells, cellId)
+  return { skipInRunAll }
 }
 
 export default connect(mapStateToProps)(CellMenuUnconnected)

--- a/src/components/cells/cell-menu.jsx
+++ b/src/components/cells/cell-menu.jsx
@@ -60,7 +60,6 @@ export class CellMenuUnconnected extends React.Component {
 function mapStateToProps(state, ownProps) {
   const { cellId } = ownProps
   const { includeInRunAll } = getCellById(state.cells, cellId)
-  console.log({ includeInRunAll })
   return { includeInRunAll }
 }
 

--- a/src/components/menu/notebook-menu-divider.jsx
+++ b/src/components/menu/notebook-menu-divider.jsx
@@ -2,5 +2,7 @@ import React from 'react'
 import Divider from 'material-ui/Divider'
 
 export default class NotebookMenuDivider extends React.Component {
-  render() { return <Divider /> }
+  render() {
+    return (<Divider className="iodide-menu-divider" />)
+  }
 }

--- a/src/components/menu/notebook-menu-item.jsx
+++ b/src/components/menu/notebook-menu-item.jsx
@@ -16,10 +16,21 @@ export default class NotebookMenuItem extends React.Component {
     ]),
   }
   static muiName = 'MenuItem'
+
+  constructor(props) {
+    super(props)
+    this.extraMenuProps = {}
+    Object.keys(this.props).forEach((k) => {
+      if (!['task', 'submenuOnClick', 'onClick'].includes(k)) {
+        this.extraMenuProps[k] = this.props[k]
+      }
+    })
+  }
+
   render() {
     return (
       <MenuItem
-        {...this.props}
+        {...this.extraMenuProps}
         classes={{ root: 'iodide-menu-item' }}
         key={this.props.task.title}
         onClick={() => {

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -44,6 +44,7 @@ const cellSchema = {
     evalStatus: {}, // FIXME change to string ONLY
     rowSettings: { type: 'object' },
     language: { type: 'string' }, // '' in case not a code cell
+    includeInRunAll: { type: 'boolean' },
   },
   additionalProperties: false,
 }
@@ -177,6 +178,7 @@ function newCell(cellId, cellType, language = 'js') {
     executionStatus: ' ',
     evalStatus: undefined,
     rowSettings: newCellRowSettings(cellType),
+    includeInRunAll: true,
     language, // default language is js, but it only matters the cell is a code cell
   }
 }

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -44,7 +44,7 @@ const cellSchema = {
     evalStatus: {}, // FIXME change to string ONLY
     rowSettings: { type: 'object' },
     language: { type: 'string' }, // '' in case not a code cell
-    includeInRunAll: { type: 'boolean' },
+    skipInRunAll: { type: 'boolean' },
   },
   additionalProperties: false,
 }
@@ -178,7 +178,7 @@ function newCell(cellId, cellType, language = 'js') {
     executionStatus: ' ',
     evalStatus: undefined,
     rowSettings: newCellRowSettings(cellType),
-    includeInRunAll: true,
+    skipInRunAll: false,
     language, // default language is js, but it only matters the cell is a code cell
   }
 }

--- a/src/style/cell-styles.css
+++ b/src/style/cell-styles.css
@@ -45,6 +45,7 @@ div#cells.presentation div.cell-row.input {
 
 .cell-menu-container {
     width: 64px;
+    font-size:12px;
 }
 
 .cell-type-label {
@@ -52,11 +53,10 @@ div#cells.presentation div.cell-row.input {
   color: hsl(275, 12%, 75%);
   cursor: pointer;
   padding: 0px 6px 0px 0px;
-  font-size:12px;
-  height:28px;
+  height: 18px;
   border: 1px solid rgba(0,0,0,0);
-  display:flex;
-  align-items:center;
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
 }
 .cell-type-label:hover {
@@ -64,6 +64,32 @@ div#cells.presentation div.cell-row.input {
   border: 1px solid #ddd;
   color: hsl(275, 4%, 40%);
 }
+
+.cell-status-indicators {
+    text-align: right;
+    padding-right: 6px;
+    color: hsla(275, 4%, 51%, 1);
+}
+
+.warning-pill {
+    background-color: hsla(53, 80%, 86%, 1);
+    color: hsl(53, 35%, 48%);
+    height: 18px;
+    padding: 0 6px;
+    border: 1px solid hsla(53, 94%, 83%, 1);
+    border-radius: 3px;
+    display: inline-block;
+}
+
+.cell-status-icons {
+    text-align: right;
+    padding: 0px 6px 0px 0px;
+}
+
+.cell-status-icons svg {
+    fill: hsl(275, 12%, 75%);
+}
+
 
 div.cell-row-container {
   width: calc(100% - 64px); /* 100% minus cell-menu-contatiner width*/

--- a/src/style/menu-styles.css
+++ b/src/style/menu-styles.css
@@ -13,6 +13,11 @@
     padding-bottom: 5px !important;
 }
 
+.iodide-menu-divider {
+    margin-top: 6px !important;
+    margin-bottom: 6px !important;
+}
+
 .secondary-menu-item {
   text-align:right;
   padding:0px !important;

--- a/src/tools/__tests__/jsmd-tools_parse.test.js
+++ b/src/tools/__tests__/jsmd-tools_parse.test.js
@@ -154,14 +154,11 @@ foo
 %% badcelltype {"rowSettings.REPORT.input":"SCROLL_carrots"}
 foo
 `
-describe('jsmd parser test case 5', () => {
+describe('jsmd parser test case 5, error parsing and bad cell type conversion', () => {
   const jsmdParsed = parseJsmd(jsmdTestCase)
   const state = stateFromJsmd(jsmdTestCase)
   const { cells } = state
   const { parseWarnings } = jsmdParsed
-  it('should have 3 cells (%% meta is not converted to a cell)', () => {
-    expect(cells.length).toEqual(3)
-  })
   it('should have 3 parse warnings', () => {
     expect(parseWarnings.length).toEqual(3)
   })
@@ -180,12 +177,11 @@ describe('jsmd parser test case 5', () => {
 })
 
 
-// test bad meta parsing and creation of default JS cell
 jsmdTestCase = `
 %% meta
 invalid_json_content for meta setings
 `
-describe('jsmd parser test case 6', () => {
+describe('jsmd parser test case 6, bad meta parsing and creation of default JS cell', () => {
   const jsmdParsed = parseJsmd(jsmdTestCase)
   const state = stateFromJsmd(jsmdTestCase)
   const { cells } = state
@@ -208,14 +204,16 @@ describe('jsmd parser test case 6', () => {
 jsmdTestCase = `
 %% js {"rowSettings.REPORT.input": "VALUE_1", "rowSettings.REPORT.output":"VALUE_2"}
 test cell
+%% js {"rowSettings.REPORT.input": "VALUE_1","skipInRunAll":true}
+test cell
 `
-describe('jsmd parser test case 7, multiple cell settings', () => {
+describe('jsmd parser test case 7, cell settings', () => {
   const jsmdParsed = parseJsmd(jsmdTestCase)
   const state = stateFromJsmd(jsmdTestCase)
   const { cells } = state
   const { parseWarnings } = jsmdParsed
-  it('should have 1 cells', () => {
-    expect(cells.length).toEqual(1)
+  it('should have 2 cells', () => {
+    expect(cells.length).toEqual(2)
   })
   it('should have 0 parse warnings', () => {
     expect(parseWarnings.length).toEqual(0)
@@ -225,6 +223,9 @@ describe('jsmd parser test case 7, multiple cell settings', () => {
   })
   it('cell 0 should have "rowSettings.REPORT.output"=="VALUE_2"', () => {
     expect(cells[0].rowSettings.REPORT.output).toEqual('VALUE_2')
+  })
+  it('cell 1 should have "skipInRunAll"===true', () => {
+    expect(cells[1].skipInRunAll).toEqual(true)
   })
   it('all cells should have content=="test cell"', () => {
     expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['test cell']))

--- a/src/tools/__tests__/jsmd-tools_serialize.test.js
+++ b/src/tools/__tests__/jsmd-tools_serialize.test.js
@@ -44,7 +44,7 @@ foo`
 })
 
 
-describe('jsmd stringifier test case 3', () => {
+describe('jsmd stringifier test case 3, non-default cell settings 1', () => {
   let state = newNotebook()
   state.title = 'foo notebook'
   state.viewMode = 'presentation'
@@ -74,12 +74,13 @@ foo`
 })
 
 
-describe('jsmd stringifier test case 4', () => {
+describe('jsmd stringifier test case 4, non-default cell settings 2', () => {
   let state = newNotebook()
   state.title = 'foo notebook'
 
   state.cells[0].content = 'foo'
   _.set(state, 'cells[0].rowSettings.REPORT.output', 'VISIBLE')
+  _.set(state, 'cells[0].skipInRunAll', true)
 
   const cellTypes = ['markdown', 'external dependencies', 'raw']
   cellTypes.forEach((cellType, i) => {
@@ -94,7 +95,7 @@ describe('jsmd stringifier test case 4', () => {
   "lastExport": "${lastExport}"
 }
 
-%% js {"rowSettings.REPORT.output":"VISIBLE"}
+%% js {"rowSettings.REPORT.output":"VISIBLE","skipInRunAll":true}
 foo
 
 %% md

--- a/src/tools/jsmd-tools.js
+++ b/src/tools/jsmd-tools.js
@@ -39,6 +39,7 @@ const jsmdValidCellSettingPaths = [
   'language',
   'rowSettings.REPORT.input',
   'rowSettings.REPORT.output',
+  'skipInRunAll',
 ]
 
 function getNonDefaultValuesForPaths(paths, target, template) {


### PR DESCRIPTION
@hamilton, this implements the UI and state bits for the skipping cells during run-all, so you should be able to plug this into the stuff you're doing, it should just be a simple check to see if the cell to be evaled has `includeInRunAll === true`

regarding the UI: i tried a number of options to indicate that a cell will be skipped during run all (a couple icons, plain grey text (italics and not), and a couple variants of the little bootstrap warning-ish pill that i ended up settling on. icons looked awkard and confusing, and this seemed to provide the best and clearest visual warning that _hey there is something weird going on with this cell that you need to be aware of_ without being too distracting and cluttery. (little icons were actually worse).

in the process, i also remember why i'd set the hover box height of the cell-label to 18px-- that matches the height of the collapsed cell rows. i needed to recover a bit of that space for the "skip" label, so i set it back to that. i think this is probably ok -- i was with you on wanting to make the cell label the same height as an empty editor, but i think that it will typically be the case that editors don't remain empty for long, and the shorter button has better visual balance with the collapse states and the `skip` warning

i punted on a kbd shortcut for for toggling skip state. this action may not need it. i haven't yet implemented "skip all cells above", but i'd imagine an action like that will be how this functionality is normally accessed.

once this is merged, i'll be ready to get started on freezing state :tada: