### PR TITLE
Array / String fixes

### DIFF
--- a/src/components/reps/array-handler.jsx
+++ b/src/components/reps/array-handler.jsx
@@ -50,7 +50,7 @@ export default {
       )
     }
     return (
-      <div>
+      <div className="array-rep">
         <div className="data-set-info">{dataSetInfo}</div>
         <div>
             [{arrayElements}]

--- a/src/components/reps/null-handler.jsx
+++ b/src/components/reps/null-handler.jsx
@@ -3,5 +3,5 @@ import React from 'react'
 export default {
   shouldHandle: value => (value === null),
 
-  render: () => <pre>null</pre>,
+  render: () => <pre className="null-rep">null</pre>,
 }

--- a/src/components/reps/undefined-handler.jsx
+++ b/src/components/reps/undefined-handler.jsx
@@ -2,5 +2,5 @@ import React from 'react'
 
 export default {
   shouldHandle: value => value === undefined,
-  render: () => <pre>undefined</pre>,
+  render: () => <pre className="undefined-rep">undefined</pre>,
 }

--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -113,7 +113,7 @@ export class ValueRenderer extends React.Component {
     const value = this.props.valueToRender
     const resultElem = renderValue(value)
     if (resultElem !== undefined) {
-      return resultElem
+      return <div className="rep-container">{resultElem}</div>
     }
     return <div className="empty-resultset" />
   }

--- a/src/style/cell-styles.css
+++ b/src/style/cell-styles.css
@@ -199,8 +199,9 @@ div.SCROLL div.main-component div.CodeMirror div.CodeMirror-scroll {
 div.SCROLL.output .main-component {
   max-height: 300px;
   outline: 1px solid #ddd;
-    overflow-y: scroll;
+  overflow-y: scroll;
 }
+
 
 
 /* FIX ME i think this style is never used, double check it*/

--- a/src/style/page.css
+++ b/src/style/page.css
@@ -50,8 +50,12 @@ div#cells.presentation {
 /************************************************/
 /* cell output styles */
 
+.rep-container {
+  overflow-x: auto;
+}
+
 .array-rep {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .data-set-info {

--- a/src/style/page.css
+++ b/src/style/page.css
@@ -94,7 +94,7 @@ div.promise-handler-value {
   margin-top:6px;
 }
 
-.undefined-rep {
+.undefined-rep, .null-rep {
   display: inline-block;
 }
 

--- a/src/style/page.css
+++ b/src/style/page.css
@@ -50,6 +50,10 @@ div#cells.presentation {
 /************************************************/
 /* cell output styles */
 
+.array-rep {
+  overflow-x: scroll;
+}
+
 .data-set-info {
   color: #888;
   font-style: italic;

--- a/src/style/page.css
+++ b/src/style/page.css
@@ -94,6 +94,10 @@ div.promise-handler-value {
   margin-top:6px;
 }
 
+.undefined-rep {
+  display: inline-block;
+}
+
 /************************************************/
 /* header bar styles */
 


### PR DESCRIPTION
This PR addresses a number of issues with our current reps w/ arrays & strings surfaced in #623:

- A single, very long string will no longer cause overflow issues, because all reps are top-level wrapped in a div with `overflow-x: auto`.
- Arrays full of long strings now have their overflow issues in particular fixed.
- `undefined` and `null` are no longer  block-level elements, so when expressed in arrays, they will not be new lines

try this with `?gist=hamilton/7b7f1f87778d9180ef53a2e60d9b9bb5`