### PR TITLE
Iodide print dom direct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -371,7 +371,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -4723,7 +4723,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -4772,7 +4772,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -5022,7 +5022,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "hpack.js": {
@@ -5857,7 +5857,7 @@
     "istanbul-lib-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -7765,7 +7765,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -8104,7 +8104,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -8448,7 +8448,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -9833,7 +9833,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
       }
@@ -10003,7 +10003,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -10317,7 +10317,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -10742,7 +10742,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "sanctuary-type-classes": {
@@ -10795,7 +10795,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "schema-utils": {
@@ -11538,7 +11538,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -11747,7 +11747,7 @@
     "test-exclude": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-      "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -168,6 +168,9 @@ function evaluateCodeCell(cell) {
     const code = cell.content
     const languageModule = state.languages[cell.language].module
     const { evaluator } = state.languages[cell.language]
+    // this is one place where we have to directly mutate the DOM b/c we need
+    // this to happen outside of React's update schedule. see also iodide-api/print.js
+    document.getElementById(`cell-${cell.id}-side-effect-target`).innerHTML = ''
     dispatch(temporarilySaveRunningCellID(cell.id))
     try {
       output = window[languageModule][evaluator](code)

--- a/src/components/cells/code-cell.jsx
+++ b/src/components/cells/code-cell.jsx
@@ -20,7 +20,7 @@ export class CodeCellUnconnected extends React.Component {
           <CellEditor cellId={this.props.cellId} />
         </CellRow>
         <CellRow cellId={this.props.cellId} rowType="sideeffect">
-          <div className="side-effect-target" />
+          <div id={`cell-${this.props.cellId}-side-effect-target`} className="side-effect-target" />
         </CellRow>
         <CellRow cellId={this.props.cellId} rowType="output">
           <CellOutput cellId={this.props.cellId} />

--- a/src/iodide-api/api.js
+++ b/src/iodide-api/api.js
@@ -4,7 +4,7 @@
 import { addOutputHandler } from '../components/reps/value-renderer'
 import { environment } from './environment'
 import { evalQueue } from './evalQueue'
-import { print, DOM } from './print'
+import { output } from './output'
 
 function getDataSync(url) {
   const re = new XMLHttpRequest()
@@ -18,8 +18,7 @@ export const iodide = {
   getDataSync,
   environment,
   evalQueue,
-  print,
-  DOM,
+  output,
 }
 
 export default iodide

--- a/src/iodide-api/api.js
+++ b/src/iodide-api/api.js
@@ -4,6 +4,7 @@
 import { addOutputHandler } from '../components/reps/value-renderer'
 import { environment } from './environment'
 import { evalQueue } from './evalQueue'
+import { print, DOM } from './print'
 
 function getDataSync(url) {
   const re = new XMLHttpRequest()
@@ -17,6 +18,8 @@ export const iodide = {
   getDataSync,
   environment,
   evalQueue,
+  print,
+  DOM,
 }
 
 export default iodide

--- a/src/iodide-api/output.js
+++ b/src/iodide-api/output.js
@@ -16,7 +16,7 @@ function sideEffectDiv(sideEffectClass, reportSideEffect) {
   // appends a side effect div to the side effect area
   const cellId = store.getState().runningCellID
   const div = document.createElement('div')
-  const printClass = (reportSideEffect === true) ? `${sideEffectClass} report-side-effect` : sideEffectClass
+  const printClass = (reportSideEffect === true) ? sideEffectClass : `${sideEffectClass} hide-side-effect`
   div.setAttribute('class', printClass)
   document.getElementById(`cell-${cellId}-side-effect-target`).append(div)
   return div

--- a/src/iodide-api/output.js
+++ b/src/iodide-api/output.js
@@ -22,17 +22,17 @@ function sideEffectDiv(sideEffectClass, reportSideEffect) {
   return div
 }
 
-export function print(s, reportSideEffect = false) {
-  // dumbly puts a string in a side effect div
-  const div = sideEffectDiv('side-effect-print', reportSideEffect)
-  div.innerHTML = s.toString()
-}
-
-export const DOM = {
-  element: (nodeType) => {
-    const cellId = store.getState().runningCellID
+export const output = {
+  text: (s, reportSideEffect = false) => {
+    // dumbly puts a string in a side effect div
+    const div = sideEffectDiv('side-effect-print', reportSideEffect)
+    div.innerHTML = s.toString()
+  },
+  element: (nodeType, reportSideEffect = true) => {
+    // const cellId = store.getState().runningCellID
+    const div = sideEffectDiv('side-effect-element', reportSideEffect)
     const node = document.createElement(nodeType)
-    document.getElementById(`cell-${cellId}-side-effect-target`).append(node)
+    div.append(node)
     return node
   },
 }

--- a/src/iodide-api/print.js
+++ b/src/iodide-api/print.js
@@ -1,0 +1,48 @@
+import { store } from '../store'
+
+/*
+These functions operate outside of the normal React/redux update cycle
+because we need to ensure that these changes to the DOM are applied
+_immediately_ from user evaled code. This is ok for now b/c these user
+side-effects are part of user code, and not really part of the app that
+Iodide has responsibility for.
+
+We may wish to refactor these mutations to fit into react/redux in the
+future, but until we run into problems, we'll use this approach to test
+things out.
+*/
+
+function sideEffectDiv(sideEffectClass, reportSideEffect) {
+  // appends a side effect div to the side effect area
+  const cellId = store.getState().runningCellID
+  const div = document.createElement('div')
+  const printClass = (reportSideEffect === true) ? `${sideEffectClass} report-side-effect` : sideEffectClass
+  div.setAttribute('class', printClass)
+  document.getElementById(`cell-${cellId}-side-effect-target`).append(div)
+  return div
+}
+
+export function print(s, reportSideEffect = false) {
+  // dumbly puts a string in a side effect div
+  const div = sideEffectDiv('side-effect-print', reportSideEffect)
+  div.innerHTML = s.toString()
+}
+
+export const DOM = {
+  element: (nodeType) => {
+    const cellId = store.getState().runningCellID
+    const node = document.createElement(nodeType)
+    document.getElementById(`cell-${cellId}-side-effect-target`).append(node)
+    return node
+  },
+}
+
+
+// export function html(s) {
+
+// }
+
+
+// export function append(s) {
+
+// }

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -142,7 +142,7 @@ function newCellRowSettings(cellType) {
     case 'code':
       return {
         EXPLORE: { input: 'VISIBLE', sideeffect: 'VISIBLE', output: 'VISIBLE' },
-        REPORT: { input: 'HIDDEN', sideeffect: 'HIDDEN', output: 'HIDDEN' },
+        REPORT: { input: 'HIDDEN', sideeffect: 'VISIBLE', output: 'HIDDEN' },
       }
     case 'markdown':
       return {

--- a/src/style/default-presentation.css
+++ b/src/style/default-presentation.css
@@ -32,7 +32,18 @@ div#cells.presentation div.cell-row-container {
 div#cells.presentation div.main-component {
   width: 100%;
 }
- 
+
+
+/* which side-effects are shown in the report view*/
+div#cells.presentation .side-effect-target {
+  max-width:800px;
+  margin: auto;
+}
+
+div#cells.presentation div.side-effect-target div.hide-side-effect {
+  display: none;
+}
+
  /* div#cells.presentation {
   padding-top:30px;
 }  */
@@ -53,8 +64,7 @@ div#cells.presentation div.main-component {
 
 /* establish block-level elements to be a certain width. This
 lets us create full width divs using css if necessary, while still
-retaining the narrower colum view for readability and flow.
-
+retaining the narrower column view for readability and flow.
 */
 
 .user-markdown p,


### PR DESCRIPTION
@hamilton @mdboom @wlach @djbarnwal 

hey guys, here's a version of print-like functionality, which, since it doesn't really print in real-time (like python print or console.log), i've decided to call "output".

for now there are two methods:
`iodide.output.text` - kind of like print, but not real time. Hidden from report view by default
`iodide.output.element` - creates an element that can be targeted with all normal DOM APIs and libs. Shown in report view by default.

I think this is low-risk, even if not terribly refined yet, so i'm going to go ahead and merge. feedback is most appreciated.

for a small demo:
https://iodide-project.github.io/master/?gist=bcolloran/f16031ce759642cbd2f2b56b752bab87
