### PR TITLE
history item styling fixes

### DIFF
--- a/src/components/menu/icon-menu.jsx
+++ b/src/components/menu/icon-menu.jsx
@@ -15,6 +15,7 @@ export default class NotebookIconMenu extends React.Component {
     this.handleClick = this.handleClick.bind(this)
     this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
   }
+
   handleClick(event) {
     this.setState({ anchorElement: event.currentTarget })
   }

--- a/src/components/panes/history-item.jsx
+++ b/src/components/panes/history-item.jsx
@@ -32,7 +32,7 @@ export default class HistoryItem extends React.Component {
         className={`cell-container ${this.props.display ? '' : 'hidden-cell'}`}
       >
         <div className="cell history-cell">
-          <div className="history-content">{mainElem}</div>
+          <div className="history-content editor">{mainElem}</div>
           <div className="history-date">{this.props.cell.lastRan.toUTCString()}</div>
         </div>
         <div className="cell-controls" />

--- a/src/style/side-panes.css
+++ b/src/style/side-panes.css
@@ -39,18 +39,28 @@ div.history-cells {
   padding-right: 20px;
 }
 
+div.history-cell {
+  width: inherit
+}
+
 div.history-cells .CodeMirror {
   height: auto;
 }
 
+div.history-cells div.cell-container {
+  padding-right:0px;
+}
+
 pre.history-item-code {
-  overflow:scroll;
+  overflow: scroll;
   padding:3px;
 }
 
-div.history-content {
-  outline: 1px solid lightgray;
 
+
+div.history-content {
+  outline: 1px solid #f1f1f1;
+  width: calc(100% - 1px)
 }
 
 div.history-date {


### PR DESCRIPTION
This PR addresses #583 -

- the history item width has been fixed and scales to the size of the parent container
- the outline now matches the unselected cell editor