### PR TITLE
decomposed all the handlers into individual files

### DIFF
--- a/src/components/reps/__tests__/array-handler.test.js
+++ b/src/components/reps/__tests__/array-handler.test.js
@@ -1,0 +1,18 @@
+import arrayHandler from '../array-handler'
+
+describe('dateHandler shouldHandle', () => {
+  it('rejects non-scalar values', () => {
+    expect(arrayHandler.shouldHandle(undefined)).toBe(false)
+    expect(arrayHandler.shouldHandle({})).toBe(false)
+    expect(arrayHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(arrayHandler.shouldHandle('string')).toBe(false)
+    expect(arrayHandler.shouldHandle(4000)).toBe(false)
+  })
+  it('accepts array objects', () => {
+    expect(arrayHandler.shouldHandle([])).toBe(true)
+    expect(arrayHandler.shouldHandle(new Array(10000))).toBe(true)
+    expect(arrayHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(true)
+    // TODO - make this pass.
+    // expect(arrayHandler.shouldHandle(new Float64Array(100000))).toBe(true)
+  })
+})

--- a/src/components/reps/__tests__/dataframe-handler.test.js
+++ b/src/components/reps/__tests__/dataframe-handler.test.js
@@ -1,0 +1,53 @@
+import dataframeHandler from '../dataframe-handler'
+
+describe('dateHandler shouldHandle', () => {
+  it('rejects non-scalar values', () => {
+    expect(dataframeHandler.shouldHandle(undefined)).toBe(false)
+    expect(dataframeHandler.shouldHandle({})).toBe(false)
+    expect(dataframeHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(dataframeHandler.shouldHandle('string')).toBe(false)
+    expect(dataframeHandler.shouldHandle(4000)).toBe(false)
+    expect(dataframeHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(false)
+  })
+  it('accepts array objects of same size and key composition', () => {
+    expect(dataframeHandler.shouldHandle([{ a: 10, b: 20 }])).toBe(true)
+    expect(dataframeHandler.shouldHandle([
+      {
+        a: 10, b: 'a', c: new Date(), e: [], f: undefined, g: null,
+      },
+      {
+        a: 20, b: 'b', c: new Date(), e: [], f: undefined, g: null,
+      },
+    ])).toBe(true)
+  })
+  it('accepts arrays of objects of same key composition but differing data types', () => {
+    expect(dataframeHandler.shouldHandle([
+      {
+        a: 10, b: 'a', c: new Date(), e: [], f: undefined, g: null,
+      },
+      {
+        a: '20', b: 4, c: +(new Date()), e: {}, f: undefined, g: null,
+      },
+    ])).toBe(true)
+  })
+  it('rejects heterogeneous arrays of objects of differing keys', () => {
+    expect(dataframeHandler.shouldHandle([
+      {
+        a: 10, b: 'a', c: new Date(), e: [], f: undefined, g: null,
+      },
+      {
+        a: '20', b: 4, c: +(new Date()), e: {}, f: undefined, h: null,
+      },
+    ])).toBe(false)
+  })
+  it('rejects heterogeneous arrays of objects of differing sizes', () => {
+    expect(dataframeHandler.shouldHandle([
+      {
+        a: 10, b: 'a', c: new Date(), e: [], f: undefined, g: null,
+      },
+      {
+        a: '20', b: 4, c: +(new Date()), e: {},
+      },
+    ])).toBe(false)
+  })
+})

--- a/src/components/reps/__tests__/date-handler.test.js
+++ b/src/components/reps/__tests__/date-handler.test.js
@@ -1,0 +1,18 @@
+import dateHandler from '../date-handler'
+
+describe('dateHandler shouldHandle', () => {
+  it('rejects non-scalar values', () => {
+    expect(dateHandler.shouldHandle(undefined)).toBe(false)
+    expect(dateHandler.shouldHandle([])).toBe(false)
+    expect(dateHandler.shouldHandle({})).toBe(false)
+    expect(dateHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(dateHandler.shouldHandle('string')).toBe(false)
+    expect(dateHandler.shouldHandle(4000)).toBe(false)
+    expect(dateHandler.shouldHandle('2010-01-01')).toBe(false)
+  })
+  it('accepts Date objects', () => {
+    expect(dateHandler.shouldHandle(new Date())).toBe(true)
+    expect(dateHandler.shouldHandle(new Date('2020-04-04'))).toBe(true)
+    expect(dateHandler.shouldHandle(new Date('invalid date string'))).toBe(true)
+  })
+})

--- a/src/components/reps/__tests__/matrix-handler.test.js
+++ b/src/components/reps/__tests__/matrix-handler.test.js
@@ -1,0 +1,23 @@
+import matrixHandler from '../matrix-handler'
+
+describe('dateHandler shouldHandle', () => {
+  it('rejects non-matrix values', () => {
+    expect(matrixHandler.shouldHandle(undefined)).toBe(false)
+    expect(matrixHandler.shouldHandle([])).toBe(false)
+    expect(matrixHandler.shouldHandle({})).toBe(false)
+    expect(matrixHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(matrixHandler.shouldHandle('string')).toBe(false)
+    expect(matrixHandler.shouldHandle(4000)).toBe(false)
+    expect(matrixHandler.shouldHandle('2010-01-01')).toBe(false)
+  })
+  it('accepts arrays of arrays of same length', () => {
+    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 2, 1, 2]])).toBe(true)
+    // this should be true
+    expect(matrixHandler.shouldHandle([[1], [3]])).toBe(true)
+  })
+  it('accepts arrays of arrays of differing length', () => {
+    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 1, 2]])).toBe(true)
+    // this should be true
+    expect(matrixHandler.shouldHandle([[1], []])).toBe(true)
+  })
+})

--- a/src/components/reps/__tests__/null-handler.test.js
+++ b/src/components/reps/__tests__/null-handler.test.js
@@ -1,0 +1,17 @@
+import nullHandler from '../null-handler'
+
+describe('nullHandler shouldHandle', () => {
+  it('rejects non-null values', () => {
+    expect(nullHandler.shouldHandle('hello')).toBe(false)
+    expect(nullHandler.shouldHandle('')).toBe(false)
+    expect(nullHandler.shouldHandle(undefined)).toBe(false)
+    expect(nullHandler.shouldHandle(new Date())).toBe(false)
+    expect(nullHandler.shouldHandle([])).toBe(false)
+    expect(nullHandler.shouldHandle({})).toBe(false)
+    expect(nullHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(nullHandler.shouldHandle('null')).toBe(false)
+  })
+  it('accepts null values', () => {
+    expect(nullHandler.shouldHandle(null)).toBe(true)
+  })
+})

--- a/src/components/reps/__tests__/scalar-handler.test.js
+++ b/src/components/reps/__tests__/scalar-handler.test.js
@@ -1,0 +1,18 @@
+import scalarHandler from '../scalar-handler'
+
+describe('scalarHandler shouldHandle', () => {
+  it('rejects non-scalar values', () => {
+    expect(scalarHandler.shouldHandle(undefined)).toBe(false)
+    expect(scalarHandler.shouldHandle(new Date())).toBe(false)
+    expect(scalarHandler.shouldHandle([])).toBe(false)
+    expect(scalarHandler.shouldHandle({})).toBe(false)
+    expect(scalarHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+  })
+  it('accepts scalar values', () => {
+    expect(scalarHandler.shouldHandle(1)).toBe(true)
+    expect(scalarHandler.shouldHandle(Infinity)).toBe(true)
+    expect(scalarHandler.shouldHandle(NaN)).toBe(true)
+    expect(scalarHandler.shouldHandle('string')).toBe(true)
+    expect(scalarHandler.shouldHandle('')).toBe(true)
+  })
+})

--- a/src/components/reps/__tests__/undefined-handler.test.js
+++ b/src/components/reps/__tests__/undefined-handler.test.js
@@ -1,0 +1,16 @@
+import undefinedHandler from '../undefined-handler'
+
+describe('nullHandler shouldHandle', () => {
+  it('rejects non-undefined values', () => {
+    expect(undefinedHandler.shouldHandle('hello')).toBe(false)
+    expect(undefinedHandler.shouldHandle('')).toBe(false)
+    expect(undefinedHandler.shouldHandle(new Date())).toBe(false)
+    expect(undefinedHandler.shouldHandle([])).toBe(false)
+    expect(undefinedHandler.shouldHandle({})).toBe(false)
+    expect(undefinedHandler.shouldHandle(new Promise(() => {}))).toBe(false)
+    expect(undefinedHandler.shouldHandle(null)).toBe(false)
+  })
+  it('accepts undefined values', () => {
+    expect(undefinedHandler.shouldHandle(undefined)).toBe(true)
+  })
+})

--- a/src/components/reps/array-handler.jsx
+++ b/src/components/reps/array-handler.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import _ from 'lodash'
+import { renderValue } from './value-renderer'
+
+export default {
+  shouldHandle: (value, inContainer) => !inContainer && _.isArray(value),
+
+  render: (value) => {
+    const dataSetInfo = `${value.length} element array`
+    const len = value.length
+    let arrayElements
+    if (len > 0) {
+      arrayElements = _.range(len > 200 ? 100 : len - 1).map(i => (
+        <span key={`array_elt_${i}`} title={`array index: ${i}`}>
+          {renderValue(value[i], true)}{', '}
+        </span>
+      ))
+      if (len > 200) {
+        arrayElements.push(<span key="array_elts omitted">…, </span>)
+        arrayElements = arrayElements
+          .concat(_.range(len - 100, len - 1)
+            .map(i => (
+              <span key={`array_elt_${i}`} title={`array index: ${i}`}>
+                {renderValue(value[i], true)}{', '}
+              </span>
+            )))
+      }
+      // final element has no trailing comma
+      arrayElements.push((
+        <span key={`array_elt_${len - 1}`} title={`array index: ${len - 1}`}>
+          {renderValue(value[len - 1], true)}
+        </span>
+      ))
+    } else {
+      arrayElements = (
+        <span key="array_elt_empty" title="array index: none">
+          {renderValue('', true)}
+        </span>
+      )
+    }
+    return (
+      <div>
+        <div className="data-set-info">{dataSetInfo}</div>
+        <div>
+            [{arrayElements}]
+        </div>
+      </div>
+    )
+  },
+}

--- a/src/components/reps/dataframe-handler.jsx
+++ b/src/components/reps/dataframe-handler.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import ReactTable from 'react-table'
+
+import { renderValue } from './value-renderer'
+import nb from '../../tools/nb'
+
+export default {
+  shouldHandle: (value, inContainer) => !inContainer && nb.isRowDf(value),
+
+  render: (value) => {
+    const columns = Object.keys(value[0])
+      .map(k => ({
+        Header: k,
+        accessor: k,
+        Cell: cell => renderValue(cell.value, true),
+      }))
+    const dataSetInfo = `array of objects: ${value.length} rows, ${columns.length} columns`
+    const pageSize = value.length > 10 ? 10 : value.length
+    return (
+      <div>
+        <div className="data-set-info">{dataSetInfo}</div>
+        <ReactTable
+          data={value}
+          columns={columns}
+          showPaginationTop
+          showPaginationBottom={false}
+          pageSizeOptions={[5, 10, 25, 50, 100]}
+          minRows={0}
+          defaultPageSize={pageSize}
+        />
+      </div>
+    )
+  },
+}

--- a/src/components/reps/date-handler.jsx
+++ b/src/components/reps/date-handler.jsx
@@ -1,0 +1,4 @@
+export default {
+  shouldHandle: value => Object.prototype.toString.call(value) === '[object Date]',
+  render: value => value.toString(),
+}

--- a/src/components/reps/matrix-handler.jsx
+++ b/src/components/reps/matrix-handler.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { SimpleTable, makeMatrixText } from './pretty-matrix'
+import nb from '../../tools/nb'
+
+export default {
+  shouldHandle: (value, inContainer) => !inContainer && nb.isMatrix(value),
+
+  render: (value) => {
+    const shape = nb.shape(value)
+    const dataSetInfo = `${shape[0]} × ${shape[1]} matrix (array of arrays)`
+    const tabledata = makeMatrixText(value, [10, 10])
+    return (
+      <div>
+        <div className="data-set-info">{dataSetInfo}</div>
+        <SimpleTable tabledata={tabledata} />
+      </div>
+    )
+  },
+}

--- a/src/components/reps/null-handler.jsx
+++ b/src/components/reps/null-handler.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default {
+  shouldHandle: value => (value === null),
+
+  render: () => <pre>null</pre>,
+}

--- a/src/components/reps/scalar-handler.jsx
+++ b/src/components/reps/scalar-handler.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const scalarHandler = {
+  scalarTypes: {
+    string: true,
+    number: true,
+  },
+
+  shouldHandle: value => (typeof (value) in scalarHandler.scalarTypes),
+
+  render: value =>
+  // TODO: This probably needs a new CSS class
+    <span className="array-output">{value}</span>,
+
+}
+
+export default scalarHandler

--- a/src/components/reps/undefined-handler.jsx
+++ b/src/components/reps/undefined-handler.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
 export default {
-  shouldHandle: value => (value === undefined),
+  shouldHandle: value => value === undefined,
   render: () => <pre>undefined</pre>,
 }

--- a/src/components/reps/undefined-handler.jsx
+++ b/src/components/reps/undefined-handler.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export default {
+  shouldHandle: value => (value === undefined),
+  render: () => <pre>undefined</pre>,
+}


### PR DESCRIPTION
This closes #276 by separating out all the different handlers in `value-renderer.jsx` into their own files.

A few questions:

- is 'handler' the term we want to go with here, or 'rep'?
- ~~should I add some basic tests to each one of these to determine if `shouldHandle` catches correctly?~~ (this one mostly done now)