### PR TITLE
Multiple Highlight, Cut Copy and Paste

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -565,6 +565,12 @@ export function unHighlightCells() {
   }
 }
 
+export function multipleCellHighlight(cellID) {
+  return {
+    type: 'MULTIPLE_CELL_HIGHLIGHT',
+    id: cellID,
+  }
+}
 
 export function cellCopy() {
   return {

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -551,10 +551,11 @@ export function selectCell(cellID, scrollToCell = false) {
   }
 }
 
-export function highlightCell(cellID) {
+export function highlightCell(cellID, revert = true) {
   return {
     type: 'HIGHLIGHT_CELL',
     id: cellID,
+    revert,
   }
 }
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -558,9 +558,22 @@ export function highlightCell(cellID) {
   }
 }
 
+export function unHighlightCells() {
+  return {
+    type: 'UNHIGHLIGHT_CELLS',
+  }
+}
+
+
 export function cellCopy() {
   return {
     type: 'CELL_COPY',
+  }
+}
+
+export function cellCut() {
+  return {
+    type: 'CELL_CUT',
   }
 }
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -558,6 +558,18 @@ export function highlightCell(cellID) {
   }
 }
 
+export function cellCopy() {
+  return {
+    type: 'CELL_COPY',
+  }
+}
+
+export function cellPaste() {
+  return {
+    type: 'CELL_PASTE',
+  }
+}
+
 export function deleteCell() {
   return {
     type: 'DELETE_CELL',

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -551,6 +551,13 @@ export function selectCell(cellID, scrollToCell = false) {
   }
 }
 
+export function highlightCell(cellID) {
+  return {
+    type: 'HIGHLIGHT_CELL',
+    id: cellID,
+  }
+}
+
 export function deleteCell() {
   return {
     type: 'DELETE_CELL',

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -155,16 +155,25 @@ tasks.addCellBelow = new UserTask({
 
 tasks.copyCell = new UserTask({
   title: 'Copy Cell',
-  keybindings: ['ctrl+c', 'meta+c'],
+  keybindings: ['ctrl+c', 'command+c'],
   displayKeybinding: `${commandKey()}+C`,
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() { dispatcher.cellCopy() },
 })
 
+tasks.cutCell = new UserTask({
+  title: 'Cut Cell',
+  keybindings: ['ctrl+x', 'command+x'],
+  displayKeybinding: `${commandKey()}+X`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellCut() },
+})
+
 tasks.pasteCell = new UserTask({
   title: 'Paste Cell',
-  keybindings: ['ctrl+v', 'meta+v'],
+  keybindings: ['ctrl+v', 'command+v'],
   displayKeybinding: `${commandKey()}+V`,
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -9,6 +9,7 @@ import {
   getCellBelowSelectedId,
   getCellAboveSelectedId, prettyDate, formatDateString,
 } from '../tools/notebook-utils'
+import { getSelectedCellId } from '../reducers/cell-reducer-utils'
 import { stateFromJsmd } from '../tools/jsmd-tools'
 
 const dispatcher = {}
@@ -70,8 +71,8 @@ tasks.evaluateCellAndSelectBelow = new UserTask({
 
 tasks.moveCellUp = new UserTask({
   title: 'Move Cell Up',
-  displayKeybinding: 'Shift+Up', // '\u21E7 \u2191',
-  keybindings: ['shift+up'],
+  displayKeybinding: `${commandKey()}+Up`,
+  keybindings: ['ctrl+up', 'meta+up'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
@@ -82,8 +83,8 @@ tasks.moveCellUp = new UserTask({
 
 tasks.moveCellDown = new UserTask({
   title: 'Move Cell Down',
-  displayKeybinding: 'Shift+Down', // '\u21E7 \u2193',
-  keybindings: ['shift+down'],
+  displayKeybinding: `${commandKey()}+Down`,
+  keybindings: ['ctrl+down', 'meta+down'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
@@ -104,6 +105,38 @@ tasks.logoutGithub = new UserTask({
 tasks.exportGist = new UserTask({
   title: 'Export Gist',
   callback() { dispatcher.exportGist() },
+})
+
+tasks.highlightUp = new UserTask({
+  title: 'Select Cell Above',
+  displayKeybinding: 'Shift+Up', // '\u21E7 \u2191',
+  keybindings: ['shift+up'],
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() {
+    const cellAboveId = getCellAboveSelectedId()
+    dispatcher.highlightCell(getSelectedCellId(store.getState()), false)
+    if (cellAboveId !== null) {
+      dispatcher.highlightCell(cellAboveId, false)
+      dispatcher.selectCell(cellAboveId, true)
+    }
+  },
+})
+
+tasks.highlightDown = new UserTask({
+  title: 'Select Cell Down',
+  displayKeybinding: 'Shift+Up', // '\u21E7 \u2193',
+  keybindings: ['shift+down'],
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() {
+    const cellBelowId = getCellBelowSelectedId()
+    dispatcher.highlightCell(getSelectedCellId(store.getState()), false)
+    if (cellBelowId !== null) {
+      dispatcher.highlightCell(cellBelowId, false)
+      dispatcher.selectCell(cellBelowId, true)
+    }
+  },
 })
 
 tasks.selectUp = new UserTask({

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -153,6 +153,24 @@ tasks.addCellBelow = new UserTask({
   },
 })
 
+tasks.copyCell = new UserTask({
+  title: 'Copy Cell',
+  keybindings: ['ctrl+c', 'meta+c'],
+  displayKeybinding: `${commandKey()}+C`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellCopy() },
+})
+
+tasks.pasteCell = new UserTask({
+  title: 'Paste Cell',
+  keybindings: ['ctrl+v', 'meta+v'],
+  displayKeybinding: `${commandKey()}+V`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellPaste() },
+})
+
 tasks.deleteCell = new UserTask({
   title: 'Delete Cell',
   keybindings: ['shift+backspace'],

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -147,7 +147,10 @@ tasks.selectUp = new UserTask({
   preventDefaultKeybinding: true,
   callback() {
     const cellAboveId = getCellAboveSelectedId()
-    if (cellAboveId !== null) { dispatcher.selectCell(cellAboveId, true) }
+    if (cellAboveId !== null) {
+      dispatcher.selectCell(cellAboveId, true)
+      dispatcher.unHighlightCells()
+    }
   },
 })
 
@@ -159,7 +162,10 @@ tasks.selectDown = new UserTask({
   preventDefaultKeybinding: true,
   callback() {
     const cellBelowId = getCellBelowSelectedId()
-    if (cellBelowId !== null) { dispatcher.selectCell(cellBelowId, true) }
+    if (cellBelowId !== null) {
+      dispatcher.selectCell(cellBelowId, true)
+      dispatcher.unHighlightCells()
+    }
   },
 })
 

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -99,7 +99,7 @@ describe('CellContainerUnconnected React component', () => {
 
   it('mouse down on cell container div fires unHighlightCells with correct props', () => {
     props.viewMode = 'editor'
-    props.selected = false
+    props.highlighted = true
     cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
     expect(unHighlightCells.mock.calls.length).toBe(1)
     expect(unHighlightCells.mock.calls[0].length).toBe(0)

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -7,6 +7,7 @@ import CellMenuContainer from '../cell-menu-container'
 describe('CellContainerUnconnected React component', () => {
   let selectCell
   let highlightCell
+  let unHighlightCells
   let props
   let mountedCont
   const node = <span>Hello</span>
@@ -21,13 +22,14 @@ describe('CellContainerUnconnected React component', () => {
   beforeEach(() => {
     selectCell = jest.fn()
     highlightCell = jest.fn()
+    unHighlightCells = jest.fn()
     props = {
       selected: true,
       cellId: 1,
       editingCell: true,
       viewMode: 'editor',
       cellType: 'code',
-      actions: { selectCell, highlightCell },
+      actions: { selectCell, highlightCell, unHighlightCells },
     }
     mountedCont = undefined
   })
@@ -94,6 +96,15 @@ describe('CellContainerUnconnected React component', () => {
     expect(selectCell.mock.calls.length).toBe(1)
     expect(selectCell.mock.calls[0].length).toBe(2)
   })
+
+  it('mouse down on cell container div fires unHighlightCells with correct props', () => {
+    props.viewMode = 'editor'
+    props.selected = false
+    cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
+    expect(unHighlightCells.mock.calls.length).toBe(1)
+    expect(unHighlightCells.mock.calls[0].length).toBe(0)
+  })
+
 
   it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
     props.viewMode = 'editor'

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -6,6 +6,7 @@ import CellMenuContainer from '../cell-menu-container'
 
 describe('CellContainerUnconnected React component', () => {
   let selectCell
+  let highlightCell
   let props
   let mountedCont
   const node = <span>Hello</span>
@@ -19,13 +20,14 @@ describe('CellContainerUnconnected React component', () => {
 
   beforeEach(() => {
     selectCell = jest.fn()
+    highlightCell = jest.fn()
     props = {
       selected: true,
       cellId: 1,
       editingCell: true,
       viewMode: 'editor',
       cellType: 'code',
-      actions: { selectCell },
+      actions: { selectCell, highlightCell },
     }
     mountedCont = undefined
   })
@@ -72,6 +74,14 @@ describe('CellContainerUnconnected React component', () => {
       .toBe('cell-container code selected-cell editing-cell')
   })
 
+  it('sets the top div with correct class if highlighted===true', () => {
+    props.selected = false
+    props.editingCell = false
+    props.highlighted = true
+    expect(cellContainer().find('div').at(0).props().className)
+      .toBe('cell-container code highlighted-cell')
+  })
+
   it('sets the onMouseDown prop to handleCellClick', () => {
     expect(cellContainer().props().onMouseDown)
       .toEqual(cellContainer().instance().handleCellClick)
@@ -80,10 +90,18 @@ describe('CellContainerUnconnected React component', () => {
   it('mouse down on cell container div fires selectCell with correct props', () => {
     props.viewMode = 'editor'
     props.selected = false
-    cellContainer().simulate('mousedown')
+    cellContainer().simulate('mousedown', { ctrlKey: false })
     expect(selectCell.mock.calls.length).toBe(1)
     expect(selectCell.mock.calls[0].length).toBe(2)
   })
+
+  it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
+    props.viewMode = 'editor'
+    cellContainer().simulate('mousedown', { ctrlKey: true })
+    expect(highlightCell.mock.calls.length).toBe(1)
+    expect(highlightCell.mock.calls[0].length).toBe(1)
+  })
+
 
   const selectCellNotFiredVariants = [
     { selected: true, viewMode: 'editor' },
@@ -95,7 +113,7 @@ describe('CellContainerUnconnected React component', () => {
     it('click on cell container div does not fires selectCell with incorrect props', () => {
       props.viewMode = state.viewMode
       props.selected = state.selected
-      cellContainer().simulate('mousedown')
+      cellContainer().simulate('mousedown', { ctrlKey: false })
       expect(selectCell.mock.calls.length).toBe(0)
     })
   })
@@ -129,6 +147,7 @@ describe('CellContainer mapStateToProps', () => {
       cells: [{
         id: 5,
         selected: true,
+        highlighted: false,
         cellType: 'code',
       },
       ],
@@ -143,6 +162,7 @@ describe('CellContainer mapStateToProps', () => {
       .toEqual({
         cellId: 5,
         selected: true,
+        highlighted: false,
         editingCell: true,
         viewMode: 'editor',
         cellType: 'code',
@@ -157,6 +177,7 @@ describe('CellContainer mapStateToProps', () => {
       .toEqual({
         cellId: 5,
         selected: false,
+        highlighted: false,
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',
@@ -171,6 +192,7 @@ describe('CellContainer mapStateToProps', () => {
       .toEqual({
         cellId: 5,
         selected: true,
+        highlighted: false,
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',
@@ -185,6 +207,7 @@ describe('CellContainer mapStateToProps', () => {
       .toEqual({
         cellId: 5,
         selected: false,
+        highlighted: false,
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -99,7 +99,11 @@ describe('CellContainerUnconnected React component', () => {
   it('mouse down on cell container div fires selectCell with correct props', () => {
     props.viewMode = 'editor'
     props.selected = false
-    cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
+    cellContainer().simulate('mousedown', {
+      ctrlKey: false,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
     expect(selectCell.mock.calls.length).toBe(1)
     expect(selectCell.mock.calls[0].length).toBe(2)
   })
@@ -107,7 +111,11 @@ describe('CellContainerUnconnected React component', () => {
   it('mouse down on cell container div fires unHighlightCells with correct props', () => {
     props.viewMode = 'editor'
     props.highlighted = true
-    cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
+    cellContainer().simulate('mousedown', {
+      ctrlKey: false,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
     expect(unHighlightCells.mock.calls.length).toBe(1)
     expect(unHighlightCells.mock.calls[0].length).toBe(0)
   })
@@ -118,6 +126,7 @@ describe('CellContainerUnconnected React component', () => {
       shiftKey: true,
       ctrlKey: true,
       metaKey: false,
+      target: document.createElement('mockElement'),
       preventDefault: () => {
       },
     })
@@ -127,7 +136,11 @@ describe('CellContainerUnconnected React component', () => {
 
   it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
     props.viewMode = 'editor'
-    cellContainer().simulate('mousedown', { ctrlKey: true, metaKey: false })
+    cellContainer().simulate('mousedown', {
+      ctrlKey: true,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
     expect(highlightCell.mock.calls.length).toBe(1)
     expect(highlightCell.mock.calls[0].length).toBe(1)
   })
@@ -143,7 +156,11 @@ describe('CellContainerUnconnected React component', () => {
     it('click on cell container div does not fires selectCell with incorrect props', () => {
       props.viewMode = state.viewMode
       props.selected = state.selected
-      cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
+      cellContainer().simulate('mousedown', {
+        ctrlKey: false,
+        metaKey: false,
+        target: document.createElement('mockElement'),
+      })
       expect(selectCell.mock.calls.length).toBe(0)
     })
   })

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -90,14 +90,14 @@ describe('CellContainerUnconnected React component', () => {
   it('mouse down on cell container div fires selectCell with correct props', () => {
     props.viewMode = 'editor'
     props.selected = false
-    cellContainer().simulate('mousedown', { ctrlKey: false })
+    cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
     expect(selectCell.mock.calls.length).toBe(1)
     expect(selectCell.mock.calls[0].length).toBe(2)
   })
 
   it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
     props.viewMode = 'editor'
-    cellContainer().simulate('mousedown', { ctrlKey: true })
+    cellContainer().simulate('mousedown', { ctrlKey: true, metaKey: false })
     expect(highlightCell.mock.calls.length).toBe(1)
     expect(highlightCell.mock.calls[0].length).toBe(1)
   })
@@ -113,7 +113,7 @@ describe('CellContainerUnconnected React component', () => {
     it('click on cell container div does not fires selectCell with incorrect props', () => {
       props.viewMode = state.viewMode
       props.selected = state.selected
-      cellContainer().simulate('mousedown', { ctrlKey: false })
+      cellContainer().simulate('mousedown', { ctrlKey: false, metaKey: false })
       expect(selectCell.mock.calls.length).toBe(0)
     })
   })

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -8,6 +8,7 @@ describe('CellContainerUnconnected React component', () => {
   let selectCell
   let highlightCell
   let unHighlightCells
+  let multipleCellHighlight
   let props
   let mountedCont
   const node = <span>Hello</span>
@@ -23,13 +24,19 @@ describe('CellContainerUnconnected React component', () => {
     selectCell = jest.fn()
     highlightCell = jest.fn()
     unHighlightCells = jest.fn()
+    multipleCellHighlight = jest.fn()
     props = {
       selected: true,
       cellId: 1,
       editingCell: true,
       viewMode: 'editor',
       cellType: 'code',
-      actions: { selectCell, highlightCell, unHighlightCells },
+      actions: {
+        selectCell,
+        highlightCell,
+        unHighlightCells,
+        multipleCellHighlight,
+      },
     }
     mountedCont = undefined
   })
@@ -105,6 +112,18 @@ describe('CellContainerUnconnected React component', () => {
     expect(unHighlightCells.mock.calls[0].length).toBe(0)
   })
 
+  it('mouse down on cell container fires multipleCellHighlight with Shift press', () => {
+    props.viewMode = 'editor'
+    cellContainer().simulate('mousedown', {
+      shiftKey: true,
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: () => {
+      },
+    })
+    expect(multipleCellHighlight.mock.calls.length).toBe(1)
+    expect(multipleCellHighlight.mock.calls[0].length).toBe(1)
+  })
 
   it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
     props.viewMode = 'editor'

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -36,7 +36,7 @@ export class CellContainerUnconnected extends React.Component {
   handleCellClick = (event) => {
     if (this.props.viewMode === 'editor') {
       const scrollToCell = false
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.metaKey) {
         this.props.actions.highlightCell(this.props.cellId)
       } else if (!this.props.selected || this.props.highlighted) {
         this.props.actions.selectCell(this.props.cellId, scrollToCell)

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -22,6 +22,7 @@ export class CellContainerUnconnected extends React.Component {
     actions: PropTypes.shape({
       selectCell: PropTypes.func.isRequired,
       highlightCell: PropTypes.func.isRequired,
+      unHighlightCells: PropTypes.func.isRequired,
     }).isRequired,
   }
 
@@ -39,6 +40,7 @@ export class CellContainerUnconnected extends React.Component {
       if (event.ctrlKey || event.metaKey) {
         this.props.actions.highlightCell(this.props.cellId)
       } else if (!this.props.selected || this.props.highlighted) {
+        this.props.actions.unHighlightCells()
         this.props.actions.selectCell(this.props.cellId, scrollToCell)
       }
     }

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -81,7 +81,6 @@ export function mapStateToProps(state, ownProps) {
     editingCell: cell.selected && state.mode === 'edit',
     viewMode: state.viewMode,
     cellType: cell.cellType,
-    mode: state.mode,
   }
 }
 

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -37,11 +37,13 @@ export class CellContainerUnconnected extends React.Component {
   handleCellClick = (event) => {
     if (this.props.viewMode === 'editor') {
       const scrollToCell = false
+      if (!this.props.selected) {
+        this.props.actions.selectCell(this.props.cellId, scrollToCell)
+      }
       if (event.ctrlKey || event.metaKey) {
         this.props.actions.highlightCell(this.props.cellId)
-      } else if (!this.props.selected || this.props.highlighted) {
+      } else if (this.props.highlighted) {
         this.props.actions.unHighlightCells()
-        this.props.actions.selectCell(this.props.cellId, scrollToCell)
       }
     }
   }

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -23,6 +23,7 @@ export class CellContainerUnconnected extends React.Component {
       selectCell: PropTypes.func.isRequired,
       highlightCell: PropTypes.func.isRequired,
       unHighlightCells: PropTypes.func.isRequired,
+      multipleCellHighlight: PropTypes.func.isRequired,
     }).isRequired,
   }
 
@@ -37,12 +38,15 @@ export class CellContainerUnconnected extends React.Component {
   handleCellClick = (event) => {
     if (this.props.viewMode === 'editor') {
       const scrollToCell = false
-      if (!this.props.selected) {
+      if (!this.props.selected && !event.shiftKey) {
         this.props.actions.selectCell(this.props.cellId, scrollToCell)
       }
-      if (event.ctrlKey || event.metaKey) {
+      if (event.shiftKey) {
+        event.preventDefault();
+        this.props.actions.multipleCellHighlight(this.props.cellId)
+      } else if (event.ctrlKey || event.metaKey) {
         this.props.actions.highlightCell(this.props.cellId)
-      } else if (this.props.highlighted) {
+      } else {
         this.props.actions.unHighlightCells()
       }
     }

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -36,7 +36,7 @@ export class CellContainerUnconnected extends React.Component {
   // }
 
   handleCellClick = (event) => {
-    if (this.props.viewMode === 'editor') {
+    if (this.props.viewMode === 'editor' && !event.target.classList.contains('CodeMirror-line')) {
       const scrollToCell = false
       if (!this.props.selected && !event.shiftKey) {
         this.props.actions.selectCell(this.props.cellId, scrollToCell)

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -21,6 +21,7 @@ export class CellContainerUnconnected extends React.Component {
     cellType: PropTypes.oneOf(cellTypeEnum.values()),
     actions: PropTypes.shape({
       selectCell: PropTypes.func.isRequired,
+      highlightCell: PropTypes.func.isRequired,
     }).isRequired,
   }
 
@@ -32,10 +33,12 @@ export class CellContainerUnconnected extends React.Component {
   //   )
   // }
 
-  handleCellClick = () => {
+  handleCellClick = (event) => {
     if (this.props.viewMode === 'editor') {
       const scrollToCell = false
-      if (!this.props.selected) {
+      if (event.ctrlKey) {
+        this.props.actions.highlightCell(this.props.cellId)
+      } else if (!this.props.selected || this.props.highlighted) {
         this.props.actions.selectCell(this.props.cellId, scrollToCell)
       }
     }
@@ -47,6 +50,8 @@ export class CellContainerUnconnected extends React.Component {
       this.props.cellType
     }${
       this.props.selected ? ' selected-cell' : ''
+    }${
+      this.props.highlighted ? ' highlighted-cell' : ''
     }${
       this.props.editingCell ? ' editing-cell' : ''
     }`
@@ -72,9 +77,11 @@ export function mapStateToProps(state, ownProps) {
   return {
     cellId: cell.id,
     selected: cell.selected,
+    highlighted: cell.highlighted,
     editingCell: cell.selected && state.mode === 'edit',
     viewMode: state.viewMode,
     cellType: cell.cellType,
+    mode: state.mode,
   }
 }
 

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -122,7 +122,6 @@ class CellEditor extends React.Component {
   }
 
   handleFocusChange(focused) {
-    console.log('HEY', focused)
     if (focused && this.props.viewMode === 'editor') {
       if (!this.props.thisCellBeingEdited) {
         this.props.actions.selectCell(this.props.cellId)

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -122,6 +122,7 @@ class CellEditor extends React.Component {
   }
 
   handleFocusChange(focused) {
+    console.log('HEY', focused)
     if (focused && this.props.viewMode === 'editor') {
       if (!this.props.thisCellBeingEdited) {
         this.props.actions.selectCell(this.props.cellId)

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -91,6 +91,7 @@ class CellEditor extends React.Component {
       changeMode: PropTypes.func.isRequired,
       updateInputContent: PropTypes.func.isRequired,
       unHighlightCells: PropTypes.func.isRequired,
+      multipleCellHighlight: PropTypes.func.isRequired,
     }).isRequired,
     inputRef: PropTypes.func,
     containerStyle: PropTypes.object,
@@ -135,7 +136,7 @@ class CellEditor extends React.Component {
   }
 
   handleChange(event) {
-    if (!event.ctrlKey) {
+    if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
       this.props.actions.unHighlightCells()
     }
   }

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -92,7 +92,6 @@ class CellEditor extends React.Component {
       changeMode: PropTypes.func.isRequired,
       updateInputContent: PropTypes.func.isRequired,
       unHighlightCells: PropTypes.func.isRequired,
-      multipleCellHighlight: PropTypes.func.isRequired,
     }).isRequired,
     inputRef: PropTypes.func,
     containerStyle: PropTypes.object,
@@ -106,7 +105,6 @@ class CellEditor extends React.Component {
     this.handleFocusChange = this.handleFocusChange.bind(this)
     this.updateInputContent = this.updateInputContent.bind(this)
     this.storeEditorElementRef = this.storeEditorElementRef.bind(this)
-    this.handleClick = this.handleClick.bind(this)
     this.getReadOnly = this.getReadOnly.bind(this)
   }
 
@@ -135,17 +133,12 @@ class CellEditor extends React.Component {
   handleFocusChange(focused) {
     if (focused && this.props.viewMode === 'editor') {
       if (!this.props.thisCellBeingEdited) {
+        this.props.actions.unHighlightCells()
         this.props.actions.selectCell(this.props.cellId)
         this.props.actions.changeMode('edit')
       }
     } else if (!focused && this.props.viewMode === 'editor') {
       this.props.actions.changeMode('command')
-    }
-  }
-
-  handleClick(event) {
-    if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
-      this.props.actions.unHighlightCells()
     }
   }
 
@@ -197,7 +190,6 @@ class CellEditor extends React.Component {
       <div
         className="editor"
         style={this.props.containerStyle}
-        onClick={this.handleClick}
       >
         <CodeMirror
           ref={this.storeEditorElementRef}

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -84,6 +84,7 @@ class CellEditor extends React.Component {
     cellId: PropTypes.number.isRequired,
     cellType: PropTypes.string,
     content: PropTypes.string,
+    highlighted: PropTypes.bool.isRequired,
     viewMode: PropTypes.oneOf(['editor', 'presentation']),
     languageIsAvailable: PropTypes.bool,
     actions: PropTypes.shape({
@@ -105,7 +106,8 @@ class CellEditor extends React.Component {
     this.handleFocusChange = this.handleFocusChange.bind(this)
     this.updateInputContent = this.updateInputContent.bind(this)
     this.storeEditorElementRef = this.storeEditorElementRef.bind(this)
-    this.handleChange = this.handleChange.bind(this)
+    this.handleClick = this.handleClick.bind(this)
+    this.getReadOnly = this.getReadOnly.bind(this)
   }
 
   componentDidMount() {
@@ -124,6 +126,12 @@ class CellEditor extends React.Component {
     }
   }
 
+  getReadOnly() {
+    if (this.props.viewMode === 'presentation') return true
+    if (this.props.highlighted) return 'nocursor'
+    return false
+  }
+
   handleFocusChange(focused) {
     if (focused && this.props.viewMode === 'editor') {
       if (!this.props.thisCellBeingEdited) {
@@ -135,7 +143,7 @@ class CellEditor extends React.Component {
     }
   }
 
-  handleChange(event) {
+  handleClick(event) {
     if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
       this.props.actions.unHighlightCells()
     }
@@ -182,14 +190,14 @@ class CellEditor extends React.Component {
         'Ctrl-Space': this.props.codeMirrorMode === 'javascript' ? this.autoComplete : undefined,
       },
       comment: this.props.codeMirrorMode === 'javascript',
-      readOnly: this.props.viewMode === 'presentation',
+      readOnly: this.getReadOnly(),
     }, this.props.editorOptions)
 
     return (
       <div
         className="editor"
         style={this.props.containerStyle}
-        onClick={this.handleChange}
+        onClick={this.handleClick}
       >
         <CodeMirror
           ref={this.storeEditorElementRef}
@@ -219,6 +227,7 @@ function mapStateToProps(state, ownProps) {
     viewMode: state.viewMode,
     cellType: cell.cellType,
     content: cell.content,
+    highlighted: cell.highlighted,
     cellId,
     codeMirrorMode,
     languageIsAvailable: cell.cellType !== 'code' ? true : window[languageModule] !== undefined,

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -90,6 +90,7 @@ class CellEditor extends React.Component {
       selectCell: PropTypes.func.isRequired,
       changeMode: PropTypes.func.isRequired,
       updateInputContent: PropTypes.func.isRequired,
+      unHighlightCells: PropTypes.func.isRequired,
     }).isRequired,
     inputRef: PropTypes.func,
     containerStyle: PropTypes.object,
@@ -103,6 +104,7 @@ class CellEditor extends React.Component {
     this.handleFocusChange = this.handleFocusChange.bind(this)
     this.updateInputContent = this.updateInputContent.bind(this)
     this.storeEditorElementRef = this.storeEditorElementRef.bind(this)
+    this.handleChange = this.handleChange.bind(this)
   }
 
   componentDidMount() {
@@ -129,6 +131,12 @@ class CellEditor extends React.Component {
       }
     } else if (!focused && this.props.viewMode === 'editor') {
       this.props.actions.changeMode('command')
+    }
+  }
+
+  handleChange(event) {
+    if (!event.ctrlKey) {
+      this.props.actions.unHighlightCells()
     }
   }
 
@@ -180,6 +188,7 @@ class CellEditor extends React.Component {
       <div
         className="editor"
         style={this.props.containerStyle}
+        onClick={this.handleChange}
       >
         <CodeMirror
           ref={this.storeEditorElementRef}

--- a/src/components/menu/cell-menu-subsection.jsx
+++ b/src/components/menu/cell-menu-subsection.jsx
@@ -16,6 +16,8 @@ export default class CellMenuSubsection extends React.Component {
         <NotebookMenuItem key={tasks.addCellBelow.title} task={tasks.addCellBelow} />
         <NotebookMenuItem key={tasks.addCellAbove.title} task={tasks.addCellAbove} />
         <NotebookMenuItem key={tasks.deleteCell.title} task={tasks.deleteCell} />
+        <NotebookMenuItem key={tasks.copyCell.title} task={tasks.copyCell} />
+        <NotebookMenuItem key={tasks.pasteCell.title} task={tasks.pasteCell} />
         <NotebookMenuDivider />
         <NotebookMenuHeader title="change cell to ..." />
         <NotebookMenuItem

--- a/src/components/menu/cell-menu-subsection.jsx
+++ b/src/components/menu/cell-menu-subsection.jsx
@@ -17,6 +17,7 @@ export default class CellMenuSubsection extends React.Component {
         <NotebookMenuItem key={tasks.addCellAbove.title} task={tasks.addCellAbove} />
         <NotebookMenuItem key={tasks.deleteCell.title} task={tasks.deleteCell} />
         <NotebookMenuItem key={tasks.copyCell.title} task={tasks.copyCell} />
+        <NotebookMenuItem key={tasks.cutCell.title} task={tasks.cutCell} />
         <NotebookMenuItem key={tasks.pasteCell.title} task={tasks.pasteCell} />
         <NotebookMenuDivider />
         <NotebookMenuHeader title="change cell to ..." />

--- a/src/components/menu/editor-mode-controls.jsx
+++ b/src/components/menu/editor-mode-controls.jsx
@@ -5,6 +5,8 @@ import UpArrow from 'material-ui-icons/ArrowUpward'
 import DownArrow from 'material-ui-icons/ArrowDownward'
 import PlayButton from 'material-ui-icons/PlayArrow'
 import FastForward from 'material-ui-icons/FastForward'
+import ContentCopy from 'material-ui-icons/ContentCopy'
+import ContentPaste from 'material-ui-icons/ContentPaste'
 
 import EditorToolbarMenu from './editor-toolbar-menu'
 import NotebookTaskButton from './notebook-task-button'
@@ -24,6 +26,12 @@ export default class EditorModeControls extends React.Component {
         </NotebookTaskButton>
         <NotebookTaskButton task={tasks.moveCellDown}>
           <DownArrow />
+        </NotebookTaskButton>
+        <NotebookTaskButton task={tasks.copyCell}>
+          <ContentCopy />
+        </NotebookTaskButton>
+        <NotebookTaskButton task={tasks.pasteCell}>
+          <ContentPaste />
         </NotebookTaskButton>
         <NotebookTaskButton task={tasks.evaluateCell}>
           <PlayButton />

--- a/src/components/menu/editor-mode-controls.jsx
+++ b/src/components/menu/editor-mode-controls.jsx
@@ -5,8 +5,6 @@ import UpArrow from 'material-ui-icons/ArrowUpward'
 import DownArrow from 'material-ui-icons/ArrowDownward'
 import PlayButton from 'material-ui-icons/PlayArrow'
 import FastForward from 'material-ui-icons/FastForward'
-import ContentCopy from 'material-ui-icons/ContentCopy'
-import ContentPaste from 'material-ui-icons/ContentPaste'
 
 import EditorToolbarMenu from './editor-toolbar-menu'
 import NotebookTaskButton from './notebook-task-button'
@@ -26,12 +24,6 @@ export default class EditorModeControls extends React.Component {
         </NotebookTaskButton>
         <NotebookTaskButton task={tasks.moveCellDown}>
           <DownArrow />
-        </NotebookTaskButton>
-        <NotebookTaskButton task={tasks.copyCell}>
-          <ContentCopy />
-        </NotebookTaskButton>
-        <NotebookTaskButton task={tasks.pasteCell}>
-          <ContentPaste />
         </NotebookTaskButton>
         <NotebookTaskButton task={tasks.evaluateCell}>
           <PlayButton />

--- a/src/reducers/cell-reducer-utils.js
+++ b/src/reducers/cell-reducer-utils.js
@@ -140,6 +140,15 @@ function getSelectedCellId(state) {
   return undefined // for now
 }
 
+function getSelectedCellIndex(state) {
+  const { cells } = state
+  const index = cells.findIndex(c => c.selected)
+  if (index > -1) {
+    return index
+  }
+  return undefined // for now
+}
+
 function getCellBelowSelectedId(state) {
   const { cells } = state
   const index = cells.findIndex(c => c.selected)
@@ -210,6 +219,7 @@ export {
   addExternalDependency,
   getSelectedCell,
   getSelectedCellId,
+  getSelectedCellIndex,
   getCellBelowSelectedId,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,

--- a/src/reducers/cell-reducer-utils.js
+++ b/src/reducers/cell-reducer-utils.js
@@ -184,6 +184,21 @@ function newStateWithPropsAssignedForCell(state, cellId, cellPropsToSet) {
   return Object.assign({}, state, { cells })
 }
 
+function checkForHighlightedCells(state) {
+  const cells = state.cells.slice()
+  return cells.find(c => c.highlighted)
+}
+
+function newStateWithPropsAssignedForHighlightedCells(state, cellPropsToSet) {
+  const cells = state.cells.slice()
+  cells.forEach((cell, i) => {
+    if (cell.highlighted) {
+      cells[i] = Object.assign({}, cell, cellPropsToSet)
+    }
+  })
+  return Object.assign({}, state, { cells })
+}
+
 function newStateWithSelectedCellPropsAssigned(state, cellPropsToSet) {
   return newStateWithPropsAssignedForCell(state, getSelectedCellId(state), cellPropsToSet)
 }
@@ -225,4 +240,6 @@ export {
   newStateWithSelectedCellPropsAssigned,
   newStateWithRowOverflowSet,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 }

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -14,6 +14,8 @@ import {
   newStateWithSelectedCellPropsAssigned,
   newStateWithRowOverflowSet,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 } from './cell-reducer-utils'
 
 const MD = MarkdownIt({ html: true }) // eslint-disable-line
@@ -153,6 +155,9 @@ const cellReducer = (state = newNotebook(), action) => {
       )
 
     case 'UPDATE_CELL_PROPERTIES':
+      if (checkForHighlightedCells(state)) {
+        return newStateWithPropsAssignedForHighlightedCells(state, action.updatedProperties)
+      }
       return newStateWithPropsAssignedForCell(state, action.cellId, action.updatedProperties)
 
     case 'UPDATE_INPUT_CONTENT':

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -58,7 +58,8 @@ const cellReducer = (state = newNotebook(), action) => {
       const cells = state.cells.slice()
       const index = cells.findIndex(c => c.id === action.id)
       const thisCell = cells[index]
-      thisCell.highlighted = !thisCell.highlighted
+      if (action.revert) thisCell.highlighted = !thisCell.highlighted
+      else thisCell.highlighted = true
       nextState = Object.assign({}, state, { cells })
       return nextState
     }

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -63,6 +63,41 @@ const cellReducer = (state = newNotebook(), action) => {
       return nextState
     }
 
+    case 'CELL_COPY': {
+      // Work on not copy at edit mode, clicking copy activated command mode
+      let copied
+      const cells = state.cells.slice()
+      copied = cells.filter(c => c.highlighted).map(c => c.id)
+      if (!copied.length) {
+        copied = [getSelectedCellId(state)]
+      }
+      return Object.assign({}, state, { copied })
+    }
+
+    case 'CELL_PASTE': {
+      if (state.copied.length === 0) {
+        return state
+      }
+      nextState = Object.assign({}, state)
+      const cellID = getSelectedCellId(state)
+      const cells = nextState.cells.slice()
+      const pasteIndex = cells.findIndex(c => c.id === cellID)
+      const newId = newCellID(cells)
+      const copiedCells = nextState.copied.map((id, i) => {
+        const copyIndex = cells.findIndex(c => c.id === id)
+        cells[copyIndex].highlighted = false
+        return Object.assign(
+          {},
+          cells[copyIndex],
+          { id: newId + i, selected: false },
+        )
+      })
+      cells.splice(pasteIndex + 1, 0, ...copiedCells)
+      // scrollToCellIfNeeded(newId + (copiedCells.length - 1))
+      nextState = Object.assign({}, nextState, { cells: [...cells], copied: [] })
+      return nextState
+    }
+
     case 'CELL_UP':
       scrollToCellIfNeeded(getSelectedCellId(state))
       return Object.assign(

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -45,11 +45,20 @@ const cellReducer = (state = newNotebook(), action) => {
 
     case 'SELECT_CELL': {
       const cells = state.cells.slice()
-      cells.forEach((c) => { c.selected = false })  // eslint-disable-line
+      cells.forEach((c) => { c.selected = false; c.highlighted = false; })  // eslint-disable-line
       const index = cells.findIndex(c => c.id === action.id)
       const thisCell = cells[index]
       thisCell.selected = true
       if (action.scrollToCell) { scrollToCellIfNeeded(thisCell.id) }
+      nextState = Object.assign({}, state, { cells })
+      return nextState
+    }
+
+    case 'HIGHLIGHT_CELL': {
+      const cells = state.cells.slice()
+      const index = cells.findIndex(c => c.id === action.id)
+      const thisCell = cells[index]
+      thisCell.highlighted = !thisCell.highlighted
       nextState = Object.assign({}, state, { cells })
       return nextState
     }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -57,6 +57,7 @@ function clearHistory(loadedState) {
   loadedState.userDefinedVarNames = []
   loadedState.history = []
   loadedState.externalDependencies = []
+  loadedState.copied = []
   loadedState.executionNumber = 0
   loadedState.cells = [...loadedState.cells.slice()]
   loadedState.cells.forEach((cell) => {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -57,7 +57,8 @@ function clearHistory(loadedState) {
   loadedState.userDefinedVarNames = []
   loadedState.history = []
   loadedState.externalDependencies = []
-  loadedState.copied = []
+  loadedState.copiedCells = []
+  loadedState.cutCells = []
   loadedState.executionNumber = 0
   loadedState.cells = [...loadedState.cells.slice()]
   loadedState.cells.forEach((cell) => {

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -53,6 +53,7 @@ const cellSchema = {
     value: {}, // empty schema, `value` can be anything
     rendered: { type: 'boolean' },
     selected: { type: 'boolean' },
+    highlighted: { type: 'boolean' },
     executionStatus: { type: 'string' },
     evalStatus: {
       type: 'string',
@@ -207,6 +208,7 @@ function newCell(cellId, cellType, language = 'js') {
     rendered: false,
     selected: false,
     asyncProcessCount: 0,
+    highlighted: false,
     executionStatus: ' ',
     evalStatus: 'UNEVALUATED',
     rowSettings: newCellRowSettings(cellType),

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -135,6 +135,7 @@ const stateSchema = {
       type: 'array',
       items: { type: 'string' },
     },
+    copied: { type: 'array' },
     savedEnvironment: {
       type: 'object',
       additionalProperties: environmentVariableSchema,
@@ -248,6 +249,7 @@ function blankState() {
     appMessages: [],
     autoSave: undefined,
     locallySaved: [],
+    copied: [],
     savedEnvironment: {},
     runningCellID: undefined,
   }

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -135,7 +135,14 @@ const stateSchema = {
       type: 'array',
       items: { type: 'string' },
     },
-    copied: { type: 'array' },
+    copiedCells: {
+      type: 'array',
+      items: cellSchema,
+    },
+    cutCells: {
+      type: 'array',
+      items: cellSchema,
+    },
     savedEnvironment: {
       type: 'object',
       additionalProperties: environmentVariableSchema,
@@ -249,7 +256,8 @@ function blankState() {
     appMessages: [],
     autoSave: undefined,
     locallySaved: [],
-    copied: [],
+    copiedCells: [],
+    cutCells: [],
     savedEnvironment: {},
     runningCellID: undefined,
   }

--- a/src/style/cell-styles.css
+++ b/src/style/cell-styles.css
@@ -177,7 +177,7 @@ div.selected-cell {
 }
 
 div.highlighted-cell {
-  background: rgba(116, 185, 255,0.3);
+  background: rgba(116, 185, 255, 0.15);
 }
 
 div.highlighted-cell div.cell-row-container {

--- a/src/style/cell-styles.css
+++ b/src/style/cell-styles.css
@@ -11,7 +11,7 @@ div.cell-container {
   width: calc(100%);
   /* put the .cell-menu-container and .cell-row-container in a row */
   display: flex;
-  flex-direction: row; 
+  flex-direction: row;
 }
 
 /* These may need to be integrated into the presentation mode style sheets
@@ -23,7 +23,7 @@ div#cells.editor div.raw-dom-element {
 }
 
 div#cells.presentation div.cell-container {
-  margin: 0 auto; 
+  margin: 0 auto;
   outline: none;
   padding: 0px;
 }
@@ -174,6 +174,14 @@ div.selected-cell.editing-cell {
 
 div.selected-cell {
   outline: 2px solid #ccc;
+}
+
+div.highlighted-cell {
+  background: rgba(116, 185, 255,0.3);
+}
+
+div.highlighted-cell div.cell-row-container {
+  z-index: -1;
 }
 
 div.CodeMirror {


### PR DESCRIPTION
This PR adds two new features - Multiple selection and Copy-Paste. These features have been discussed at Issue #65 and Issue #433 

To select multiple cells hold down `Ctrl` or `⌘` key and click on the cells. Copy-Paste works with the standard key bindings.

<!---
@huboard:{"milestone_order":172.93514056697302}
-->
