### PR TITLE
updated webpack urls for prod build to point to iodide.io, not iodide-project.github.io

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,10 +30,10 @@ module.exports = (env) => {
       } else {
         APP_VERSION_STRING = gitRev.branch()
       }
-      APP_PATH_STRING = 'https://iodide-project.github.io/master/'
+      APP_PATH_STRING = 'https://iodide.io/master/'
     } else {
       APP_VERSION_STRING = gitRev.tag()
-      APP_PATH_STRING = 'https://iodide-project.github.io/dist/'
+      APP_PATH_STRING = 'https://iodide.io/dist/'
     }
     CSS_PATH_STRING = APP_PATH_STRING
     plugins.push(new UglifyJSPlugin())


### PR DESCRIPTION
Not 100% sure if this is the right way to do this, but I figured it was, since `npm run build` outputs the thing that's served over in `iodide.io/master`. This is motivated by #644 - it turns out that urls with https don't like this cross domain resource fetching, so `iodide-project.github.io` resources don't work. Probably goes without saying we'll need https to work, since browsers often redirect there anyway in all sorts of scenarios.