### PR TITLE
language plugin load now applies syntax highlighting to all language cells

### DIFF
--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -197,7 +197,9 @@ class CellEditor extends React.Component {
 function mapStateToProps(state, ownProps) {
   const { cellId } = ownProps
   const cell = getCellById(state.cells, cellId)
-  const languageModule = state.languages[cell.language].module
+  const languageModule = cell.language in state.languages ?
+    state.languages[cell.language].module : null
+
   const codeMirrorMode = (
     cell.cellType === 'code' ? state.languages[cell.language].codeMirrorMode : cell.cellType
   )

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -85,6 +85,7 @@ class CellEditor extends React.Component {
     cellType: PropTypes.string,
     content: PropTypes.string,
     viewMode: PropTypes.oneOf(['editor', 'presentation']),
+    languageIsAvailable: PropTypes.bool,
     actions: PropTypes.shape({
       selectCell: PropTypes.func.isRequired,
       changeMode: PropTypes.func.isRequired,
@@ -159,8 +160,8 @@ class CellEditor extends React.Component {
   }
 
   render() {
-    const editorOptions = Object.assign({
-      mode: this.props.codeMirrorMode,
+    const editorOptions = Object.assign({}, {
+      mode: this.props.languageIsAvailable ? this.props.codeMirrorMode : '',
       lineWrapping: false,
       matchBrackets: true,
       autoCloseBrackets: true,
@@ -196,9 +197,11 @@ class CellEditor extends React.Component {
 function mapStateToProps(state, ownProps) {
   const { cellId } = ownProps
   const cell = getCellById(state.cells, cellId)
+  const languageModule = state.languages[cell.language].module
   const codeMirrorMode = (
     cell.cellType === 'code' ? state.languages[cell.language].codeMirrorMode : cell.cellType
   )
+
   return {
     thisCellBeingEdited: cell.selected && state.mode === 'edit',
     viewMode: state.viewMode,
@@ -206,6 +209,7 @@ function mapStateToProps(state, ownProps) {
     content: cell.content,
     cellId,
     codeMirrorMode,
+    languageIsAvailable: cell.cellType !== 'code' ? true : window[languageModule] !== undefined,
   }
 }
 

--- a/src/components/reps/promise-handler.jsx
+++ b/src/components/reps/promise-handler.jsx
@@ -10,18 +10,19 @@ export class PromiseRep extends React.Component {
       value: undefined,
       runTime: 0,
     }
-    this.state.promise = props.promise.then(
-      (val) => {
-        this.setState({ status: 'fulfilled', value: val })
-        return val
-      },
-      (val) => {
-        this.setState({ status: 'rejected', value: val })
-        return val
-      },
-    ).catch((e) => {
-      this.setState({ status: 'rejected', value: e })
-    })
+    this.state.promise = props.promise
+      .then(
+        (val) => {
+          this.setState({ status: 'fulfilled', value: val })
+          return val
+        },
+        (val) => {
+          this.setState({ status: 'rejected', value: val })
+          return val
+        },
+      ).catch((e) => {
+        this.setState({ status: 'rejected', value: e })
+      })
     const runTimer = setInterval(() => {
       if (this.state.status === 'pending') {
         this.setState({ runTime: this.state.runTime + 1 })


### PR DESCRIPTION
This fixes #563. The easiest way to check if a language has been added is to see if we have `window[languageModule]`. Saved notebooks with languages defined in the jsmd (like python) don't actually indicate if the language module is loaded yet, so you have to look for it. There is probably a smarter way of saving this information in the state so we don't have to do that. Either way, my approach changes a computed prop based on whether the module is present in `window`, which forces an update to the editor by changing the mode from `''` to `<language>`