### PR TITLE
Remove ctrl-e / ctrl-shift-e shortcuts for export

### DIFF
--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -256,16 +256,13 @@ tasks.saveNotebook = new UserTask({
 
 tasks.exportNotebook = new UserTask({
   title: 'Export Notebook',
-  keybindings: ['meta+e'],
-  displayKeybinding: `${commandKey()}+E`,
+  keybindings: ['ctrl+shift+e', 'meta+shift+e'],
+  displayKeybinding: `Shift+${commandKey()}+E`,
   callback() { dispatcher.exportNotebook() },
 })
 
 tasks.exportNotebookAsReport = new UserTask({
   title: 'Export Notebook as Report',
-  keybindings: ['meta+shift+e'],
-  displayKeybinding: `Shift+${commandKey()}+E`,
-  keybindingPrecondition: isCommandMode,
   callback() { dispatcher.exportNotebook(true, false) },
 })
 

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -256,14 +256,14 @@ tasks.saveNotebook = new UserTask({
 
 tasks.exportNotebook = new UserTask({
   title: 'Export Notebook',
-  keybindings: ['ctrl+e', 'meta+e'],
+  keybindings: ['meta+e'],
   displayKeybinding: `${commandKey()}+E`,
   callback() { dispatcher.exportNotebook() },
 })
 
 tasks.exportNotebookAsReport = new UserTask({
   title: 'Export Notebook as Report',
-  keybindings: ['ctrl+shift+e', 'meta+shift+e'],
+  keybindings: ['meta+shift+e'],
   displayKeybinding: `Shift+${commandKey()}+E`,
   keybindingPrecondition: isCommandMode,
   callback() { dispatcher.exportNotebook(true, false) },


### PR DESCRIPTION
They conflict with the browser binding for ctrl-e, which moves to the
end of line in a textbox (commonly used among emacs power users)