### PR TITLE
iodide.file API

### DIFF
--- a/src/iodide-api/__test__/file.test.js
+++ b/src/iodide-api/__test__/file.test.js
@@ -19,12 +19,15 @@ const d9 = [
 const d10 = [
   { a: 10, b: { n: 1 } }, { a: 1, b: { n: 1000 } },
 ]
-
 const d11 = () => { console.log('this should break!') }
-
-// embedded fcns in array of objects?
 const d12 = [
   { a: 10, b: () => 100 }, { a: 20, b: () => 200 },
+]
+
+const d13 = undefined
+const d14 = null
+const d15 = [
+  { a: undefined, b: null }, { a: undefined, b: null },
 ]
 
 describe('toCSVString transformations', () => {
@@ -42,6 +45,9 @@ describe('toCSVString transformations', () => {
     expect(() => toCSVString(d11)).toThrow()
     // should functions be expressed w/ toString like this, or as [function Function] or whatver?
     expect(toCSVString(d12)).toBe(`a,b\r\n10,${d12[0].b.toString()}\r\n20,${d12[1].b.toString()}`)
+    expect(() => { toCSVString(d13) }).toThrow()
+    expect(() => { toCSVString(d14) }).toThrow()
+    expect(toCSVString(d15)).toBe('a,b\r\n,\r\n,') // is this right? should undefined / null be these empty things?
   })
 })
 

--- a/src/iodide-api/__test__/file.test.js
+++ b/src/iodide-api/__test__/file.test.js
@@ -1,0 +1,47 @@
+import { toCSVString } from '../file'
+
+const d1 = [1, 2, 3, 4, 5]
+const d2 = [new Date('2010-01-01'), new Date('2010-01-02')]
+const d3 = 'test string'
+const d4 = 10000000.234
+const d5 = new Int16Array([5, 3, 2, 1])
+const d6 = {
+  a: 1,
+  b: 2,
+}
+const d7 = [[1, 2, 3], [4, 5, 6]]
+const d8 = [
+  { a: 10, b: 20 }, { a: 1, b: 2 },
+]
+const d9 = [
+  { a: 10, b: new Date() }, { a: 1, b: new Date() },
+]
+const d10 = [
+  { a: 10, b: { n: 1 } }, { a: 1, b: { n: 1000 } },
+]
+
+const d11 = () => { console.log('this should break!') }
+
+// embedded fcns in array of objects?
+const d12 = [
+  { a: 10, b: () => 100 }, { a: 20, b: () => 200 },
+]
+
+describe('toCSVString transformations', () => {
+  it('transforms arrays of values', () => {
+    expect(toCSVString(d1)).toBe('1\r\n2\r\n3\r\n4\r\n5')
+    expect(toCSVString(d2)).toBe(`${d2[0].toString()}\r\n${d2[1].toString()}`)
+    expect(() => toCSVString(d3)).toThrow() // is this right?
+    expect(() => toCSVString(d4)).toThrow() // is this right?
+    expect(toCSVString(d5)).toBe('5\r\n3\r\n2\r\n1')
+    expect(() => toCSVString(d6)).toThrow()
+    expect(toCSVString(d7)).toBe('c1,c2,c3\r\n1,2,3\r\n4,5,6')
+    expect(toCSVString(d8)).toBe('a,b\r\n10,20\r\n1,2')
+    expect(toCSVString(d9)).toBe(`a,b\r\n10,${d9[0].b.toString()}\r\n1,${d9[1].b.toString()}`)
+    expect(toCSVString(d10)).toBe('a,b\r\n10,[object Object]\r\n1,[object Object]')
+    expect(() => toCSVString(d11)).toThrow()
+    // should functions be expressed w/ toString like this, or as [function Function] or whatver?
+    expect(toCSVString(d12)).toBe(`a,b\r\n10,${d12[0].b.toString()}\r\n20,${d12[1].b.toString()}`)
+  })
+})
+

--- a/src/iodide-api/api.js
+++ b/src/iodide-api/api.js
@@ -5,6 +5,7 @@ import { addOutputHandler } from '../components/reps/value-renderer'
 import { environment } from './environment'
 import { evalQueue } from './evalQueue'
 import { output } from './output'
+import { file } from './file'
 
 function getDataSync(url) {
   const re = new XMLHttpRequest()
@@ -19,6 +20,7 @@ export const iodide = {
   environment,
   evalQueue,
   output,
+  file,
 }
 
 export default iodide

--- a/src/iodide-api/file.js
+++ b/src/iodide-api/file.js
@@ -1,7 +1,7 @@
 import matrix from '../components/reps/matrix-handler'
 import dataframe from '../components/reps/dataframe-handler'
 import array from '../components/reps/array-handler'
-import { downloadResource } from '../tools/notebook-utils'
+import { downloadResource } from '../reducers/notebook-reducer'
 
 export function toCSVString(data, delimiter = ',', header = true) {
   let headerRow = ''

--- a/src/iodide-api/file.js
+++ b/src/iodide-api/file.js
@@ -1,0 +1,42 @@
+import matrix from '../components/reps/matrix-handler'
+import dataframe from '../components/reps/dataframe-handler'
+import array from '../components/reps/array-handler'
+import { downloadResource } from '../tools/notebook-utils'
+
+export function toCSVString(data, delimiter = ',', header = true) {
+  let headerRow = ''
+  let body = []
+  if (matrix.shouldHandle(data)) {
+    if (header) headerRow = `${data[0].map((d, i) => `c${i + 1}`)}\r\n`
+    body = data.map(r => r.join(delimiter))
+  } else if (dataframe.shouldHandle(data)) {
+    const keys = Object.keys(data[0])
+    if (header) headerRow = `${keys}\r\n`
+    body = data.map(row => `${keys.map(k => row[k]).join(delimiter)}`)
+  } else if (array.shouldHandle(data)) body = data
+  else throw Error('data is not in the correct format for csv export.')
+  return `${headerRow}${body.join('\r\n')}`
+}
+
+export function exportCSV(data, filename, delimiter = ',') {
+  const content = `data:text/csv;charset=utf-8,${encodeURIComponent(toCSVString(data, delimiter))}`
+  downloadResource(content, filename)
+}
+
+export function exportJSON(data, filename = undefined, level = 0) {
+  const out = JSON.stringify(data, null, level)
+  const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(out)}`
+  downloadResource(dataStr, filename)
+}
+
+export function exportRaw(data, filename = undefined) {
+  const blob = new Blob(data, { type: 'octet/stream' })
+  const url = window.URL.createObjectURL(blob)
+  downloadResource(url, filename)
+}
+
+export const file = {
+  exportJSON,
+  exportRaw,
+  exportCSV,
+}

--- a/src/iodide-api/file.js
+++ b/src/iodide-api/file.js
@@ -2,6 +2,11 @@ import matrix from '../components/reps/matrix-handler'
 import dataframe from '../components/reps/dataframe-handler'
 import array from '../components/reps/array-handler'
 import { downloadResource } from '../reducers/notebook-reducer'
+// THIS CAUSES SOME TESTS TO FAIL FOR SOME REASON.
+// TODO: investigate why having downloadResource in notebook-utils causes a test failure
+// in reducers/__tests__/notebook-reducer.test.js. No other test breaks because of
+// downloadResource being elsewhere.
+// import { downloadResource } from '../tools/notebook-utils'
 
 export function toCSVString(data, delimiter = ',', header = true) {
   let headerRow = ''

--- a/src/reducers/__tests__/notebook-reducer.test.js
+++ b/src/reducers/__tests__/notebook-reducer.test.js
@@ -1,3 +1,4 @@
+
 import notebookReducer from '../notebook-reducer'
 import { newNotebook, blankState, addNewCellToState } from '../../state-prototypes'
 import {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -6,11 +6,9 @@ import {
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
 
-import { downloadResource } from '../tools/notebook-utils'
-
 const AUTOSAVE = 'AUTOSAVE: '
 
-function getSavedNotebooks() {
+export function getSavedNotebooks() {
   const autoSave = Object.keys(localStorage).filter(n => n.includes(AUTOSAVE))[0]
   const locallySaved = Object.keys(localStorage).filter(n => !n.includes(AUTOSAVE))
   locallySaved.sort((a, b) => {
@@ -26,6 +24,13 @@ function getSavedNotebooks() {
     autoSave,
     locallySaved,
   }
+}
+
+export function downloadResource(dataStr, filename) {
+  const dlAnchorElem = document.getElementById('export-anchor')
+  dlAnchorElem.setAttribute('href', dataStr)
+  dlAnchorElem.setAttribute('download', filename)
+  dlAnchorElem.click()
 }
 
 function clearHistory(loadedState) {
@@ -239,7 +244,5 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
   }
 }
-
-export { getSavedNotebooks }
 
 export default notebookReducer

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -6,6 +6,8 @@ import {
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
 
+import { downloadResource } from '../tools/notebook-utils'
+
 const AUTOSAVE = 'AUTOSAVE: '
 
 function getSavedNotebooks() {
@@ -78,12 +80,8 @@ const notebookReducer = (state = newNotebook(), action) => {
         { viewMode: action.exportAsReport ? 'presentation' : 'editor' },
       )
       const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(exportJsmdBundle(exportState))}`
-      const dlAnchorElem = document.getElementById('export-anchor')
-      dlAnchorElem.setAttribute('href', dataStr)
       title = exportState.title === undefined ? 'new-notebook' : exportState.title
-      dlAnchorElem.setAttribute('download', titleToHtmlFilename(title))
-      dlAnchorElem.click()
-
+      downloadResource(dataStr, titleToHtmlFilename(title))
       return state
     }
 

--- a/src/tools/notebook-utils.js
+++ b/src/tools/notebook-utils.js
@@ -47,13 +47,6 @@ function getCellById(cells, cellID) {
   return thisCell
 }
 
-function downloadResource(dataStr, filename) {
-  const dlAnchorElem = document.getElementById('export-anchor')
-  dlAnchorElem.setAttribute('href', dataStr)
-  dlAnchorElem.setAttribute('download', filename)
-  dlAnchorElem.click()
-}
-
 function prettyDate(time) {
   const date = new Date(time)
   const diff = (((new Date()).getTime() - date.getTime()) / 1000)
@@ -89,6 +82,5 @@ export {
   getCellById,
   getCellBelowSelectedId, getCellAboveSelectedId,
   isCommandMode,
-  downloadResource,
   viewModeIsEditor, viewModeIsPresentation,
 }

--- a/src/tools/notebook-utils.js
+++ b/src/tools/notebook-utils.js
@@ -47,6 +47,13 @@ function getCellById(cells, cellID) {
   return thisCell
 }
 
+function downloadResource(dataStr, filename) {
+  const dlAnchorElem = document.getElementById('export-anchor')
+  dlAnchorElem.setAttribute('href', dataStr)
+  dlAnchorElem.setAttribute('download', filename)
+  dlAnchorElem.click()
+}
+
 function prettyDate(time) {
   const date = new Date(time)
   const diff = (((new Date()).getTime() - date.getTime()) / 1000)
@@ -82,5 +89,6 @@ export {
   getCellById,
   getCellBelowSelectedId, getCellAboveSelectedId,
   isCommandMode,
+  downloadResource,
   viewModeIsEditor, viewModeIsPresentation,
 }


### PR DESCRIPTION
This adds API calls around exporting variables / data to files (#627). For now, it supports exporting as CSV, JSON, and as a general blob. CSV export really is the trickiest, because the JSON / raw representation relies on the JS apis for those, and CSV we have to make up as we go. With that said, the tests I've written are primarily about the file representation of various types of objects.

I have some open questions:

- should `exportCSV` work fine with single strings, numbers, & other scalars? I have it set up so it throws if these are accepted, but I don't really know / don't have a strong feeling about this right now.
- should `exportCSV` not use the `.toString` representation of functions?
- I have broken out the downloading function from `notebook-reducer` into its own exported function. For some reason, however, when I put this new function in `notebook-utils`, one of the tests breaks, but only one. And I can't figure out why that'd be the case, since other tests utilize the function that breaks. It's baffling. SO I've kept this downloader function in `notebook-reducer.js` because it doesn't break that test.

<!---
@huboard:{"milestone_order":658.0658}
-->
