### PR TITLE
Add support for importing ipynb files

### DIFF
--- a/src/tools/ipynb-import.js
+++ b/src/tools/ipynb-import.js
@@ -1,0 +1,87 @@
+function importIpynb(url, json) {
+  if (json.nbformat !== 4) {
+    throw new Error('Iodide can only import version 4 of the .ipynb format')
+  }
+
+  const title = url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'))
+
+  const { metadata, cells } = json;
+  const languageInfo = metadata.language_info;
+  if (languageInfo.name !== 'python') {
+    throw new Error(`Ioside can only import Python .ipynb notebooks at this time.  Found ${languageInfo.name}.`)
+  }
+
+  let jsmd = `
+%% meta
+{
+  "title": "${title}",
+  "languages": {
+    "js": {
+      "pluginType": "language",
+      "languageId": "js",
+      "displayName": "Javascript",
+      "codeMirrorMode": "javascript",
+      "module": "window",
+      "evaluator": "eval",
+      "keybinding": "j",
+      "url": ""
+    },
+    "py": {
+      "languageId": "py",
+      "displayName": "python",
+      "codeMirrorMode": "python",
+      "keybinding": "p",
+      "url": "https://iodide-project.github.io/pyodide-demo/pyodide.js",
+      "module": "pyodide",
+      "evaluator": "runPython",
+      "pluginType": "language"
+    }
+  },
+  "lastExport": "${new Date().toISOString()}"
+}
+
+%% md
+
+Imported automatically from [${url}](${encodeURI(url)}).
+
+Support for importing Jupyter notebooks into Iodide is experimental.  In particular, the following things are known not to work:
+
+- IPython magics (lines starting with \`%\`)
+
+%% plugin
+{
+  "languageId": "py",
+  "displayName": "python",
+  "codeMirrorMode": "python",
+  "keybinding": "p",
+  "url": "https://iodide-project.github.io/pyodide-demo/pyodide.js",
+  "module": "pyodide",
+  "evaluator": "runPython",
+  "pluginType": "language"
+}
+
+%% js
+pyodide.loadPackage('matplotlib')
+`;
+
+  cells.forEach((cell) => {
+    if (cell.cell_type === 'markdown') {
+      jsmd += '\n%% md\n\n'
+    } else if (cell.cell_type === 'code') {
+      jsmd += '\n%% code {"language":"py"}\n\n'
+    }
+    cell.source.forEach((line) => {
+      jsmd += line
+    })
+  })
+
+  // Set the base URL of the page to the url of the source document, so links to
+  // image content in markdown will work.
+  const base = document.createElement('base')
+  base.href = url
+  document.body.appendChild(base)
+
+  return jsmd
+}
+
+export { importIpynb };


### PR DESCRIPTION
To try this out, try appending to the URL:

`?ipynb=https://raw.githubusercontent.com/mdboom/strata-mpl-tutorial/master/Introduction%20to%20matplotlib.ipynb`

Eventually, we'll want a UI for this (and to send the errors somewhere other than the console), but I think this is good enough for demo purposes.

~~Note that the linked notebook revealed a bug in pyodide, in that the matplotlib figure isn't updated automatically when parameters are changed after it's created (see https://github.com/iodide-project/pyodide/issues/46), but if you force a refresh by panning and zooming you should be fine.  I think that bug will be easy to fix in short time anyway.~~