### PR TITLE
added evalQueue.await to the iodide api

### DIFF
--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -77,7 +77,6 @@ describe('flow API', () => {
 
   it('correctly awaits for Promises to resolve', () => {
     jest.clearAllTimers()
-
     evalQueue.await([
       Promise.resolve(10),
       Promise.resolve(20),
@@ -89,8 +88,6 @@ describe('flow API', () => {
       .catch((err) => {
         throw new Error(err)
       })
-
-
     jest.runAllTimers()
   })
 

--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -93,4 +93,23 @@ describe('flow API', () => {
 
     jest.runAllTimers()
   })
+
+  it('tests error with async/await', async () => {
+    // evalQueue.await([
+    //   Promise.resolve(10).then(d => d.json()),
+    // ])
+    await expect(evalQueue.await([
+      Promise.resolve(10).then(d => d.json()),
+    ])).rejects.toThrowError()
+    // try {
+    //   evalQueue.await([
+    //     Promise.resolve(10).then(d => d.json()),
+    //   ]).then(() => {
+    //     // this should fail if we get to it.
+    //     expect(true).toBe(false)
+    //   })
+    // } catch (e) {
+    //   expect(e.message).toEqual('TypeError: d.json is not a function');
+    // }
+  })
 })

--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -4,6 +4,7 @@ import {
   setRunningCellEvalStatus,
   waitForExplicitContinuationStatusResolution,
   evalQueue,
+  getRunningCellAsyncProcessStatus,
 } from '../evalQueue'
 import { store } from '../../store'
 import { temporarilySaveRunningCellID, newNotebook } from '../../actions/actions'
@@ -31,8 +32,9 @@ describe('flow API', () => {
   it('allows for explicit setting of cell continuation', () => {
     evalQueue.requireExplicitContinuation()
     expect(runningEvalStatus()).toBe('ASYNC_PENDING')
+    expect(getRunningCellAsyncProcessStatus()).toBe(1)
     evalQueue.continue()
-    expect(runningEvalStatus()).toBe('SUCCESS')
+    expect(getRunningCellAsyncProcessStatus()).toBe(0)
   })
   it('accepts only valid setExplicitContinuationStatus arguments', () => {
     expect(() => setRunningCellEvalStatus('whatever')).toThrow()
@@ -80,9 +82,14 @@ describe('flow API', () => {
       Promise.resolve(10),
       Promise.resolve(20),
     ]).then((d) => {
-      expect(d).toBe([10, 20])
-      expect(getRunningCellEvalStatus()).toBe('UNEVALUATED')
+      expect(d).toEqual([10, 20])
+      expect(getRunningCellAsyncProcessStatus()).toBe(0)
+      expect(getRunningCellEvalStatus()).toBe('SUCCESS')
     })
+      .catch((err) => {
+        throw new Error(err)
+      })
+
 
     jest.runAllTimers()
   })

--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -72,4 +72,18 @@ describe('flow API', () => {
     expect(setInterval).toHaveBeenCalledTimes(1)
     jest.runAllTimers()
   })
+
+  it('correctly awaits for Promises to resolve', () => {
+    jest.clearAllTimers()
+
+    evalQueue.await([
+      Promise.resolve(10),
+      Promise.resolve(20),
+    ]).then((d) => {
+      expect(d).toBe([10, 20])
+      expect(getRunningCellEvalStatus()).toBe('UNEVALUATED')
+    })
+
+    jest.runAllTimers()
+  })
 })

--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -95,21 +95,8 @@ describe('flow API', () => {
   })
 
   it('tests error with async/await', async () => {
-    // evalQueue.await([
-    //   Promise.resolve(10).then(d => d.json()),
-    // ])
     await expect(evalQueue.await([
       Promise.resolve(10).then(d => d.json()),
     ])).rejects.toThrowError()
-    // try {
-    //   evalQueue.await([
-    //     Promise.resolve(10).then(d => d.json()),
-    //   ]).then(() => {
-    //     // this should fail if we get to it.
-    //     expect(true).toBe(false)
-    //   })
-    // } catch (e) {
-    //   expect(e.message).toEqual('TypeError: d.json is not a function');
-    // }
   })
 })

--- a/src/iodide-api/evalQueue.js
+++ b/src/iodide-api/evalQueue.js
@@ -34,7 +34,18 @@ export const waitForExplicitContinuationStatusResolution = () => new Promise((re
   }
 })
 
+const awaitPromises = promises =>
+  // is functionally identical to Promise.all.
+  Promise.resolve()
+    .then(() => setRunningCellEvalStatus('ASYNC_PENDING'))
+    .then(() => Promise.all(promises))
+    .then((resolutions) => {
+      setRunningCellEvalStatus('SUCCESS')
+      return resolutions
+    })
+
 export const evalQueue = {
   requireExplicitContinuation: () => { setRunningCellEvalStatus('ASYNC_PENDING') },
   continue: () => { setRunningCellEvalStatus('SUCCESS') },
+  await: awaitPromises,
 }

--- a/src/iodide-api/evalQueue.js
+++ b/src/iodide-api/evalQueue.js
@@ -59,14 +59,14 @@ export const waitForExplicitContinuationStatusResolution = () => new Promise((re
   }
 })
 
-const awaitPromises = promises =>
-  // is functionally identical to Promise.all.
-  Promise.resolve()
-    .then(() => {
-      setRunningCellEvalStatus('ASYNC_PENDING')
-      incrementAsyncProcessCount()
-    })
-    .then(() => Promise.all(promises).catch((err) => { throw Error(err) }))
+const awaitPromises = (promises) => {
+  setRunningCellEvalStatus('ASYNC_PENDING')
+  incrementAsyncProcessCount()
+  return Promise.resolve().then(() => Promise.all(promises).catch((err) => {
+    resetAsyncProcessCount()
+    setRunningCellEvalStatus('ERROR')
+    throw Error(err)
+  }))
     .then((resolutions) => {
       incrementAsyncProcessCount(-1)
       if (getRunningCellAsyncProcessStatus() === 0) {
@@ -74,6 +74,7 @@ const awaitPromises = promises =>
       }
       return resolutions
     })
+}
 
 export const evalQueue = {
   requireExplicitContinuation: () => {

--- a/src/iodide-api/evalQueue.js
+++ b/src/iodide-api/evalQueue.js
@@ -66,7 +66,7 @@ const awaitPromises = promises =>
       setRunningCellEvalStatus('ASYNC_PENDING')
       incrementAsyncProcessCount()
     })
-    .then(() => Promise.all(promises))
+    .then(() => Promise.all(promises).catch((err) => { throw Error(err) }))
     .then((resolutions) => {
       incrementAsyncProcessCount(-1)
       if (getRunningCellAsyncProcessStatus() === 0) {

--- a/src/iodide-api/evalQueue.js
+++ b/src/iodide-api/evalQueue.js
@@ -4,6 +4,30 @@ import { getCellById } from '../tools/notebook-utils'
 
 export const getRunningCellID = () => store.getState().runningCellID
 
+export const resetAsyncProcessCount = () => {
+  const cellId = getRunningCellID()
+  store.dispatch(updateCellProperties(cellId, {
+    asyncProcessCount: 0,
+  }))
+}
+
+export const incrementAsyncProcessCount = (n = 1) => {
+  const cellId = getRunningCellID()
+  const cell = getCellById(store.getState().cells, cellId)
+  store.dispatch(updateCellProperties(cellId, {
+    asyncProcessCount: cell.asyncProcessCount + n,
+  }))
+}
+
+export const getRunningCellAsyncProcessStatus = () => {
+  const cellId = getRunningCellID()
+  const cell = getCellById(store.getState().cells, cellId)
+  if (cell !== undefined) {
+    return cell.asyncProcessCount
+  }
+  return undefined
+}
+
 export const getRunningCellEvalStatus = () => {
   const cellId = getRunningCellID()
   const cell = getCellById(store.getState().cells, cellId)
@@ -22,9 +46,10 @@ export const setRunningCellEvalStatus = (evalStatus) => {
 }
 
 export const waitForExplicitContinuationStatusResolution = () => new Promise((resolve) => {
-  if (getRunningCellEvalStatus() === 'ASYNC_PENDING') {
+  if (getRunningCellAsyncProcessStatus() > 0) {
     const interval = setInterval(() => {
-      if (getRunningCellEvalStatus() === 'SUCCESS') {
+      if (getRunningCellAsyncProcessStatus() === 0) {
+        setRunningCellEvalStatus('SUCCESS')
         resolve()
         clearInterval(interval)
       }
@@ -37,15 +62,26 @@ export const waitForExplicitContinuationStatusResolution = () => new Promise((re
 const awaitPromises = promises =>
   // is functionally identical to Promise.all.
   Promise.resolve()
-    .then(() => setRunningCellEvalStatus('ASYNC_PENDING'))
+    .then(() => {
+      setRunningCellEvalStatus('ASYNC_PENDING')
+      incrementAsyncProcessCount()
+    })
     .then(() => Promise.all(promises))
     .then((resolutions) => {
-      setRunningCellEvalStatus('SUCCESS')
+      incrementAsyncProcessCount(-1)
+      if (getRunningCellAsyncProcessStatus() === 0) {
+        setRunningCellEvalStatus('SUCCESS')
+      }
       return resolutions
     })
 
 export const evalQueue = {
-  requireExplicitContinuation: () => { setRunningCellEvalStatus('ASYNC_PENDING') },
-  continue: () => { setRunningCellEvalStatus('SUCCESS') },
+  requireExplicitContinuation: () => {
+    setRunningCellEvalStatus('ASYNC_PENDING')
+    incrementAsyncProcessCount(1)
+  },
+  continue: () => {
+    if (getRunningCellAsyncProcessStatus() > 0) incrementAsyncProcessCount(-1)
+  },
   await: awaitPromises,
 }

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -38,6 +38,7 @@ const cellSchema = {
       type: 'string',
       enum: cellTypeEnum.values(),
     },
+    asyncProcessCount: { type: 'integer', minimum: 0 },
     value: {}, // empty schema, `value` can be anything
     rendered: { type: 'boolean' },
     selected: { type: 'boolean' },
@@ -193,6 +194,7 @@ function newCell(cellId, cellType, language = 'js') {
     value: undefined,
     rendered: false,
     selected: false,
+    asyncProcessCount: 0,
     executionStatus: ' ',
     evalStatus: 'UNEVALUATED',
     rowSettings: newCellRowSettings(cellType),


### PR DESCRIPTION
This PR adds another feature to the iodide api - `iodide.evalQueue.await`. Motivated by the discussion in #597, we want an easy way to prevent further cell evaluation until certain Promises are resolved, specifically any using the `fetch` api. So `iodide.evalQueue.await` works exactly as `Promise.all` - you pass in an array of promises (like `fetch` calls) and it waits for all of the Promises to resolve / reject before moving on.

I would imagine that the majority of data scientists / our users would prefer to just use this function instead of `iodide.evalQueue.requireExplicitContinuation` / `iodide.evalQueue.continue`, but those pieces are functionality will be vital in non-Promise situations, and at any rate I use both of them within `iodide.evalQueue.await`.

Use `?gist=hamilton/50e813eb8169f0486b48d55d5d206df8` for an example.  Below is a code block that demonstrates the functionality:

```javascript
let url1 = 'https://normandy.cdn.mozilla.net/api/v2/recipe/?format=json&ordering=-last_updated'
let url2 = 'https://normandy.cdn.mozilla.net/api/v2/recipe/?format=json&ordering=-last_updated&page=2'
var data1 =[]
var data2 = []

let timer = new Promise((go)=>{
  setTimeout(()=>{
    go('setTimeout Resolved.')
  }, 4000)
})

iodide.evalQueue.await([
  timer,
  fetch(url1).then(d=>d.json()).then(d=>{data1 = d; return d}),
  fetch(url2).then(d=>d.json()).then(d=>{data2 = d; return d})
])

```