### PR TITLE
Enforce semi-colons in js and add them where missing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
   ],
   "extends": "airbnb",
   "rules": {
-    "semi": ["off"],
     // Restricting for..of seems pretty controversial, let's disable that.
     // See https://github.com/airbnb/javascript/issues/1271
     "no-restricted-syntax": ["off"],

--- a/src/actions/__tests__/actions.test.js
+++ b/src/actions/__tests__/actions.test.js
@@ -10,10 +10,10 @@ describe('temporarilySaveRunningCellID', () => {
 
 describe('updateAppMessages', () => {
   it('creates an object with a type: UPDATE_APP_MESSAGES and message payload', () => {
-    const message1 = { message: 'hello' }
+    const message1 = { message: 'hello' };
     expect(actions.updateAppMessages(message1).message.message).toEqual('hello');
     expect(actions.updateAppMessages(message1).message.details).toEqual('hello');
-    const message2 = { message: 'ok', details: '---', when: new Date().toString() }
+    const message2 = { message: 'ok', details: '---', when: new Date().toString() };
     expect(actions.updateAppMessages(message2).message.message).toEqual('ok');
     expect(actions.updateAppMessages(message2).message.details).toEqual('---');
     expect(actions.updateAppMessages(message2).message.when).toEqual(message2.when);

--- a/src/actions/__tests__/user-task.test.js
+++ b/src/actions/__tests__/user-task.test.js
@@ -1,67 +1,67 @@
-import UserTask, { TASK_ERRORS } from '../user-task'
+import UserTask, { TASK_ERRORS } from '../user-task';
 
 describe('Improperly instantiating a class should throw an Error', () => {
   it('should throw an error if you have not provided any arguments', () => {
-    expect(() => new UserTask()).toThrowError(TASK_ERRORS.argumentMustBeObject)
-  })
+    expect(() => new UserTask()).toThrowError(TASK_ERRORS.argumentMustBeObject);
+  });
 
   it('should throw an error if you have provided something other than an object', () => {
-    expect(() => new UserTask([1, 2, 3, 4, 5])).toThrowError(TASK_ERRORS.argumentMustBeObject)
-  })
+    expect(() => new UserTask([1, 2, 3, 4, 5])).toThrowError(TASK_ERRORS.argumentMustBeObject);
+  });
 
   it('should throw an error if you have provided a keybindingCallback but no keybindings', () => {
     expect(() => new UserTask({ keybindingCallback: () => {} }))
-      .toThrowError(TASK_ERRORS.noKeybindingsWithCallback)
-  })
-})
+      .toThrowError(TASK_ERRORS.noKeybindingsWithCallback);
+  });
+});
 
 describe('title element is required, and alternate title getters default to title', () => {
   it('should throw an error if you do not have a title', () => {
-    expect(() => new UserTask({ callback: () => {} })).toThrowError(TASK_ERRORS.noTitleSupplied)
-  })
+    expect(() => new UserTask({ callback: () => {} })).toThrowError(TASK_ERRORS.noTitleSupplied);
+  });
 
-  const nbName = 'test task'
-  const nbMenuTitle = 'TEST'
-  const nb1 = new UserTask({ title: nbName, menuTitle: nbMenuTitle, callback: () => {} })
-  const nb2 = new UserTask({ title: nbName, callback: () => {} })
+  const nbName = 'test task';
+  const nbMenuTitle = 'TEST';
+  const nb1 = new UserTask({ title: nbName, menuTitle: nbMenuTitle, callback: () => {} });
+  const nb2 = new UserTask({ title: nbName, callback: () => {} });
   it('should have the getter return the title element', () => {
-    expect(nb1.title).toBe(nbName)
-  })
+    expect(nb1.title).toBe(nbName);
+  });
   it('should allow menuTitle to be the set menuTitle, if present', () => {
-    expect(nb1.menuTitle).toBe(nbMenuTitle)
-  })
+    expect(nb1.menuTitle).toBe(nbMenuTitle);
+  });
   it('should default to default title if menuTitle was not declared', () => {
-    expect(nb2.menuTitle).toBe(nb2.title)
-  })
-})
+    expect(nb2.menuTitle).toBe(nb2.title);
+  });
+});
 
 describe('callbacks are functions', () => {
   it('should throw an error if there is no callback of any kind supplied', () => {
-    expect(() => new UserTask({ title: 'welp' })).toThrowError(TASK_ERRORS.noCallback)
-  })
+    expect(() => new UserTask({ title: 'welp' })).toThrowError(TASK_ERRORS.noCallback);
+  });
   it('should throw an error if the callback is not a function', () => {
-    expect(() => new UserTask({ title: 'welp', callback: 'uh-oh!' })).toThrowError(TASK_ERRORS.callbackIsNotFunction)
-  })
-})
+    expect(() => new UserTask({ title: 'welp', callback: 'uh-oh!' })).toThrowError(TASK_ERRORS.callbackIsNotFunction);
+  });
+});
 
 describe('keybindings and keybinding callbacks', () => {
   it('should throw an error if you have provided a keybindingCallback but no keybindings', () => {
     expect(() => new UserTask({ keybindingCallback: () => {} }))
-      .toThrowError(TASK_ERRORS.noKeybindingsWithCallback)
-  })
+      .toThrowError(TASK_ERRORS.noKeybindingsWithCallback);
+  });
   it('should throw an error if you did not pass in an array for keybindings', () => {
     expect(() => new UserTask({ keybindings: 'not an array', keybindingCallback: () => {}, title: 'whatever dude' }))
-      .toThrowError(TASK_ERRORS.keybindingsNotArray)
-  })
-  const nb1 = new UserTask({ title: 'ok1', keybindings: ['meta+s'], callback: () => {} })
+      .toThrowError(TASK_ERRORS.keybindingsNotArray);
+  });
+  const nb1 = new UserTask({ title: 'ok1', keybindings: ['meta+s'], callback: () => {} });
   it('should output an array for the keybinding', () => {
-    expect(nb1.keybindings).toBeInstanceOf(Array)
-  })
+    expect(nb1.keybindings).toBeInstanceOf(Array);
+  });
 
   it('should tell you if it has keybindings or not', (() => {
-    const nb3 = new UserTask({ title: 'okokok', callback: () => {} })
-    const nb4 = new UserTask({ title: 'ok2', keybindings: ['meta+s'], callback: () => {} })
-    expect(nb3.hasKeybinding()).toBe(false)
-    expect(nb4.hasKeybinding()).toBe(true)
-  }))
-})
+    const nb3 = new UserTask({ title: 'okokok', callback: () => {} });
+    const nb4 = new UserTask({ title: 'ok2', keybindings: ['meta+s'], callback: () => {} });
+    expect(nb3.hasKeybinding()).toBe(false);
+    expect(nb4.hasKeybinding()).toBe(true);
+  }));
+});

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -1,22 +1,22 @@
-import MarkdownIt from 'markdown-it'
-import MarkdownItKatex from 'markdown-it-katex'
-import MarkdownItAnchor from 'markdown-it-anchor'
+import MarkdownIt from 'markdown-it';
+import MarkdownItKatex from 'markdown-it-katex';
+import MarkdownItAnchor from 'markdown-it-anchor';
 
-import { exportJsmdBundle, titleToHtmlFilename } from '../tools/jsmd-tools'
-import { getCellById, isCommandMode } from '../tools/notebook-utils'
+import { exportJsmdBundle, titleToHtmlFilename } from '../tools/jsmd-tools';
+import { getCellById, isCommandMode } from '../tools/notebook-utils';
 import {
   addExternalDependency,
   getSelectedCell,
-} from '../reducers/cell-reducer-utils'
+} from '../reducers/cell-reducer-utils';
 
-import { waitForExplicitContinuationStatusResolution } from '../iodide-api/evalQueue'
+import { waitForExplicitContinuationStatusResolution } from '../iodide-api/evalQueue';
 
-import { addLanguageKeybinding } from '../keybindings'
+import { addLanguageKeybinding } from '../keybindings';
 
-let evaluationQueue = Promise.resolve()
+let evaluationQueue = Promise.resolve();
 
-const MD = MarkdownIt({ html: true })
-MD.use(MarkdownItKatex).use(MarkdownItAnchor)
+const MD = MarkdownIt({ html: true });
+MD.use(MarkdownItKatex).use(MarkdownItAnchor);
 
 const CodeMirror = require('codemirror') // eslint-disable-line
 
@@ -24,35 +24,35 @@ export function temporarilySaveRunningCellID(cellID) {
   return {
     type: 'TEMPORARILY_SAVE_RUNNING_CELL_ID',
     cellID,
-  }
+  };
 }
 
 export function updateAppMessages(messageObj) {
   //     message.when = (new Date()).toString()
   //     message.details, when, message.
-  const { message } = messageObj
-  let { details, when } = messageObj
-  if (when === undefined) when = new Date().toString()
-  if (details === undefined) details = message
+  const { message } = messageObj;
+  let { details, when } = messageObj;
+  if (when === undefined) when = new Date().toString();
+  if (details === undefined) details = message;
   return {
     type: 'UPDATE_APP_MESSAGES',
     message: { message, details, when },
-  }
+  };
 }
 
 export function importNotebook(newState) {
   return {
     type: 'IMPORT_NOTEBOOK',
     newState,
-  }
+  };
 }
 
 export function importFromURL(importedState) {
   return (dispatch) => {
-    dispatch(importNotebook(importedState))
-    dispatch(updateAppMessages({ message: 'Notebook successfully imported from URL.' }))
-    return Promise.resolve()
-  }
+    dispatch(importNotebook(importedState));
+    dispatch(updateAppMessages({ message: 'Notebook successfully imported from URL.' }));
+    return Promise.resolve();
+  };
 }
 
 export function exportNotebook(exportAsReport = false, exportToClipboard = false) {
@@ -60,68 +60,68 @@ export function exportNotebook(exportAsReport = false, exportToClipboard = false
     type: 'EXPORT_NOTEBOOK',
     exportAsReport,
     exportToClipboard,
-  }
+  };
 }
 
 export function saveNotebook(autosave = false) {
   return {
     type: 'SAVE_NOTEBOOK',
     autosave,
-  }
+  };
 }
 
 export function loadNotebook(title) {
   return {
     type: 'LOAD_NOTEBOOK',
     title,
-  }
+  };
 }
 
 export function deleteNotebook(title) {
   return {
     type: 'DELETE_NOTEBOOK',
     title,
-  }
+  };
 }
 
 export function newNotebook() {
   return {
     type: 'NEW_NOTEBOOK',
-  }
+  };
 }
 
 export function clearVariables() {
   return {
     type: 'CLEAR_VARIABLES',
-  }
+  };
 }
 
 export function changePageTitle(title) {
   return {
     type: 'CHANGE_PAGE_TITLE',
     title,
-  }
+  };
 }
 
 export function changeMode(mode) {
   return {
     type: 'CHANGE_MODE',
     mode,
-  }
+  };
 }
 
 export function setViewMode(viewMode) {
   return {
     type: 'SET_VIEW_MODE',
     viewMode,
-  }
+  };
 }
 
 export function updateInputContent(text) {
   return {
     type: 'UPDATE_INPUT_CONTENT',
     content: text,
-  }
+  };
 }
 
 export function changeCellType(cellType, language = 'js') {
@@ -131,9 +131,9 @@ export function changeCellType(cellType, language = 'js') {
         type: 'CHANGE_CELL_TYPE',
         cellType,
         language,
-      })
+      });
     }
-  }
+  };
 }
 
 export function appendToEvalHistory(cellId, content) {
@@ -141,7 +141,7 @@ export function appendToEvalHistory(cellId, content) {
     type: 'APPEND_TO_EVAL_HISTORY',
     cellId,
     content,
-  }
+  };
 }
 
 // note: this function is NOT EXPORTED. It is a private function meant
@@ -151,55 +151,55 @@ export function updateCellProperties(cellId, updatedProperties) {
     type: 'UPDATE_CELL_PROPERTIES',
     cellId,
     updatedProperties,
-  }
+  };
 }
 
 export function incrementExecutionNumber() {
   return {
     type: 'INCREMENT_EXECUTION_NUMBER',
-  }
+  };
 }
 export function updateUserVariables() {
   return {
     type: 'UPDATE_USER_VARIABLES',
-  }
+  };
 }
 
 
 function evaluateCodeCell(cell) {
   return (dispatch, getState) => {
     // this variable may get changed in eval.
-    const state = getState()
-    let output
-    let evalStatus
-    const code = cell.content
-    const languageModule = state.languages[cell.language].module
-    const { evaluator } = state.languages[cell.language]
+    const state = getState();
+    let output;
+    let evalStatus;
+    const code = cell.content;
+    const languageModule = state.languages[cell.language].module;
+    const { evaluator } = state.languages[cell.language];
     // this is one place where we have to directly mutate the DOM b/c we need
     // this to happen outside of React's update schedule. see also iodide-api/print.js
-    document.getElementById(`cell-${cell.id}-side-effect-target`).innerHTML = ''
-    dispatch(temporarilySaveRunningCellID(cell.id))
+    document.getElementById(`cell-${cell.id}-side-effect-target`).innerHTML = '';
+    dispatch(temporarilySaveRunningCellID(cell.id));
     try {
-      output = window[languageModule][evaluator](code)
+      output = window[languageModule][evaluator](code);
     } catch (e) {
-      output = e
-      evalStatus = 'ERROR'
+      output = e;
+      evalStatus = 'ERROR';
     }
     const updateCellAfterEvaluation = () => {
-      const cellProperties = { value: output, rendered: true }
-      if (evalStatus === 'ERROR') cellProperties.evalStatus = evalStatus
-      dispatch(updateCellProperties(cell.id, cellProperties))
-      dispatch(incrementExecutionNumber())
-      dispatch(appendToEvalHistory(cell.id, cell.content))
-      dispatch(updateUserVariables())
-    }
+      const cellProperties = { value: output, rendered: true };
+      if (evalStatus === 'ERROR') cellProperties.evalStatus = evalStatus;
+      dispatch(updateCellProperties(cell.id, cellProperties));
+      dispatch(incrementExecutionNumber());
+      dispatch(appendToEvalHistory(cell.id, cell.content));
+      dispatch(updateUserVariables());
+    };
 
     const evaluation = Promise.resolve()
       .then(updateCellAfterEvaluation)
       .then(waitForExplicitContinuationStatusResolution)
-      .then(() => dispatch(temporarilySaveRunningCellID(undefined)))
-    return evaluation
-  }
+      .then(() => dispatch(temporarilySaveRunningCellID(undefined)));
+    return evaluation;
+  };
 }
 
 function evaluateMarkdownCell(cell) {
@@ -210,23 +210,23 @@ function evaluateMarkdownCell(cell) {
       rendered: true,
       evalStatus: 'SUCCESS',
     },
-  ))
+  ));
 }
 
 function evaluateResourceCell(cell) {
   return (dispatch, getState) => {
-    const externalDependencies = [...getState().externalDependencies]
-    const dependencies = cell.content.split('\n').filter(d => d.trim().slice(0, 2) !== '//')
+    const externalDependencies = [...getState().externalDependencies];
+    const dependencies = cell.content.split('\n').filter(d => d.trim().slice(0, 2) !== '//');
     const newValues = dependencies
       .filter(d => !externalDependencies.includes(d))
-      .map(addExternalDependency)
+      .map(addExternalDependency);
 
     newValues.forEach((d) => {
       if (!externalDependencies.includes(d.src)) {
-        externalDependencies.push(d.src)
+        externalDependencies.push(d.src);
       }
-    })
-    const evalStatus = newValues.map(d => d.status).includes('error') ? 'ERROR' : 'SUCCESS'
+    });
+    const evalStatus = newValues.map(d => d.status).includes('error') ? 'ERROR' : 'SUCCESS';
     dispatch(updateCellProperties(
       cell.id,
       {
@@ -234,16 +234,16 @@ function evaluateResourceCell(cell) {
         rendered: true,
         evalStatus,
       },
-    ))
+    ));
     if (newValues.length) {
       dispatch(appendToEvalHistory(
         cell.id,
         `// added external dependencies:\n${newValues.map(s => `// ${s.src}`).join('\n')}`,
-      ))
+      ));
     }
-    dispatch(incrementExecutionNumber())
-    dispatch(updateUserVariables())
-  }
+    dispatch(incrementExecutionNumber());
+    dispatch(updateUserVariables());
+  };
 }
 
 function evaluateCSSCell(cell) {
@@ -255,55 +255,55 @@ function evaluateCSSCell(cell) {
         rendered: true,
         evalStatus: 'SUCCESS',
       },
-    ))
-  }
+    ));
+  };
 }
 
 export function addLanguage(languageDefinition) {
   return {
     type: 'ADD_LANGUAGE',
     languageDefinition,
-  }
+  };
 }
 
 function evaluateLanguagePluginCell(cell) {
   return (dispatch) => {
-    let pluginData
-    let value
-    let evalStatus
-    let languagePluginPromise
-    const rendered = true
+    let pluginData;
+    let value;
+    let evalStatus;
+    let languagePluginPromise;
+    const rendered = true;
     try {
-      pluginData = JSON.parse(cell.content)
+      pluginData = JSON.parse(cell.content);
     } catch (err) {
-      value = `plugin definition failed to parse:\n${err.message}`
-      evalStatus = 'ERROR'
+      value = `plugin definition failed to parse:\n${err.message}`;
+      evalStatus = 'ERROR';
     }
 
     if (pluginData.url === undefined) {
-      value = 'plugin definition missing "url"'
-      evalStatus = 'ERROR'
-      dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }))
+      value = 'plugin definition missing "url"';
+      evalStatus = 'ERROR';
+      dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }));
     } else {
       const {
         url, keybinding, languageId, displayName,
-      } = pluginData
+      } = pluginData;
 
       languagePluginPromise = new Promise((resolve, reject) => {
-        const xhrObj = new XMLHttpRequest()
+        const xhrObj = new XMLHttpRequest();
 
         xhrObj.addEventListener('progress', (evt) => {
-          value = `downloading plugin: ${evt.loaded} bytes loaded`
+          value = `downloading plugin: ${evt.loaded} bytes loaded`;
           if (evt.total > 0) {
-            value += `out of ${evt.total} (${evt.loaded / evt.total}%)`
+            value += `out of ${evt.total} (${evt.loaded / evt.total}%)`;
           }
-          evalStatus = 'ASYNC_PENDING'
-          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }))
-        })
+          evalStatus = 'ASYNC_PENDING';
+          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }));
+        });
 
         xhrObj.addEventListener('load', () => {
-          value = `${displayName} plugin downloaded, initializing`
-          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }))
+          value = `${displayName} plugin downloaded, initializing`;
+          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }));
           // see the following for asynchronous loading of scripts from strings:
           // https://developer.mozilla.org/en-US/docs/Games/Techniques/Async_scripts
 
@@ -312,12 +312,12 @@ function evaluateLanguagePluginCell(cell) {
           // But if it returns a Promise, then we can wait for that promise to resolve
           // before we continue execution.
           const pr = Promise.resolve(window
-            .eval(xhrObj.responseText)) // eslint-disable-line no-eval
+            .eval(xhrObj.responseText)); // eslint-disable-line no-eval
 
           pr.then(() => {
-            value = `${displayName} plugin ready`
-            evalStatus = 'SUCCESS'
-            dispatch(addLanguage(pluginData))
+            value = `${displayName} plugin ready`;
+            evalStatus = 'SUCCESS';
+            dispatch(addLanguage(pluginData));
             // FIXME: adding the keybinding move to a reducer ideally, but since it mutates
             // a part of global state in a snowflake sideffect-ish way, and since it
             // needs `dispatch` we'll do it here.
@@ -325,82 +325,82 @@ function evaluateLanguagePluginCell(cell) {
               addLanguageKeybinding(
                 [keybinding],
                 () => dispatch(changeCellType('code', languageId)),
-              )
+              );
             }
-            dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }))
-            resolve()
-          })
-        })
+            dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }));
+            resolve();
+          });
+        });
 
         xhrObj.addEventListener('error', () => {
-          value = `${displayName} plugin failed to load`
-          evalStatus = 'ERROR'
-          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }))
-          reject()
-        })
+          value = `${displayName} plugin failed to load`;
+          evalStatus = 'ERROR';
+          dispatch(updateCellProperties(cell.id, { value, evalStatus, rendered }));
+          reject();
+        });
 
-        xhrObj.open('GET', url, true)
-        xhrObj.send()
-        CodeMirror.requireMode(pluginData.codeMirrorMode, () => { })
-      })
+        xhrObj.open('GET', url, true);
+        xhrObj.send();
+        CodeMirror.requireMode(pluginData.codeMirrorMode, () => { });
+      });
     }
-    return languagePluginPromise
-  }
+    return languagePluginPromise;
+  };
 }
 
 export function evaluateCell(cellId) {
   return (dispatch, getState) => {
-    let evaluation
-    let cell
+    let evaluation;
+    let cell;
     if (cellId === undefined) {
-      cell = getSelectedCell(getState())
+      cell = getSelectedCell(getState());
     } else {
-      cell = getCellById(getState().cells, cellId)
+      cell = getCellById(getState().cells, cellId);
     }
     // here is where we should mark a cell as PENDING.
     if (cell.cellType === 'code') {
       evaluationQueue = evaluationQueue
-        .then(() => dispatch(evaluateCodeCell(cell)))
-      evaluation = evaluationQueue
+        .then(() => dispatch(evaluateCodeCell(cell)));
+      evaluation = evaluationQueue;
     } else if (cell.cellType === 'markdown') {
-      evaluation = dispatch(evaluateMarkdownCell(cell))
+      evaluation = dispatch(evaluateMarkdownCell(cell));
     } else if (cell.cellType === 'external dependencies') {
-      evaluation = dispatch(evaluateResourceCell(cell))
+      evaluation = dispatch(evaluateResourceCell(cell));
     } else if (cell.cellType === 'css') {
-      evaluation = dispatch(evaluateCSSCell(cell))
+      evaluation = dispatch(evaluateCSSCell(cell));
     } else if (cell.cellType === 'plugin') {
       if (JSON.parse(cell.content).pluginType === 'language') {
-        evaluationQueue = evaluationQueue.then(() => dispatch(evaluateLanguagePluginCell(cell)))
-        evaluation = evaluationQueue
+        evaluationQueue = evaluationQueue.then(() => dispatch(evaluateLanguagePluginCell(cell)));
+        evaluation = evaluationQueue;
       } else {
-        evaluation = dispatch(updateAppMessages({ message: 'No loader for plugin type or missing "pluginType" entry' }))
+        evaluation = dispatch(updateAppMessages({ message: 'No loader for plugin type or missing "pluginType" entry' }));
       }
     } else {
-      cell.rendered = false
+      cell.rendered = false;
     }
-    return evaluation
-  }
+    return evaluation;
+  };
 }
 
 export function evaluateAllCells(cells) {
   return (dispatch) => {
-    let p = Promise.resolve()
+    let p = Promise.resolve();
     cells.forEach((cell) => {
       if (cell.cellType === 'css' && !cell.skipInRunAll) {
-        p = p.then(() => dispatch(evaluateCell(cell.id)))
+        p = p.then(() => dispatch(evaluateCell(cell.id)));
       }
-    })
+    });
     cells.forEach((cell) => {
       if (cell.cellType === 'markdown' && !cell.skipInRunAll) {
-        p = p.then(() => dispatch(evaluateCell(cell.id)))
+        p = p.then(() => dispatch(evaluateCell(cell.id)));
       }
-    })
+    });
     cells.forEach((cell) => {
       if (cell.cellType !== 'markdown' && cell.cellType !== 'css' && !cell.skipInRunAll) {
-        p = p.then(() => dispatch(evaluateCell(cell.id)))
+        p = p.then(() => dispatch(evaluateCell(cell.id)));
       }
-    })
-  }
+    });
+  };
 }
 
 
@@ -411,13 +411,13 @@ export function setCellRowCollapsedState(viewMode, rowType, rowOverflow, cellId)
     rowType,
     rowOverflow,
     cellId,
-  }
+  };
 }
 
 export function markCellNotRendered() {
   return {
     type: 'MARK_CELL_NOT_RENDERED',
-  }
+  };
 }
 
 function loginSuccess(userData) {
@@ -425,31 +425,31 @@ function loginSuccess(userData) {
     dispatch({
       type: 'LOGIN_SUCCESS',
       userData,
-    })
-    dispatch(updateAppMessages({ message: 'You are logged in' }))
-  }
+    });
+    dispatch(updateAppMessages({ message: 'You are logged in' }));
+  };
 }
 
 function loginFailure() {
   return (dispatch) => {
-    dispatch(updateAppMessages({ message: 'Login Failed' }))
-  }
+    dispatch(updateAppMessages({ message: 'Login Failed' }));
+  };
 }
 
 export function login() {
-  const url = '/auth/github'
-  const name = 'github_login'
-  const specs = 'width=500,height=600'
-  const authWindow = window.open(url, name, specs)
-  authWindow.focus()
+  const url = '/auth/github';
+  const name = 'github_login';
+  const specs = 'width=500,height=600';
+  const authWindow = window.open(url, name, specs);
+  authWindow.focus();
 
   return (dispatch) => {
     // Functions to be called by child window
     window.loginSuccess = (userData) => {
-      dispatch(loginSuccess(userData))
-    }
-    window.loginFailure = () => dispatch(loginFailure())
-  }
+      dispatch(loginSuccess(userData));
+    };
+    window.loginFailure = () => dispatch(loginFailure());
+  };
 }
 
 export function logout() {
@@ -458,11 +458,11 @@ export function logout() {
       .then(response => response.json())
       .then((json) => {
         if (json.status === 'success') {
-          dispatch({ type: 'LOGOUT' })
-          dispatch(updateAppMessages({ message: 'Logged Out' }))
-        } else dispatch(updateAppMessages({ message: 'Logout Failed' }))
-      })
-  }
+          dispatch({ type: 'LOGOUT' });
+          dispatch(updateAppMessages({ message: 'Logged Out' }));
+        } else dispatch(updateAppMessages({ message: 'Logout Failed' }));
+      });
+  };
 }
 
 export function exportGist() {
@@ -470,12 +470,12 @@ export function exportGist() {
   // Match the discription and fileName for each gist
   // If mactch found, update it
   // If none found then create a new Gist
-  const API_ROUTE = 'https://api.github.com'
+  const API_ROUTE = 'https://api.github.com';
   return (dispatch, getState) => {
-    const state = getState()
-    const filename = titleToHtmlFilename(state.title)
-    let matchDescription
-    let gistCreated = false
+    const state = getState();
+    const filename = titleToHtmlFilename(state.title);
+    let matchDescription;
+    let gistCreated = false;
     const gistData = {
       description: state.title,
       public: true,
@@ -489,43 +489,43 @@ export function exportGist() {
         matchDescription = json.filter(gist =>
           gist.description === gistData.description &&
           Object.keys(gist.files).length === 1 &&
-          Object.keys(gist.files)[0] === filename)
+          Object.keys(gist.files)[0] === filename);
 
         if (!matchDescription.length) {
           return fetch(`${API_ROUTE}/gists?access_token=${state.userData.accessToken}`, {
             body: JSON.stringify(gistData),
             method: 'POST',
-          })
+          });
         }
-        gistCreated = true
-        const gistID = matchDescription[0].id
+        gistCreated = true;
+        const gistID = matchDescription[0].id;
         return fetch(`${API_ROUTE}/gists/${gistID}?access_token=${state.userData.accessToken}`, {
           body: JSON.stringify(gistData),
           method: 'PATCH',
-        })
+        });
       })
       .then(response => response.json())
       .then((json) => {
-        const message = gistCreated ? 'Updated Gist' : 'Exported to GitHub Gist'
+        const message = gistCreated ? 'Updated Gist' : 'Exported to GitHub Gist';
         dispatch(updateAppMessages({
           message,
           details: `${message}<br /><a href="${json.html_url}" target="_blank">Gist</a> -
         <a href="https://iodide-project.github.io/master/?gist=${json.owner.login}/${json.id}" target="_blank"> Runnable notebook</a>`,
-        }))
-      })
-  }
+        }));
+      });
+  };
 }
 
 export function cellUp() {
   return {
     type: 'CELL_UP',
-  }
+  };
 }
 
 export function cellDown() {
   return {
     type: 'CELL_DOWN',
-  }
+  };
 }
 
 export function insertCell(cellType, direction) {
@@ -533,14 +533,14 @@ export function insertCell(cellType, direction) {
     type: 'INSERT_CELL',
     cellType,
     direction,
-  }
+  };
 }
 
 export function addCell(cellType) {
   return {
     type: 'ADD_CELL',
     cellType,
-  }
+  };
 }
 
 export function selectCell(cellID, scrollToCell = false) {
@@ -548,54 +548,54 @@ export function selectCell(cellID, scrollToCell = false) {
     type: 'SELECT_CELL',
     id: cellID,
     scrollToCell,
-  }
+  };
 }
 
 export function deleteCell() {
   return {
     type: 'DELETE_CELL',
-  }
+  };
 }
 
 export function changeElementType(elementType) {
   return {
     type: 'CHANGE_ELEMENT_TYPE',
     elementType,
-  }
+  };
 }
 
 export function changeDOMElementID(elemID) {
   return {
     type: 'CHANGE_DOM_ELEMENT_ID',
     elemID,
-  }
+  };
 }
 
 export function changeSidePaneMode(mode) {
   return {
     type: 'CHANGE_SIDE_PANE_MODE',
     mode,
-  }
+  };
 }
 
 export function changeSidePaneWidth(widthShift) {
   return {
     type: 'CHANGE_SIDE_PANE_WIDTH',
     widthShift,
-  }
+  };
 }
 
 export function setCellSkipInRunAll(value) {
   return (dispatch, getState) => {
-    let setValue = value
+    let setValue = value;
     if (setValue === undefined) {
-      setValue = !getSelectedCell(getState()).skipInRunAll
+      setValue = !getSelectedCell(getState()).skipInRunAll;
     }
     dispatch(updateCellProperties(
       getSelectedCell(getState()).id,
       { skipInRunAll: setValue },
-    ))
-  }
+    ));
+  };
 }
 
 export function saveEnvironment(updateObj, update) {
@@ -603,5 +603,5 @@ export function saveEnvironment(updateObj, update) {
     type: 'SAVE_ENVIRONMENT',
     updateObj,
     update,
-  }
+  };
 }

--- a/src/actions/external-link-task.js
+++ b/src/actions/external-link-task.js
@@ -1,28 +1,28 @@
-import UserTask from './user-task'
+import UserTask from './user-task';
 // is this the right way to compose?
 export default class VisitExternalLink {
   constructor(args) {
-    const combinedArgs = Object.assign(args, { callback() { window.open(args.url, '_blank') } })
-    this.userTask = new UserTask(combinedArgs)
+    const combinedArgs = Object.assign(args, { callback() { window.open(args.url, '_blank'); } });
+    this.userTask = new UserTask(combinedArgs);
   }
 
   get title() {
-    return this.userTask.title
+    return this.userTask.title;
   }
 
   get menuTitle() {
-    return this.userTask.menuTitle
+    return this.userTask.menuTitle;
   }
 
   get callback() {
-    return this.userTask.callback
+    return this.userTask.callback;
   }
 
   get keybindingCallack() {
-    return this.userTask.keybindingCallback
+    return this.userTask.keybindingCallback;
   }
 
   hasKeybinding() {
-    return this.userTask.hasKeybinding()
+    return this.userTask.hasKeybinding();
   }
 }

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -1,72 +1,72 @@
-import UserTask from './user-task'
-import ExternalLinkTask from './external-link-task'
-import { store } from '../store'
-import * as actions from './actions'
+import UserTask from './user-task';
+import ExternalLinkTask from './external-link-task';
+import { store } from '../store';
+import * as actions from './actions';
 import {
   isCommandMode,
   viewModeIsEditor,
   getCells,
   getCellBelowSelectedId,
   getCellAboveSelectedId, prettyDate, formatDateString,
-} from '../tools/notebook-utils'
-import { stateFromJsmd } from '../tools/jsmd-tools'
+} from '../tools/notebook-utils';
+import { stateFromJsmd } from '../tools/jsmd-tools';
 
-const dispatcher = {}
+const dispatcher = {};
 for (const action in actions) {
   if (Object.prototype.hasOwnProperty.call(actions, action)) {
-    dispatcher[action] = (...params) => (store.dispatch(actions[action](...params)))
+    dispatcher[action] = (...params) => (store.dispatch(actions[action](...params)));
   }
 }
 
-const oscpu = window.navigator.oscpu || window.navigator.platform
-let OSName = 'Unknown OS'
-if (oscpu.indexOf('Win') !== -1) OSName = 'Windows'
-if (oscpu.indexOf('Mac') !== -1) OSName = 'MacOS'
-if (oscpu.indexOf('X11') !== -1) OSName = 'UNIX'
-if (oscpu.indexOf('Linux') !== -1) OSName = 'Linux'
+const oscpu = window.navigator.oscpu || window.navigator.platform;
+let OSName = 'Unknown OS';
+if (oscpu.indexOf('Win') !== -1) OSName = 'Windows';
+if (oscpu.indexOf('Mac') !== -1) OSName = 'MacOS';
+if (oscpu.indexOf('X11') !== -1) OSName = 'UNIX';
+if (oscpu.indexOf('Linux') !== -1) OSName = 'Linux';
 
-const commandKey = () => (OSName === 'MacOS' ? '⌘' : 'Ctrl')
+const commandKey = () => (OSName === 'MacOS' ? '⌘' : 'Ctrl');
 
-const tasks = {}
+const tasks = {};
 
 tasks.evaluateCell = new UserTask({
   title: 'Run Cell',
   keybindings: ['mod+enter'],
 
   callback() {
-    dispatcher.changeMode('command')
-    dispatcher.saveNotebook(true)
-    dispatcher.evaluateCell()
+    dispatcher.changeMode('command');
+    dispatcher.saveNotebook(true);
+    dispatcher.evaluateCell();
   },
-})
+});
 
 tasks.evaluateAllCells = new UserTask({
   title: 'Run All Cells',
   menuTitle: 'Run All Cells',
   callback() {
-    dispatcher.saveNotebook(true)
-    dispatcher.evaluateAllCells(getCells(), store)
+    dispatcher.saveNotebook(true);
+    dispatcher.evaluateAllCells(getCells(), store);
   },
-})
+});
 
 tasks.evaluateCellAndSelectBelow = new UserTask({
   title: 'Evaluate Cell and Select Below',
   keybindings: ['shift+enter'],
   keybindingPrecondition: viewModeIsEditor,
   callback() {
-    dispatcher.changeMode('command')
-    dispatcher.saveNotebook(true)
-    dispatcher.evaluateCell()
-    const cellBelowId = getCellBelowSelectedId()
+    dispatcher.changeMode('command');
+    dispatcher.saveNotebook(true);
+    dispatcher.evaluateCell();
+    const cellBelowId = getCellBelowSelectedId();
     if (cellBelowId !== null) {
-      dispatcher.selectCell(cellBelowId, true)
+      dispatcher.selectCell(cellBelowId, true);
     } else {
     // if cellBelowId *is* null, need to add a new cell.
-      dispatcher.addCell('code')
-      dispatcher.selectCell(getCellBelowSelectedId(), true)
+      dispatcher.addCell('code');
+      dispatcher.selectCell(getCellBelowSelectedId(), true);
     }
   },
-})
+});
 
 tasks.moveCellUp = new UserTask({
   title: 'Move Cell Up',
@@ -75,9 +75,9 @@ tasks.moveCellUp = new UserTask({
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
-    dispatcher.cellUp()
+    dispatcher.cellUp();
   },
-})
+});
 
 
 tasks.moveCellDown = new UserTask({
@@ -87,24 +87,24 @@ tasks.moveCellDown = new UserTask({
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
-    dispatcher.cellDown()
+    dispatcher.cellDown();
   },
-})
+});
 
 tasks.loginGithub = new UserTask({
   title: 'Login using GitHub',
-  callback() { dispatcher.login() },
-})
+  callback() { dispatcher.login(); },
+});
 
 tasks.logoutGithub = new UserTask({
   title: 'Logout',
-  callback() { dispatcher.logout() },
-})
+  callback() { dispatcher.logout(); },
+});
 
 tasks.exportGist = new UserTask({
   title: 'Export Gist',
-  callback() { dispatcher.exportGist() },
-})
+  callback() { dispatcher.exportGist(); },
+});
 
 tasks.selectUp = new UserTask({
   title: 'Select Cell Above',
@@ -113,10 +113,10 @@ tasks.selectUp = new UserTask({
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
-    const cellAboveId = getCellAboveSelectedId()
-    if (cellAboveId !== null) { dispatcher.selectCell(cellAboveId, true) }
+    const cellAboveId = getCellAboveSelectedId();
+    if (cellAboveId !== null) { dispatcher.selectCell(cellAboveId, true); }
   },
-})
+});
 
 tasks.selectDown = new UserTask({
   title: 'Select Cell Down',
@@ -125,10 +125,10 @@ tasks.selectDown = new UserTask({
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
-    const cellBelowId = getCellBelowSelectedId()
-    if (cellBelowId !== null) { dispatcher.selectCell(cellBelowId, true) }
+    const cellBelowId = getCellBelowSelectedId();
+    if (cellBelowId !== null) { dispatcher.selectCell(cellBelowId, true); }
   },
-})
+});
 
 tasks.addCellAbove = new UserTask({
   title: 'Add Cell Above',
@@ -136,10 +136,10 @@ tasks.addCellAbove = new UserTask({
   displayKeybinding: 'A',
   keybindingPrecondition: isCommandMode,
   callback() {
-    dispatcher.insertCell('code', 'above')
-    dispatcher.selectCell(getCellAboveSelectedId(), true)
+    dispatcher.insertCell('code', 'above');
+    dispatcher.selectCell(getCellAboveSelectedId(), true);
   },
-})
+});
 
 tasks.addCellBelow = new UserTask({
   title: 'Add Cell Below',
@@ -148,18 +148,18 @@ tasks.addCellBelow = new UserTask({
   keybindingPrecondition: isCommandMode,
 
   callback() {
-    dispatcher.insertCell('code', 'below')
-    dispatcher.selectCell(getCellBelowSelectedId(), true)
+    dispatcher.insertCell('code', 'below');
+    dispatcher.selectCell(getCellBelowSelectedId(), true);
   },
-})
+});
 
 tasks.deleteCell = new UserTask({
   title: 'Delete Cell',
   keybindings: ['shift+backspace'],
   displayKeybinding: 'Shift+Backspace', // '\u21E7 \u232b',
   keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.deleteCell() },
-})
+  callback() { dispatcher.deleteCell(); },
+});
 
 tasks.changeToJavascriptCell = new UserTask({
   title: 'Change to Javascript',
@@ -167,9 +167,9 @@ tasks.changeToJavascriptCell = new UserTask({
   displayKeybinding: 'J',
   keybindingPrecondition: isCommandMode,
   callback() {
-    dispatcher.changeCellType('code', 'js')
+    dispatcher.changeCellType('code', 'js');
   },
-})
+});
 
 tasks.changeToMarkdownCell = new UserTask({
   title: 'Change to Markdown',
@@ -177,9 +177,9 @@ tasks.changeToMarkdownCell = new UserTask({
   displayKeybinding: 'M',
   keybindingPrecondition: isCommandMode,
   callback() {
-    dispatcher.changeCellType('markdown')
+    dispatcher.changeCellType('markdown');
   },
-})
+});
 
 tasks.changeToExternalResourceCell = new UserTask({
   title: 'Change to External Resource',
@@ -187,51 +187,51 @@ tasks.changeToExternalResourceCell = new UserTask({
   displayKeybinding: 'E',
   keybindingPrecondition: isCommandMode,
   callback() {
-    dispatcher.changeCellType('external dependencies')
+    dispatcher.changeCellType('external dependencies');
   },
-})
+});
 
 tasks.changeToRawCell = new UserTask({
   title: 'Change to Raw',
   keybindings: ['r'],
   displayKeybinding: 'R',
   keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.changeCellType('raw') },
-})
+  callback() { dispatcher.changeCellType('raw'); },
+});
 
 tasks.changeToCSSCell = new UserTask({
   title: 'Change to CSS',
   keybindings: ['c'],
   displayKeybinding: 'C',
   keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.changeCellType('css') },
-})
+  callback() { dispatcher.changeCellType('css'); },
+});
 
 tasks.changeToPluginCell = new UserTask({
   title: 'Change to Plugin Loader',
   keybindings: ['l'],
   displayKeybinding: 'L',
   keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.changeCellType('plugin') },
-})
+  callback() { dispatcher.changeCellType('plugin'); },
+});
 
 tasks.toggleSkipCellInRunAll = new UserTask({
   title: 'Toggle Skipping Cell in Run All',
   keybindings: ['s'],
   displayKeybinding: 'S',
   keybindingPrecondition: isCommandMode,
-  callback() { dispatcher.setCellSkipInRunAll() },
-})
+  callback() { dispatcher.setCellSkipInRunAll(); },
+});
 
 tasks.changeMode = new UserTask({
   title: 'Change Mode',
-  callback(mode) { dispatcher.changeMode(mode) },
-})
+  callback(mode) { dispatcher.changeMode(mode); },
+});
 
 tasks.changeToMenuMode = new UserTask({
   title: 'Change to Menu Mode',
-  callback() { dispatcher.changeMode('title-edit') },
-})
+  callback() { dispatcher.changeMode('title-edit'); },
+});
 
 tasks.changeToEditMode = new UserTask({
   title: 'Change to Edit Mode',
@@ -239,65 +239,65 @@ tasks.changeToEditMode = new UserTask({
   displayKeybinding: 'Enter',
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
-  callback() { dispatcher.changeMode('edit') },
-})
+  callback() { dispatcher.changeMode('edit'); },
+});
 
 tasks.changeToCommandMode = new UserTask({
   title: 'Change to Command Mode',
   keybindings: ['esc'],
   preventDefaultKeybinding: true,
-  callback() { dispatcher.changeMode('command') },
-})
+  callback() { dispatcher.changeMode('command'); },
+});
 
 tasks.changeTitle = new UserTask({
   title: 'Change Title',
-  callback(t) { dispatcher.changePageTitle(t) },
-})
+  callback(t) { dispatcher.changePageTitle(t); },
+});
 
 tasks.createNewNotebook = new UserTask({
   title: 'New Notebook',
   preventDefaultKeybinding: true,
-  callback() { dispatcher.newNotebook() },
-})
+  callback() { dispatcher.newNotebook(); },
+});
 
 tasks.saveNotebook = new UserTask({
   title: 'Save Notebook',
   keybindings: ['ctrl+s', 'meta+s'],
   displayKeybinding: `${commandKey()}+S`,
   preventDefaultKeybinding: true,
-  callback() { dispatcher.saveNotebook() },
-})
+  callback() { dispatcher.saveNotebook(); },
+});
 
 tasks.exportNotebook = new UserTask({
   title: 'Export Notebook',
   keybindings: ['ctrl+shift+e', 'meta+shift+e'],
   displayKeybinding: `Shift+${commandKey()}+E`,
-  callback() { dispatcher.exportNotebook() },
-})
+  callback() { dispatcher.exportNotebook(); },
+});
 
 tasks.exportNotebookAsReport = new UserTask({
   title: 'Export Notebook as Report',
-  callback() { dispatcher.exportNotebook(true, false) },
-})
+  callback() { dispatcher.exportNotebook(true, false); },
+});
 
 tasks.exportNotebookToClipboard = new UserTask({
   title: 'Export Notebook to clipboard',
   callback() {
-    dispatcher.exportNotebook(false, true)
-    dispatcher.updateAppMessages({ message: 'Notebook copied to clipboard' })
+    dispatcher.exportNotebook(false, true);
+    dispatcher.updateAppMessages({ message: 'Notebook copied to clipboard' });
   },
-})
+});
 
 tasks.clearVariables = new UserTask({
   title: 'Clear Variables',
   preventDefaultKeybinding: true,
-  callback() { dispatcher.clearVariables() },
-})
+  callback() { dispatcher.clearVariables(); },
+});
 
 tasks.changeSidePaneWidth = new UserTask({
   title: 'Change Width of Side Pane',
-  callback(widthShift) { dispatcher.changeSidePaneWidth(widthShift) },
-})
+  callback(widthShift) { dispatcher.changeSidePaneWidth(widthShift); },
+});
 
 tasks.toggleDeclaredVariablesPane = new UserTask({
   title: 'Toggle the Declared Variables Pane',
@@ -308,12 +308,12 @@ tasks.toggleDeclaredVariablesPane = new UserTask({
   keybindingPrecondition: isCommandMode,
   callback() {
     if (store.getState().sidePaneMode !== 'declared variables') {
-      dispatcher.changeSidePaneMode('declared variables')
+      dispatcher.changeSidePaneMode('declared variables');
     } else {
-      dispatcher.changeSidePaneMode()
+      dispatcher.changeSidePaneMode();
     }
   },
-})
+});
 
 tasks.toggleHistoryPane = new UserTask({
   title: 'Toggle the History Pane',
@@ -324,12 +324,12 @@ tasks.toggleHistoryPane = new UserTask({
   keybindingPrecondition: isCommandMode,
   callback() {
     if (store.getState().sidePaneMode !== 'history') {
-      dispatcher.changeSidePaneMode('history')
+      dispatcher.changeSidePaneMode('history');
     } else {
-      dispatcher.changeSidePaneMode()
+      dispatcher.changeSidePaneMode();
     }
   },
-})
+});
 
 tasks.toggleAppInfoPane = new UserTask({
   title: 'Toggle the Iodide Info Pane',
@@ -340,51 +340,51 @@ tasks.toggleAppInfoPane = new UserTask({
   keybindingPrecondition: isCommandMode,
   callback() {
     if (store.getState().sidePaneMode !== '_APP_INFO') {
-      dispatcher.changeSidePaneMode('_APP_INFO')
+      dispatcher.changeSidePaneMode('_APP_INFO');
     } else {
-      dispatcher.changeSidePaneMode()
+      dispatcher.changeSidePaneMode();
     }
   },
-})
+});
 
 tasks.setViewModeToEditor = new UserTask({
   title: 'Set View Mode to Editor',
   callback() {
-    dispatcher.setViewMode('editor')
+    dispatcher.setViewMode('editor');
   },
-})
+});
 
 tasks.setViewModeToPresentation = new UserTask({
   title: 'Set View Mode to Presentation',
   callback() {
-    dispatcher.setViewMode('presentation')
+    dispatcher.setViewMode('presentation');
   },
-})
+});
 
 tasks.fileAnIssue = new ExternalLinkTask({
   title: 'File an Issue',
   menuTitle: 'File an Issue ...',
   url: 'http://github.com/iodide-project/iodide/issues/new',
-})
+});
 
 tasks.seeAllExamples = new ExternalLinkTask({
   title: 'See All Examples',
   menuTitle: 'See All Examples ...',
   url: 'http://github.com/iodide-project/iodide-examples/',
-})
+});
 
 export function getLocalStorageNotebook(name) {
-  const localStorageEntry = localStorage.getItem(name)
-  if (localStorageEntry == null) return undefined
-  let { lastSaved } = stateFromJsmd(localStorageEntry)
-  lastSaved = (lastSaved !== undefined) ? prettyDate(formatDateString(lastSaved)) : ' '
+  const localStorageEntry = localStorage.getItem(name);
+  if (localStorageEntry == null) return undefined;
+  let { lastSaved } = stateFromJsmd(localStorageEntry);
+  lastSaved = (lastSaved !== undefined) ? prettyDate(formatDateString(lastSaved)) : ' ';
   return new UserTask({
     title: name,
     secondaryText: lastSaved,
     callback() {
-      dispatcher.loadNotebook(name)
+      dispatcher.loadNotebook(name);
     },
-  })
+  });
 }
 
-export default tasks
+export default tasks;

--- a/src/actions/user-task.js
+++ b/src/actions/user-task.js
@@ -5,81 +5,81 @@ const TASK_ERRORS = {
   noTitleSupplied: 'no title supplied',
   callbackIsNotFunction: 'the callback supplied is not a function',
   keybindingsNotArray: 'keybindings must be in the form of an array',
-}
+};
 
-export { TASK_ERRORS }
+export { TASK_ERRORS };
 
 export function preventDefault(e) {
   if (e.preventDefault) {
-    e.preventDefault()
+    e.preventDefault();
   } else {
-    e.returnValue = false
+    e.returnValue = false;
   }
 }
 
 export default class UserTask {
   constructor(args) {
     if (!(args instanceof Object && args.constructor === Object)) {
-      throw new TypeError(TASK_ERRORS.argumentMustBeObject)
+      throw new TypeError(TASK_ERRORS.argumentMustBeObject);
     }
     if (!args.keybindingCallback && !args.callback) {
-      throw new TypeError(TASK_ERRORS.noCallback)
+      throw new TypeError(TASK_ERRORS.noCallback);
     }
     if (args.keybindingCallback && !args.keybindings) {
-      throw new TypeError(TASK_ERRORS.noKeybindingsWithCallback)
+      throw new TypeError(TASK_ERRORS.noKeybindingsWithCallback);
     }
 
     if (args.keybindings && !Array.isArray(args.keybindings)) {
-      throw new TypeError(TASK_ERRORS.keybindingsNotArray)
+      throw new TypeError(TASK_ERRORS.keybindingsNotArray);
     }
     if (typeof args.callback !== 'function' && args.callback !== undefined) {
-      throw new TypeError(TASK_ERRORS.callbackIsNotFunction)
+      throw new TypeError(TASK_ERRORS.callbackIsNotFunction);
     }
-    if (!args.title) throw new TypeError(TASK_ERRORS.noTitleSupplied)
+    if (!args.title) throw new TypeError(TASK_ERRORS.noTitleSupplied);
 
-    this.args = args
-    if (this.args.callback) this.args.callback = this.args.callback.bind(this)
+    this.args = args;
+    if (this.args.callback) this.args.callback = this.args.callback.bind(this);
     if (this.args.keybindingCallback) {
-      this.args.keybindingCallback = this.args.keybindingCallback.bind(this)
+      this.args.keybindingCallback = this.args.keybindingCallback.bind(this);
     }
   }
 
   get keybindingCallback() {
     return this.args.keybindingCallback || ((e) => {
       if ('keybindingPrecondition' in this.args) {
-        if (!this.args.keybindingPrecondition()) return
+        if (!this.args.keybindingPrecondition()) return;
       }
-      if (this.args.preventDefaultKeybinding) { preventDefault(e) }
-      this.args.callback()
-    })
+      if (this.args.preventDefaultKeybinding) { preventDefault(e); }
+      this.args.callback();
+    });
   }
 
   get keybindings() {
-    return this.args.keybindings
+    return this.args.keybindings;
   }
 
   get secondaryText() {
     // primarily things that go in keybinding spot, like "last saved" info
-    return this.args.secondaryText
+    return this.args.secondaryText;
   }
 
   hasKeybinding() {
-    return this.args.keybindings !== undefined && this.args.keybindings.length !== 0
+    return this.args.keybindings !== undefined && this.args.keybindings.length !== 0;
   }
 
   get displayKeybinding() {
-    return this.args.displayKeybinding || ''
+    return this.args.displayKeybinding || '';
   }
 
   get callback() {
-    return this.args.callback
+    return this.args.callback;
   }
 
   get title() {
-    return this.args.title
+    return this.args.title;
   }
 
   get menuTitle() {
-    return this.args.menuTitle || this.args.title
+    return this.args.menuTitle || this.args.title;
   }
 }

--- a/src/components/app-messages/app-messages.jsx
+++ b/src/components/app-messages/app-messages.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import Button from 'material-ui/Button'
-import SnackBar from 'material-ui/Snackbar'
-import tasks from '../../actions/task-definitions'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Button from 'material-ui/Button';
+import SnackBar from 'material-ui/Snackbar';
+import tasks from '../../actions/task-definitions';
 
 export class appMessagesUnconnected extends React.Component {
   static propTypes = {
@@ -12,24 +12,24 @@ export class appMessagesUnconnected extends React.Component {
   }
 
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
       open: false,
       latestMessage: {},
-    }
+    };
   }
 
   shouldComponentUpdate(props, state) {
-    const { latestMessage } = state
-    const newMessage = props.appMessages.slice(-1)[0]
-    if (newMessage === undefined) return false
-    const newTimestamp = newMessage.when.toString()
+    const { latestMessage } = state;
+    const newMessage = props.appMessages.slice(-1)[0];
+    if (newMessage === undefined) return false;
+    const newTimestamp = newMessage.when.toString();
     const latestTimestamp = latestMessage.when === undefined ?
-      undefined : latestMessage.when.toString()
+      undefined : latestMessage.when.toString();
     if (latestTimestamp === undefined || newTimestamp !== latestTimestamp) {
-      this.setState({ latestMessage: newMessage, open: true })
+      this.setState({ latestMessage: newMessage, open: true });
     }
-    return true
+    return true;
   }
 
   handleClose = () => {
@@ -37,8 +37,8 @@ export class appMessagesUnconnected extends React.Component {
   }
 
   handleMore = () => {
-    this.setState({ open: false })
-    if (this.props.sidePaneMode !== '_APP_INFO') { tasks.toggleAppInfoPane.callback() }
+    this.setState({ open: false });
+    if (this.props.sidePaneMode !== '_APP_INFO') { tasks.toggleAppInfoPane.callback(); }
   }
 
   render() {
@@ -54,7 +54,7 @@ export class appMessagesUnconnected extends React.Component {
           </Button>
       }
       />
-    )
+    );
   }
 }
 
@@ -62,7 +62,7 @@ function mapStateToProps(state) {
   return {
     appMessages: state.appMessages,
     sidePaneMode: state.sidePaneMode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(appMessagesUnconnected)
+export default connect(mapStateToProps)(appMessagesUnconnected);

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -1,24 +1,24 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { CellContainerUnconnected, mapStateToProps } from '../cell-container'
-import CellMenuContainer from '../cell-menu-container'
+import { CellContainerUnconnected, mapStateToProps } from '../cell-container';
+import CellMenuContainer from '../cell-menu-container';
 
 describe('CellContainerUnconnected React component', () => {
-  let selectCell
-  let props
-  let mountedCont
-  const node = <span>Hello</span>
+  let selectCell;
+  let props;
+  let mountedCont;
+  const node = <span>Hello</span>;
 
   const cellContainer = () => {
     if (!mountedCont) {
-      mountedCont = shallow(<CellContainerUnconnected {...props}>{node}</CellContainerUnconnected>)
+      mountedCont = shallow(<CellContainerUnconnected {...props}>{node}</CellContainerUnconnected>);
     }
-    return mountedCont
-  }
+    return mountedCont;
+  };
 
   beforeEach(() => {
-    selectCell = jest.fn()
+    selectCell = jest.fn();
     props = {
       selected: true,
       cellId: 1,
@@ -26,103 +26,103 @@ describe('CellContainerUnconnected React component', () => {
       viewMode: 'editor',
       cellType: 'code',
       actions: { selectCell },
-    }
-    mountedCont = undefined
-  })
+    };
+    mountedCont = undefined;
+  });
 
   it('always renders two div', () => {
-    expect(cellContainer().find('div').length).toBe(2)
-  })
+    expect(cellContainer().find('div').length).toBe(2);
+  });
 
   it('always renders two children inside top div', () => {
     expect(cellContainer().find('div').at(0).children()
-      .length).toBe(2)
-  })
+      .length).toBe(2);
+  });
 
   it('sets the top div to have id cell-1', () => {
     expect(cellContainer().find('div').at(0).props().id)
-      .toBe('cell-1')
-  })
+      .toBe('cell-1');
+  });
 
   it('sets the top div with correct class if selected===false and editingCell===false', () => {
-    props.selected = false
-    props.editingCell = false
+    props.selected = false;
+    props.editingCell = false;
     expect(cellContainer().find('div').at(0).props().className)
-      .toBe('cell-container code')
-  })
+      .toBe('cell-container code');
+  });
 
   it('sets the top div with correct class if selected===true and editingCell===false', () => {
-    props.selected = true
-    props.editingCell = false
+    props.selected = true;
+    props.editingCell = false;
     expect(cellContainer().find('div').at(0).props().className)
-      .toBe('cell-container code selected-cell')
-  })
+      .toBe('cell-container code selected-cell');
+  });
 
   it('sets the top div with correct class if selected===false and editingCell===true', () => {
-    props.selected = false
-    props.editingCell = true
+    props.selected = false;
+    props.editingCell = true;
     expect(cellContainer().find('div').at(0).props().className)
-      .toBe('cell-container code editing-cell')
-  })
+      .toBe('cell-container code editing-cell');
+  });
 
   it('sets the top div with correct class if selected===true and editingCell===true', () => {
-    props.selected = true
-    props.editingCell = true
+    props.selected = true;
+    props.editingCell = true;
     expect(cellContainer().find('div').at(0).props().className)
-      .toBe('cell-container code selected-cell editing-cell')
-  })
+      .toBe('cell-container code selected-cell editing-cell');
+  });
 
   it('sets the onMouseDown prop to handleCellClick', () => {
     expect(cellContainer().props().onMouseDown)
-      .toEqual(cellContainer().instance().handleCellClick)
-  })
+      .toEqual(cellContainer().instance().handleCellClick);
+  });
 
   it('mouse down on cell container div fires selectCell with correct props', () => {
-    props.viewMode = 'editor'
-    props.selected = false
-    cellContainer().simulate('mousedown')
-    expect(selectCell.mock.calls.length).toBe(1)
-    expect(selectCell.mock.calls[0].length).toBe(2)
-  })
+    props.viewMode = 'editor';
+    props.selected = false;
+    cellContainer().simulate('mousedown');
+    expect(selectCell.mock.calls.length).toBe(1);
+    expect(selectCell.mock.calls[0].length).toBe(2);
+  });
 
   const selectCellNotFiredVariants = [
     { selected: true, viewMode: 'editor' },
     { selected: false, viewMode: 'presentation' },
     { selected: true, viewMode: 'presentation' },
-  ]
+  ];
 
   selectCellNotFiredVariants.forEach((state) => {
     it('click on cell container div does not fires selectCell with incorrect props', () => {
-      props.viewMode = state.viewMode
-      props.selected = state.selected
-      cellContainer().simulate('mousedown')
-      expect(selectCell.mock.calls.length).toBe(0)
-    })
-  })
+      props.viewMode = state.viewMode;
+      props.selected = state.selected;
+      cellContainer().simulate('mousedown');
+      expect(selectCell.mock.calls.length).toBe(0);
+    });
+  });
 
   it('always renders one CellMenuContainer inside top div', () => {
     expect(cellContainer().find('div').at(0)
-      .find(CellMenuContainer)).toHaveLength(1)
-  })
+      .find(CellMenuContainer)).toHaveLength(1);
+  });
 
   it("sets the CellMenuContainer cellId prop to be the CellContainer's cellId prop", () => {
     expect(cellContainer().find(CellMenuContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('always renders one div with class cell-row-container inside top div', () => {
     expect(cellContainer().wrap(cellContainer().find('div').at(0)
-      .props().children).find('div.cell-row-container')).toHaveLength(1)
-  })
+      .props().children).find('div.cell-row-container')).toHaveLength(1);
+  });
 
   it('always has a children inside the second div', () => {
     expect(cellContainer().find('div.cell-row-container')
-      .props().children).toEqual(node)
-  })
-})
+      .props().children).toEqual(node);
+  });
+});
 
 describe('CellContainer mapStateToProps', () => {
-  let state
+  let state;
 
   beforeEach(() => {
     state = {
@@ -134,11 +134,11 @@ describe('CellContainer mapStateToProps', () => {
       ],
       mode: 'edit',
       viewMode: 'editor',
-    }
-  })
+    };
+  });
 
   it('should return the basic info for the correct cell', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -146,13 +146,13 @@ describe('CellContainer mapStateToProps', () => {
         editingCell: true,
         viewMode: 'editor',
         cellType: 'code',
-      })
-  })
+      });
+  });
 
   it('should return editingCell as false if selected===false and mode===edit', () => {
-    const ownProps = { cellId: 5 }
-    state.mode = 'edit'
-    state.cells[0].selected = false
+    const ownProps = { cellId: 5 };
+    state.mode = 'edit';
+    state.cells[0].selected = false;
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -160,13 +160,13 @@ describe('CellContainer mapStateToProps', () => {
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',
-      })
-  })
+      });
+  });
 
   it('should return editingCell as false if selected===true and mode===not_edit', () => {
-    const ownProps = { cellId: 5 }
-    state.mode = 'not_edit'
-    state.cells[0].selected = true
+    const ownProps = { cellId: 5 };
+    state.mode = 'not_edit';
+    state.cells[0].selected = true;
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -174,13 +174,13 @@ describe('CellContainer mapStateToProps', () => {
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',
-      })
-  })
+      });
+  });
 
   it('should return editingCell as false if selected===false and mode===not_edit', () => {
-    const ownProps = { cellId: 5 }
-    state.mode = 'not_edit'
-    state.cells[0].selected = false
+    const ownProps = { cellId: 5 };
+    state.mode = 'not_edit';
+    state.cells[0].selected = false;
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -188,6 +188,6 @@ describe('CellContainer mapStateToProps', () => {
         editingCell: false,
         viewMode: 'editor',
         cellType: 'code',
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/cells/__tests__/cell-menu.test.js
+++ b/src/components/cells/__tests__/cell-menu.test.js
@@ -1,73 +1,73 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { CellMenuUnconnected, mapStateToProps } from '../cell-menu'
-import NotebookMenuItem from '../../menu/notebook-menu-item'
-import NotebookMenuDivider from '../../menu/notebook-menu-divider'
+import { CellMenuUnconnected, mapStateToProps } from '../cell-menu';
+import NotebookMenuItem from '../../menu/notebook-menu-item';
+import NotebookMenuDivider from '../../menu/notebook-menu-divider';
 
 describe('CellMenuUnconnected React component', () => {
-  let props
-  let mountedMenu
+  let props;
+  let mountedMenu;
 
   const cellMenu = () => {
     if (!mountedMenu) {
-      mountedMenu = shallow(<CellMenuUnconnected {...props} />)
+      mountedMenu = shallow(<CellMenuUnconnected {...props} />);
     }
-    return mountedMenu
-  }
+    return mountedMenu;
+  };
 
   beforeEach(() => {
     props = {
       menuLabel: 'css',
       cellId: 5,
       skipInRunAll: false,
-    }
-    mountedMenu = undefined
-  })
+    };
+    mountedMenu = undefined;
+  });
 
   it('always renders one div', () => {
-    expect(cellMenu().find('div').length).toBe(1)
-  })
+    expect(cellMenu().find('div').length).toBe(1);
+  });
 
   it('sets the div to have class cell-menu-items-containe', () => {
     expect(cellMenu().find('div').props().className)
-      .toBe('cell-menu-items-container')
-  })
+      .toBe('cell-menu-items-container');
+  });
 
   it('always renders seven NotebookMenuItem', () => {
-    expect(cellMenu().find(NotebookMenuItem).length).toBe(7)
-  })
+    expect(cellMenu().find(NotebookMenuItem).length).toBe(7);
+  });
 
   it('always renders one NotebookMenuDivider', () => {
-    expect(cellMenu().find(NotebookMenuDivider).length).toBe(1)
-  })
+    expect(cellMenu().find(NotebookMenuDivider).length).toBe(1);
+  });
 
-  const cellTypes = ['js', 'md', 'css', 'resource', 'raw', 'plugin']
+  const cellTypes = ['js', 'md', 'css', 'resource', 'raw', 'plugin'];
 
   cellTypes.forEach((cellType, i) => {
     it(`sets the NotebookMenuItem disabled prop to be correct for option ${cellType}`, () => {
       expect(cellMenu().find(NotebookMenuItem).at(i).props().disabled)
-        .toBe(props.menuLabel === cellType)
-    })
-  })
-})
+        .toBe(props.menuLabel === cellType);
+    });
+  });
+});
 
 describe('cellMenu mapStateToProps', () => {
-  let state
+  let state;
   beforeEach(() => {
     state = {
       cells: [{
         id: 5,
         skipInRunAll: false,
       }],
-    }
-  })
+    };
+  });
 
   it('should return the basic info for the correct cell', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         skipInRunAll: false,
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/cells/__tests__/cell-output.test.js
+++ b/src/components/cells/__tests__/cell-output.test.js
@@ -1,45 +1,45 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { CellOutputUnconnected, mapStateToProps } from '../cell-output'
-import { ValueRenderer } from '../../reps/value-renderer'
+import { CellOutputUnconnected, mapStateToProps } from '../cell-output';
+import { ValueRenderer } from '../../reps/value-renderer';
 
 describe('CellOutputUnconnected React component', () => {
-  let props
-  let mountedOutput
+  let props;
+  let mountedOutput;
 
   const cellOutput = () => {
     if (!mountedOutput) {
-      mountedOutput = shallow(<CellOutputUnconnected {...props} />)
+      mountedOutput = shallow(<CellOutputUnconnected {...props} />);
     }
-    return mountedOutput
-  }
+    return mountedOutput;
+  };
 
   beforeEach(() => {
     props = {
       render: true,
       valueToRender: 'value',
-    }
-    mountedOutput = undefined
-  })
+    };
+    mountedOutput = undefined;
+  });
 
   it('always renders one ValueRenderer', () => {
-    expect(cellOutput().find(ValueRenderer).length).toBe(1)
-  })
+    expect(cellOutput().find(ValueRenderer).length).toBe(1);
+  });
 
   it("sets the ValueRenderer render prop to be the cellOutput's render prop", () => {
     expect(cellOutput().find(ValueRenderer).props().render)
-      .toBe(props.render)
-  })
+      .toBe(props.render);
+  });
 
   it("sets the ValueRenderer valueToRender prop to be the cellOutput's valueToRender prop", () => {
     expect(cellOutput().find(ValueRenderer).props().valueToRender)
-      .toBe(props.valueToRender)
-  })
-})
+      .toBe(props.valueToRender);
+  });
+});
 
 describe('CellRow mapStateToPropsCellRows', () => {
-  let state
+  let state;
   beforeEach(() => {
     state = {
       cells: [{
@@ -47,15 +47,15 @@ describe('CellRow mapStateToPropsCellRows', () => {
         value: '<p>hello</p>',
         rendered: true,
       }],
-    }
-  })
+    };
+  });
 
   it('should return the basic info for the correct cell', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         valueToRender: '<p>hello</p>',
         render: true,
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/cells/__tests__/cell-row.test.js
+++ b/src/components/cells/__tests__/cell-row.test.js
@@ -1,26 +1,26 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Tooltip from 'material-ui/Tooltip'
+import Tooltip from 'material-ui/Tooltip';
 
-import { CellRowUnconnected, mapStateToPropsCellRows } from '../cell-row'
+import { CellRowUnconnected, mapStateToPropsCellRows } from '../cell-row';
 
 describe('CellRowUnconnected React component', () => {
-  let setCellRowCollapsedState
-  let props
-  let mountedRow
-  const node = <span>Hello</span>
+  let setCellRowCollapsedState;
+  let props;
+  let mountedRow;
+  const node = <span>Hello</span>;
 
   const cellRow = () => {
     if (!mountedRow) {
-      mountedRow = shallow(<CellRowUnconnected {...props}>{node}</CellRowUnconnected>)
+      mountedRow = shallow(<CellRowUnconnected {...props}>{node}</CellRowUnconnected>);
     }
-    return mountedRow
-  }
+    return mountedRow;
+  };
 
   beforeEach(() => {
-    setCellRowCollapsedState = jest.fn()
+    setCellRowCollapsedState = jest.fn();
     props = {
       selected: true,
       rowOverflow: 'VISIBLE',
@@ -31,97 +31,97 @@ describe('CellRowUnconnected React component', () => {
       collapseTooltipPlacement: 'top',
       tooltipText: 'text',
       actions: { setCellRowCollapsedState },
-    }
-    mountedRow = undefined
-  })
+    };
+    mountedRow = undefined;
+  });
 
   it('always renders three div', () => {
-    expect(cellRow().find('div').length).toBe(3)
-  })
+    expect(cellRow().find('div').length).toBe(3);
+  });
 
   it('sets the top div to have correct class', () => {
     expect(cellRow().find('div').at(0).props().className)
-      .toBe('cell-row input VISIBLE')
-  })
+      .toBe('cell-row input VISIBLE');
+  });
 
   it('always renders two children inside top div', () => {
     expect(cellRow().find('div').at(0).children()
-      .length).toBe(2)
-  })
+      .length).toBe(2);
+  });
 
   it('always renders one Tooltip component inside top div', () => {
     expect(cellRow().wrap(cellRow().find('div').at(0))
-      .find(Tooltip)).toHaveLength(1)
-  })
+      .find(Tooltip)).toHaveLength(1);
+  });
 
   it('always renders one div component with class collapse-button inside Tooltip', () => {
     expect(cellRow().wrap(cellRow().find(Tooltip))
-      .find('div.collapse-button')).toHaveLength(1)
-  })
+      .find('div.collapse-button')).toHaveLength(1);
+  });
 
   it('sets the onClick prop to handleCollapseButtonClick', () => {
     expect(cellRow().find('div.collapse-button').props().onClick)
-      .toEqual(cellRow().instance().handleCollapseButtonClick)
-  })
+      .toEqual(cellRow().instance().handleCollapseButtonClick);
+  });
 
   it('click on cell collapse-button div with correct props fires setCellRowCollapsedState', () => {
-    props.viewMode = 'editor'
-    cellRow().find('div.collapse-button').simulate('click')
-    expect(setCellRowCollapsedState.mock.calls.length).toBe(1)
-    expect(setCellRowCollapsedState.mock.calls[0].length).toBe(3)
-  })
+    props.viewMode = 'editor';
+    cellRow().find('div.collapse-button').simulate('click');
+    expect(setCellRowCollapsedState.mock.calls.length).toBe(1);
+    expect(setCellRowCollapsedState.mock.calls[0].length).toBe(3);
+  });
 
   it('click on cell collapse-button div with incorrect props does not fire setCellRowCollapsedState', () => {
-    props.viewMode = 'presentation'
-    cellRow().find('div.collapse-button').simulate('click')
-    expect(setCellRowCollapsedState.mock.calls.length).toBe(0)
-  })
+    props.viewMode = 'presentation';
+    cellRow().find('div.collapse-button').simulate('click');
+    expect(setCellRowCollapsedState.mock.calls.length).toBe(0);
+  });
 
   it('always renders one children inside Tooltip', () => {
     expect(cellRow().find(Tooltip).children()
-      .length).toBe(1)
-  })
+      .length).toBe(1);
+  });
 
   it("sets the Tooltip placement prop to be Cell Row's collapseTooltipPlacement prop", () => {
     expect(cellRow().find(Tooltip).props().placement)
-      .toBe(props.collapseTooltipPlacement)
-  })
+      .toBe(props.collapseTooltipPlacement);
+  });
 
   it("sets the Tooltip title prop to be Cell Row's tooltipText prop", () => {
     expect(cellRow().find(Tooltip).props().title)
-      .toBe(props.tooltipText)
-  })
+      .toBe(props.tooltipText);
+  });
 
   it('always renders one div component with class main-component inside top div', () => {
     expect(cellRow().wrap(cellRow().find('div').at(0))
-      .find('div.main-component')).toHaveLength(1)
-  })
+      .find('div.main-component')).toHaveLength(1);
+  });
 
   it('always has a children inside the div with class main-component', () => {
     expect(cellRow().find('div.main-component')
-      .props().children).toEqual(node)
-  })
+      .props().children).toEqual(node);
+  });
 
   it('fires setCellRowCollapsedState when component updates with correct props', () => {
     const nodes = document.createElement('div');
     ReactDOM.render(<CellRowUnconnected {...props} />, nodes);
     props.uncollapseOnUpdate = true;
     ReactDOM.render(<CellRowUnconnected {...props} />, nodes);
-    expect(setCellRowCollapsedState.mock.calls.length).toBe(1)
-  })
+    expect(setCellRowCollapsedState.mock.calls.length).toBe(1);
+  });
 
   it('does not fire setCellRowCollapsedState when component updates with wrong props', () => {
     const nodes = document.createElement('div');
     ReactDOM.render(<CellRowUnconnected {...props} />, nodes);
     props.uncollapseOnUpdate = false;
     ReactDOM.render(<CellRowUnconnected {...props} />, nodes);
-    expect(setCellRowCollapsedState.mock.calls.length).toBe(0)
-  })
-})
+    expect(setCellRowCollapsedState.mock.calls.length).toBe(0);
+  });
+});
 
 
 describe('CellRow mapStateToPropsCellRows', () => {
-  let state
+  let state;
   const rowSettingsObject = {
     EXPLORE: {
       input: 'VISIBLE',
@@ -133,7 +133,7 @@ describe('CellRow mapStateToPropsCellRows', () => {
       sideeffect: 'VISIBLE',
       output: 'HIDDEN',
     },
-  }
+  };
   beforeEach(() => {
     state = {
       cells: [{
@@ -146,11 +146,11 @@ describe('CellRow mapStateToPropsCellRows', () => {
       ],
       mode: 'edit',
       viewMode: 'editor',
-    }
-  })
+    };
+  });
 
   it('should return the basic info for the correct cell', () => {
-    const ownProps = { cellId: 5, rowType: 'input' }
+    const ownProps = { cellId: 5, rowType: 'input' };
     expect(mapStateToPropsCellRows(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -160,12 +160,12 @@ describe('CellRow mapStateToPropsCellRows', () => {
         rowOverflow: 'VISIBLE',
         collapseTooltipPlacement: 'right',
         tooltipText: 'click to scroll this input',
-      })
-  })
+      });
+  });
 
   it('should return the correct info with viewMode===presentation', () => {
-    const ownProps = { cellId: 5, rowType: 'input' }
-    state.viewMode = 'presentation'
+    const ownProps = { cellId: 5, rowType: 'input' };
+    state.viewMode = 'presentation';
     expect(mapStateToPropsCellRows(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -175,11 +175,11 @@ describe('CellRow mapStateToPropsCellRows', () => {
         rowOverflow: 'HIDDEN',
         collapseTooltipPlacement: 'bottom',
         tooltipText: 'click to expand this input',
-      })
-  })
+      });
+  });
 
   it('should return the correct info with rowType!==input', () => {
-    const ownProps = { cellId: 5, rowType: 'output' }
+    const ownProps = { cellId: 5, rowType: 'output' };
     expect(mapStateToPropsCellRows(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -189,12 +189,12 @@ describe('CellRow mapStateToPropsCellRows', () => {
         rowOverflow: 'VISIBLE',
         collapseTooltipPlacement: 'right',
         tooltipText: 'click to scroll this output',
-      })
-  })
+      });
+  });
 
   it('should return the correct info with cellType!==code', () => {
-    const ownProps = { cellId: 5, rowType: 'input' }
-    state.cells[0].cellType = 'css'
+    const ownProps = { cellId: 5, rowType: 'input' };
+    state.cells[0].cellType = 'css';
     expect(mapStateToPropsCellRows(state, ownProps))
       .toEqual({
         cellId: 5,
@@ -204,18 +204,18 @@ describe('CellRow mapStateToPropsCellRows', () => {
         rowOverflow: 'VISIBLE',
         collapseTooltipPlacement: 'right',
         tooltipText: 'click to scroll this input',
-      })
-  })
+      });
+  });
 
   it('should throw error with message Unsupported viewMode for wrong vieMode', () => {
-    const ownProps = { cellId: 5, rowType: 'input' }
-    state.viewMode = 'display'
+    const ownProps = { cellId: 5, rowType: 'input' };
+    state.viewMode = 'display';
     try {
-      mapStateToPropsCellRows(state, ownProps)
+      mapStateToPropsCellRows(state, ownProps);
       // Fail test if above expression doesn't throw anything.
       expect(true).toBe(false);
     } catch (e) {
-      expect(e.message).toBe('Unsupported viewMode: display')
+      expect(e.message).toBe('Unsupported viewMode: display');
     }
-  })
-})
+  });
+});

--- a/src/components/cells/__tests__/css-cell.test.js
+++ b/src/components/cells/__tests__/css-cell.test.js
@@ -1,86 +1,86 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
 import {
   CSSCellUnconnected as CSSCell,
   mapStateToProps,
-} from '../css-cell'
-import CellEditor from '../cell-editor'
-import { CellContainer } from '../cell-container'
-import CellRow from '../cell-row'
+} from '../css-cell';
+import CellEditor from '../cell-editor';
+import { CellContainer } from '../cell-container';
+import CellRow from '../cell-row';
 
 
 describe('CSSCell_unconnected react component', () => {
-  let props
-  let mountedCell
+  let props;
+  let mountedCell;
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<CSSCell {...props} />)
+      mountedCell = shallow(<CSSCell {...props} />);
     }
-    return mountedCell
-  }
+    return mountedCell;
+  };
 
   beforeEach(() => {
     props = {
       cellId: 5,
       value: 'h1 {color:pink}',
       rendered: false,
-    }
-    mountedCell = undefined
-  })
+    };
+    mountedCell = undefined;
+  });
 
   it('always renders one CellContainer', () => {
-    expect(cell().find(CellContainer).length).toBe(1)
-  })
+    expect(cell().find(CellContainer).length).toBe(1);
+  });
 
   it('always renders one CellRow inside CellContainer', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(1)
-  })
+      .find(CellRow)).toHaveLength(1);
+  });
 
   it('is a CellRow with two children', () => {
-    expect(cell().find(CellRow).children().length).toBe(2)
-  })
+    expect(cell().find(CellRow).children().length).toBe(2);
+  });
 
   it('always renders one CellEditor inside CellRow', () => {
-    expect(cell().find(CellEditor).parent().is(CellRow)).toEqual(true)
-  })
+    expect(cell().find(CellEditor).parent().is(CellRow)).toEqual(true);
+  });
 
   it('always renders one style elt inside CellRow', () => {
-    expect(cell().find('style').parent().is(CellRow)).toEqual(true)
-  })
+    expect(cell().find('style').parent().is(CellRow)).toEqual(true);
+  });
 
   it('the style elt has the correct value if rendered===true', () => {
-    props.rendered = true
-    const styleElts = cell().find('style')
-    expect(styleElts.text()).toEqual('h1 {color:pink}')
-  })
+    props.rendered = true;
+    const styleElts = cell().find('style');
+    expect(styleElts.text()).toEqual('h1 {color:pink}');
+  });
 
   it('the style elt is empty if rendered==false', () => {
-    const styleElts = cell().find('style')
-    expect(styleElts.text()).toEqual('')
-  })
+    const styleElts = cell().find('style');
+    expect(styleElts.text()).toEqual('');
+  });
 
   it("sets the CellContainer cellId prop to be the CSSCell's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it("sets the CellRow cellId prop to be the CSSCell's cellId prop", () => {
     expect(cell().find(CellRow).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the CellRow rowType prop to be input', () => {
     expect(cell().find(CellRow).props().rowType)
-      .toBe('input')
-  })
+      .toBe('input');
+  });
 
   it('sets the CellEditor cellId prop to be the CSSCell cellId input prop', () => {
     expect(cell().find(CellEditor).props().cellId)
-      .toBe(props.cellId)
-  })
-})
+      .toBe(props.cellId);
+  });
+});
 
 
 describe('CSSCell mapStateToProps', () => {
@@ -88,17 +88,17 @@ describe('CSSCell mapStateToProps', () => {
     cells: [
       { id: 5, value: 'h1 {color:pink}', rendered: true },
       { id: 3, value: 'h1 {color:blue}', rendered: false }],
-  }
+  };
 
   it('should return the content of the correct cells', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps))
-      .toEqual({ value: 'h1 {color:pink}', rendered: true, cellId: 5 })
-  })
+      .toEqual({ value: 'h1 {color:pink}', rendered: true, cellId: 5 });
+  });
 
   it('should return the content of the correct cells', () => {
-    const ownProps = { cellId: 3 }
+    const ownProps = { cellId: 3 };
     expect(mapStateToProps(state, ownProps))
-      .toEqual({ value: 'h1 {color:blue}', rendered: false, cellId: 3 })
-  })
-})
+      .toEqual({ value: 'h1 {color:blue}', rendered: false, cellId: 3 });
+  });
+});

--- a/src/components/cells/__tests__/external-resource-cell.test.js
+++ b/src/components/cells/__tests__/external-resource-cell.test.js
@@ -1,27 +1,27 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
 
 import {
   ExternalResourceCellUnconnected as ExternalResourceCell,
   mapStateToProps,
-} from '../external-resource-cell'
-import { CellContainer } from '../cell-container'
-import CellRow from '../cell-row'
-import CellEditor from '../cell-editor'
-import ExternalResourceOutput from '../../reps/output-handler-external-resource'
+} from '../external-resource-cell';
+import { CellContainer } from '../cell-container';
+import CellRow from '../cell-row';
+import CellEditor from '../cell-editor';
+import ExternalResourceOutput from '../../reps/output-handler-external-resource';
 
-const STANDARD_NETWORK_ERROR = 'A network error occurred.'
+const STANDARD_NETWORK_ERROR = 'A network error occurred.';
 
 describe('ExternalResourceCellUnconnected contains the expected child components', () => {
-  let props
-  let mountedCell
+  let props;
+  let mountedCell;
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<ExternalResourceCell {...props} />)
+      mountedCell = shallow(<ExternalResourceCell {...props} />);
     }
-    return mountedCell
-  }
+    return mountedCell;
+  };
 
   beforeEach(() => {
     props = {
@@ -47,64 +47,64 @@ describe('ExternalResourceCellUnconnected contains the expected child components
           statusExplanation: STANDARD_NETWORK_ERROR,
         },
       ],
-    }
-    mountedCell = undefined
-  })
+    };
+    mountedCell = undefined;
+  });
 
   it('always renders one CellContainer', () => {
-    expect(cell().find(CellContainer).length).toBe(1)
-  })
+    expect(cell().find(CellContainer).length).toBe(1);
+  });
 
   it('always renders two CellRow inside CellContainer', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(2)
-  })
+      .find(CellRow)).toHaveLength(2);
+  });
 
   it('always renders one CellEditor inside first CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(0))
-      .find(CellEditor)).toHaveLength(1)
-  })
+      .find(CellEditor)).toHaveLength(1);
+  });
 
   it('always renders one ExternalResourceOutput inside second CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(1))
-      .find(ExternalResourceOutput)).toHaveLength(1)
-  })
+      .find(ExternalResourceOutput)).toHaveLength(1);
+  });
 
   it("sets the CellContainer cellId prop to be the ExternalResourceCells's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it("sets the first CellRow cellId prop to be the ExternalResourceCells's cellId prop", () => {
     expect(cell().find(CellRow).at(0).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the first CellRow rowType prop to be input', () => {
     expect(cell().find(CellRow).at(0).props().rowType)
-      .toBe('input')
-  })
+      .toBe('input');
+  });
 
   it("sets the second CellRow cellId prop to be the ExternalResourceCells's cellId prop", () => {
     expect(cell().find(CellRow).at(1).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the second CellRow rowType prop to be output', () => {
     expect(cell().find(CellRow).at(1).props().rowType)
-      .toBe('output')
-  })
+      .toBe('output');
+  });
 
   it("sets the CellEditor cellId prop to be the ExternalResourceCells's cellId prop", () => {
     expect(cell().find(CellEditor).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it("sets the ExternalResourceOutput value prop to be the ExternalResourceCells's value prop", () => {
     expect(cell().find(ExternalResourceOutput).props().value)
-      .toBe(props.value)
-  })
-})
+      .toBe(props.value);
+  });
+});
 
 describe('ExternalResourceCell mapStateToProps', () => {
   const state = {
@@ -132,11 +132,11 @@ describe('ExternalResourceCell mapStateToProps', () => {
         },
       ],
     }],
-  }
+  };
 
   it('should have the right number of value entries', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps).value.length)
-      .toEqual(4)
-  })
-})
+      .toEqual(4);
+  });
+});

--- a/src/components/cells/__tests__/javascript-cell-test.test.js
+++ b/src/components/cells/__tests__/javascript-cell-test.test.js
@@ -1,96 +1,96 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import { CodeCellUnconnected as CodeCell } from '../code-cell'
-import { CellContainer } from '../cell-container'
-import CellRow from '../cell-row'
-import CellEditor from '../cell-editor'
-import CellOutput from '../cell-output'
+import { CodeCellUnconnected as CodeCell } from '../code-cell';
+import { CellContainer } from '../cell-container';
+import CellRow from '../cell-row';
+import CellEditor from '../cell-editor';
+import CellOutput from '../cell-output';
 
 describe('CodeCell_unconnected react component', () => {
-  let props
-  let mountedCell
+  let props;
+  let mountedCell;
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<CodeCell {...props} />)
+      mountedCell = shallow(<CodeCell {...props} />);
     }
-    return mountedCell
-  }
+    return mountedCell;
+  };
 
   beforeEach(() => {
     props = {
       cellId: 5,
-    }
-    mountedCell = undefined
-  })
+    };
+    mountedCell = undefined;
+  });
 
   it('always renders one CellContainer', () => {
-    expect(cell().find(CellContainer).length).toBe(1)
-  })
+    expect(cell().find(CellContainer).length).toBe(1);
+  });
 
   it('always renders two CellRow inside CellContainer', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(3)
-  })
+      .find(CellRow)).toHaveLength(3);
+  });
 
   it('always renders one CellEditor inside first CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(0))
-      .find(CellEditor)).toHaveLength(1)
-  })
+      .find(CellEditor)).toHaveLength(1);
+  });
 
   it('always renders one div inside second CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(1))
-      .find('div')).toHaveLength(1)
-  })
+      .find('div')).toHaveLength(1);
+  });
 
   it('always renders one CellOutput inside third CellRow', () => {
     expect(cell().wrap(cell().find(CellRow).at(2))
-      .find(CellOutput)).toHaveLength(1)
-  })
+      .find(CellOutput)).toHaveLength(1);
+  });
 
   it("sets the CellContainer cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it("sets the first CellRow cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellRow).at(0).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the first CellRow rowType prop to be input', () => {
     expect(cell().find(CellRow).at(0).props().rowType)
-      .toBe('input')
-  })
+      .toBe('input');
+  });
 
   it("sets the 2nd CellRow cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellRow).at(1).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the second CellRow rowType prop to be sideeffect', () => {
     expect(cell().find(CellRow).at(1).props().rowType)
-      .toBe('sideeffect')
-  })
+      .toBe('sideeffect');
+  });
 
   it('sets the div in the sideeffect row to have class side-effect-target', () => {
     expect(cell().find('div').props().className)
-      .toBe('side-effect-target')
-  })
+      .toBe('side-effect-target');
+  });
 
   it("sets the third CellRow cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellRow).at(2).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the third CellRow rowType prop to be output', () => {
     expect(cell().find(CellRow).at(2).props().rowType)
-      .toBe('output')
-  })
+      .toBe('output');
+  });
 
 
   it("sets the CellEditor cellId prop to be the CodeCell's cellId prop", () => {
     expect(cell().find(CellEditor).props().cellId)
-      .toBe(props.cellId)
-  })
-})
+      .toBe(props.cellId);
+  });
+});

--- a/src/components/cells/__tests__/markdown-cell.test.js
+++ b/src/components/cells/__tests__/markdown-cell.test.js
@@ -1,141 +1,141 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { MarkdownCellUnconnected, mapStateToProps } from '../markdown-cell'
-import CellEditor from '../cell-editor'
-import CellRow from '../cell-row'
-import { CellContainer } from '../cell-container'
+import { MarkdownCellUnconnected, mapStateToProps } from '../markdown-cell';
+import CellEditor from '../cell-editor';
+import CellRow from '../cell-row';
+import { CellContainer } from '../cell-container';
 
 describe('MarkdownCell_unconnected react component', () => {
-  let props
-  let mountedCell
-  let markCellNotRendered
-  let changeMode
+  let props;
+  let mountedCell;
+  let markCellNotRendered;
+  let changeMode;
 
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<MarkdownCellUnconnected {...props} />)
+      mountedCell = shallow(<MarkdownCellUnconnected {...props} />);
     }
-    return mountedCell
-  }
+    return mountedCell;
+  };
 
   beforeEach(() => {
-    markCellNotRendered = jest.fn()
-    changeMode = jest.fn()
+    markCellNotRendered = jest.fn();
+    changeMode = jest.fn();
     props = {
       cellId: 1,
       value: 'a _markdown_ string',
       showMarkdown: true,
       viewMode: 'editor',
       actions: { markCellNotRendered, changeMode },
-    }
-    mountedCell = undefined
-  })
+    };
+    mountedCell = undefined;
+  });
 
   it('always renders one CellContainer', () => {
-    expect(cell().find(CellContainer).length).toBe(1)
-  })
+    expect(cell().find(CellContainer).length).toBe(1);
+  });
 
   it("sets the CellContainer cellId prop to be the MarkdownCell's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('the CellContainer should have two CellRow', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(2)
-  })
+      .find(CellRow)).toHaveLength(2);
+  });
 
   it("sets the first CellRow cellId prop to be the MarkdownCell's cellId prop", () => {
     expect(cell().find(CellRow).at(0).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the first CellRow rowType prop to be input', () => {
     expect(cell().find(CellRow).at(0).props().rowType)
-      .toBe('input')
-  })
+      .toBe('input');
+  });
 
   it('sets the second CellRow rowType prop to be output', () => {
     expect(cell().find(CellRow).at(1).props().rowType)
-      .toBe('output')
-  })
+      .toBe('output');
+  });
 
   it("sets the second CellRow cellId prop to be the MarkdownCell's cellId prop", () => {
     expect(cell().find(CellRow).at(1).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('the first CellRow always has a child that is a CellEditor', () => {
     expect(cell().wrap(cell().find(CellRow).at(0)
-      .props().children).find(CellEditor)).toHaveLength(1)
-  })
+      .props().children).find(CellEditor)).toHaveLength(1);
+  });
 
 
   it('the second CellRow always has a child that is is a div', () => {
     expect(cell().wrap(cell().find(CellRow).at(1)
-      .props().children).find('div')).toHaveLength(1)
-  })
+      .props().children).find('div')).toHaveLength(1);
+  });
 
   it('correct display styles set if showMarkdown===true', () => {
-    props.showMarkdown = true
+    props.showMarkdown = true;
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({ display: 'none' })
+      .toEqual({ display: 'none' });
 
     expect(cell().wrap(cell().find('div')).props().style)
-      .toEqual({ display: 'block' })
-  })
+      .toEqual({ display: 'block' });
+  });
 
   it('correct display styles set if showMarkdown===false', () => {
-    props.showMarkdown = false
+    props.showMarkdown = false;
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({ display: 'block' })
+      .toEqual({ display: 'block' });
 
     expect(cell().wrap(cell().find('div')).props().style)
-      .toEqual({ display: 'none' })
-  })
+      .toEqual({ display: 'none' });
+  });
 
   it('div should have dangerouslySetInnerHTML', () => {
-    props.value = 'html string'
+    props.value = 'html string';
     expect(cell().wrap(cell().find('div')).props().dangerouslySetInnerHTML)
-      .toEqual({ __html: props.value })
-  })
+      .toEqual({ __html: props.value });
+  });
 
   it('both the output recieves enterEditMode() as props', () => {
     expect(cell().wrap(cell().find('div')).props().onDoubleClick)
-      .toEqual(cell().instance().enterEditMode)
-  })
+      .toEqual(cell().instance().enterEditMode);
+  });
 
   it('dblclick on MD div fires markCellNotRendered AND changeMode', () => {
-    props.showMarkdown = true
-    props.viewMode = 'editor'
-    cell().find('div').simulate('dblclick')
+    props.showMarkdown = true;
+    props.viewMode = 'editor';
+    cell().find('div').simulate('dblclick');
     expect(cell().wrap(cell().find('div')).props().style)
-      .toEqual({ display: 'block' })
-    expect(changeMode.mock.calls.length).toBe(1)
-    expect(markCellNotRendered.mock.calls.length).toBe(1)
-  })
+      .toEqual({ display: 'block' });
+    expect(changeMode.mock.calls.length).toBe(1);
+    expect(markCellNotRendered.mock.calls.length).toBe(1);
+  });
 
   it('click on editor fires no actions', () => {
-    props.showMarkdown = false
-    props.viewMode = 'editor'
-    cell().find(CellEditor).simulate('containerClick')
+    props.showMarkdown = false;
+    props.viewMode = 'editor';
+    cell().find(CellEditor).simulate('containerClick');
     expect(cell().wrap(cell().find(CellEditor)).props().containerStyle)
-      .toEqual({ display: 'block' })
-    expect(markCellNotRendered.mock.calls.length).toBe(0)
-    expect(changeMode.mock.calls.length).toBe(0)
-  })
-})
+      .toEqual({ display: 'block' });
+    expect(markCellNotRendered.mock.calls.length).toBe(0);
+    expect(changeMode.mock.calls.length).toBe(0);
+  });
+});
 
 
 describe('MarkdownCell mapStateToProps', () => {
-  let state
+  let state;
 
   const markdownShownVariants = [
     { selected: true, mode: 'not_edit', rendered: true },
     { selected: false, mode: 'edit', rendered: true },
     { selected: false, mode: 'not_edit', rendered: true },
-  ]
+  ];
 
   const markdownNotShownVariants = [
     { selected: true, mode: 'edit', rendered: true },
@@ -144,7 +144,7 @@ describe('MarkdownCell mapStateToProps', () => {
     { selected: true, mode: 'not_edit', rendered: false },
     { selected: false, mode: 'edit', rendered: false },
     { selected: false, mode: 'not_edit', rendered: false },
-  ]
+  ];
 
   beforeEach(() => {
     state = {
@@ -157,45 +157,45 @@ describe('MarkdownCell mapStateToProps', () => {
       ],
       mode: 'edit',
       viewMode: 'presentation',
-    }
-  })
+    };
+  });
 
   it('should return the basic info for the correct cell', () => {
-    const ownProps = { cellId: 5 }
+    const ownProps = { cellId: 5 };
     expect(mapStateToProps(state, ownProps))
       .toEqual({
         value: '#MD string',
         showMarkdown: false,
         viewMode: 'presentation',
-      })
-  })
+      });
+  });
 
   markdownShownVariants.forEach((stateMods) => {
     it(`should have showMarkdown:true for ${JSON.stringify(stateMods)}`, () => {
-      state.cells[0].rendered = stateMods.rendered
-      state.cells[0].selected = stateMods.selected
-      state.mode = stateMods.mode
-      const ownProps = { cellId: 5 }
+      state.cells[0].rendered = stateMods.rendered;
+      state.cells[0].selected = stateMods.selected;
+      state.mode = stateMods.mode;
+      const ownProps = { cellId: 5 };
       expect(mapStateToProps(state, ownProps))
         .toEqual({
           value: '#MD string',
           showMarkdown: true,
           viewMode: 'presentation',
-        })
-    })
-  })
+        });
+    });
+  });
   markdownNotShownVariants.forEach((stateMods) => {
     it(`should have showMarkdown:false for ${JSON.stringify(stateMods)}`, () => {
-      state.cells[0].rendered = stateMods.rendered
-      state.cells[0].selected = stateMods.selected
-      state.mode = stateMods.mode
-      const ownProps = { cellId: 5 }
+      state.cells[0].rendered = stateMods.rendered;
+      state.cells[0].selected = stateMods.selected;
+      state.mode = stateMods.mode;
+      const ownProps = { cellId: 5 };
       expect(mapStateToProps(state, ownProps))
         .toEqual({
           value: '#MD string',
           showMarkdown: false,
           viewMode: 'presentation',
-        })
-    })
-  })
-})
+        });
+    });
+  });
+});

--- a/src/components/cells/__tests__/raw-cell.test.js
+++ b/src/components/cells/__tests__/raw-cell.test.js
@@ -1,60 +1,60 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import { RawCellUnconnected as RawCell } from '../raw-cell'
-import { CellContainer } from '../cell-container'
-import CellRow from '../cell-row'
-import CellEditor from '../cell-editor'
+import { RawCellUnconnected as RawCell } from '../raw-cell';
+import { CellContainer } from '../cell-container';
+import CellRow from '../cell-row';
+import CellEditor from '../cell-editor';
 
 
 describe('RawCellUnconnected react component', () => {
-  let props
-  let mountedCell
+  let props;
+  let mountedCell;
   const cell = () => {
     if (!mountedCell) {
-      mountedCell = shallow(<RawCell {...props} />)
+      mountedCell = shallow(<RawCell {...props} />);
     }
-    return mountedCell
-  }
+    return mountedCell;
+  };
 
   beforeEach(() => {
     props = {
       cellId: 5,
-    }
-    mountedCell = undefined
-  })
+    };
+    mountedCell = undefined;
+  });
 
   it('always renders one CellContainer', () => {
-    expect(cell().find(CellContainer).length).toBe(1)
-  })
+    expect(cell().find(CellContainer).length).toBe(1);
+  });
 
   it('always renders one CellRow inside CellContainer', () => {
     expect(cell().wrap(cell().find(CellContainer))
-      .find(CellRow)).toHaveLength(1)
-  })
+      .find(CellRow)).toHaveLength(1);
+  });
 
   it('always renders one CellEditor inside CellRow', () => {
     expect(cell().wrap(cell().find(CellRow))
-      .find(CellEditor)).toHaveLength(1)
-  })
+      .find(CellEditor)).toHaveLength(1);
+  });
 
   it("sets the CellContainer cellId prop to be the RawCell's cellId prop", () => {
     expect(cell().find(CellContainer).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it("sets the CellRow cellId prop to be the RawCell's cellId prop", () => {
     expect(cell().find(CellRow).props().cellId)
-      .toBe(props.cellId)
-  })
+      .toBe(props.cellId);
+  });
 
   it('sets the CellRow rowType prop to be input', () => {
     expect(cell().find(CellRow).props().rowType)
-      .toBe('input')
-  })
+      .toBe('input');
+  });
 
   it("sets the CellEditor cellId prop to be the RawCell's cellId prop", () => {
     expect(cell().find(CellEditor).props().cellId)
-      .toBe(props.cellId)
-  })
-})
+      .toBe(props.cellId);
+  });
+});

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
-import * as actions from '../../actions/actions'
-import { getCellById } from '../../tools/notebook-utils'
-import { cellTypeEnum } from '../../state-prototypes'
+import * as actions from '../../actions/actions';
+import { getCellById } from '../../tools/notebook-utils';
+import { cellTypeEnum } from '../../state-prototypes';
 
-import CellMenuContainer from './cell-menu-container'
+import CellMenuContainer from './cell-menu-container';
 
 
 export class CellContainerUnconnected extends React.Component {
@@ -34,9 +34,9 @@ export class CellContainerUnconnected extends React.Component {
 
   handleCellClick = () => {
     if (this.props.viewMode === 'editor') {
-      const scrollToCell = false
+      const scrollToCell = false;
       if (!this.props.selected) {
-        this.props.actions.selectCell(this.props.cellId, scrollToCell)
+        this.props.actions.selectCell(this.props.cellId, scrollToCell);
       }
     }
   }
@@ -49,7 +49,7 @@ export class CellContainerUnconnected extends React.Component {
       this.props.selected ? ' selected-cell' : ''
     }${
       this.props.editingCell ? ' editing-cell' : ''
-    }`
+    }`;
 
     return (
       <div
@@ -62,28 +62,28 @@ export class CellContainerUnconnected extends React.Component {
           {this.props.children}
         </div>
       </div>
-    )
+    );
   }
 }
 
 
 export function mapStateToProps(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
+  const cell = getCellById(state.cells, ownProps.cellId);
   return {
     cellId: cell.id,
     selected: cell.selected,
     editingCell: cell.selected && state.mode === 'edit',
     viewMode: state.viewMode,
     cellType: cell.cellType,
-  }
+  };
 }
 
 export function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
 // export default connect(mapStateToProps, mapDispatchToProps)(Page)
 const CellContainerConnected = connect(mapStateToProps, mapDispatchToProps)(CellContainerUnconnected) // eslint-disable-line
-export { CellContainerConnected as CellContainer }
+export { CellContainerConnected as CellContainer };

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -1,81 +1,81 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 
 
-import CodeMirror from '@skidding/react-codemirror'
-import js from 'codemirror/mode/javascript/javascript' // eslint-disable-line no-unused-vars
-import markdown from 'codemirror/mode/markdown/markdown' // eslint-disable-line no-unused-vars
-import css from 'codemirror/mode/css/css' // eslint-disable-line no-unused-vars
-import matchbrackets from 'codemirror/addon/edit/matchbrackets' // eslint-disable-line no-unused-vars
-import closebrackets from 'codemirror/addon/edit/closebrackets' // eslint-disable-line no-unused-vars
-import autorefresh from 'codemirror/addon/display/autorefresh' // eslint-disable-line no-unused-vars
-import comment from 'codemirror/addon/comment/comment' // eslint-disable-line no-unused-vars
-import 'codemirror/addon/hint/show-hint'
-import 'codemirror/addon/hint/javascript-hint'
+import CodeMirror from '@skidding/react-codemirror';
+import js from 'codemirror/mode/javascript/javascript'; // eslint-disable-line no-unused-vars
+import markdown from 'codemirror/mode/markdown/markdown'; // eslint-disable-line no-unused-vars
+import css from 'codemirror/mode/css/css'; // eslint-disable-line no-unused-vars
+import matchbrackets from 'codemirror/addon/edit/matchbrackets'; // eslint-disable-line no-unused-vars
+import closebrackets from 'codemirror/addon/edit/closebrackets'; // eslint-disable-line no-unused-vars
+import autorefresh from 'codemirror/addon/display/autorefresh'; // eslint-disable-line no-unused-vars
+import comment from 'codemirror/addon/comment/comment'; // eslint-disable-line no-unused-vars
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/javascript-hint';
 
-import sublime from '../../codemirror-keymap-sublime' // eslint-disable-line no-unused-vars
-import { getCellById } from '../../tools/notebook-utils'
-import * as actions from '../../actions/actions'
+import sublime from '../../codemirror-keymap-sublime'; // eslint-disable-line no-unused-vars
+import { getCellById } from '../../tools/notebook-utils';
+import * as actions from '../../actions/actions';
 
 // This block is from CodeMirror's loadmode.js, modified to work in this environment
 {
   const CodeMirrorBase = require('codemirror') // eslint-disable-line
   CodeMirrorBase.modeUrl =
-    `https://cdnjs.cloudflare.com/ajax/libs/codemirror/${CodeMirrorBase.version}/mode/%N/%N.js`
-  window.CodeMirror = CodeMirrorBase
+    `https://cdnjs.cloudflare.com/ajax/libs/codemirror/${CodeMirrorBase.version}/mode/%N/%N.js`;
+  window.CodeMirror = CodeMirrorBase;
 
-  const modeLoading = {}
+  const modeLoading = {};
   function splitCallback(cont, n) {
-    let countDown = n
+    let countDown = n;
     return () => {
-      countDown -= 1
+      countDown -= 1;
       if (countDown === 0) {
-        cont()
+        cont();
       }
-    }
+    };
   }
 
   function ensureDeps(mode, cont) {
-    const deps = CodeMirrorBase.modes[mode].dependencies
-    if (!deps) return cont()
-    const missing = []
+    const deps = CodeMirrorBase.modes[mode].dependencies;
+    if (!deps) return cont();
+    const missing = [];
     for (let i = 0; i < deps.length; ++i) {
       if (!Object.prototype.hasOwnProperty.call(CodeMirrorBase.modes, deps[i])) {
-        missing.push(deps[i])
+        missing.push(deps[i]);
       }
     }
-    if (!missing.length) return cont()
-    const split = splitCallback(cont, missing.length)
+    if (!missing.length) return cont();
+    const split = splitCallback(cont, missing.length);
     for (let i = 0; i < missing.length; ++i) {
-      CodeMirrorBase.requireMode(missing[i], split)
+      CodeMirrorBase.requireMode(missing[i], split);
     }
-    return undefined
+    return undefined;
   }
 
   CodeMirrorBase.requireMode = (mode, cont) => {
     if (Object.prototype.hasOwnProperty.call(CodeMirrorBase.modes, mode)) {
-      return ensureDeps(mode, cont)
+      return ensureDeps(mode, cont);
     }
     if (Object.prototype.hasOwnProperty.call(modeLoading, mode)) {
-      return modeLoading[mode].push(cont)
+      return modeLoading[mode].push(cont);
     }
 
-    const file = CodeMirrorBase.modeUrl.replace(/%N/g, mode)
-    const script = document.createElement('script')
-    script.src = file
-    const others = document.getElementsByTagName('script')[0]
-    modeLoading[mode] = [cont]
-    const list = modeLoading[mode]
+    const file = CodeMirrorBase.modeUrl.replace(/%N/g, mode);
+    const script = document.createElement('script');
+    script.src = file;
+    const others = document.getElementsByTagName('script')[0];
+    modeLoading[mode] = [cont];
+    const list = modeLoading[mode];
     CodeMirrorBase.on(script, 'load', () => {
       ensureDeps(mode, () => {
-        for (let i = 0; i < list.length; ++i) list[i]()
-      })
-    })
-    others.parentNode.insertBefore(script, others)
-    return undefined
-  }
+        for (let i = 0; i < list.length; ++i) list[i]();
+      });
+    });
+    others.parentNode.insertBefore(script, others);
+    return undefined;
+  };
 }
 
 class CellEditor extends React.Component {
@@ -97,55 +97,55 @@ class CellEditor extends React.Component {
   }
 
   constructor(props) {
-    super(props)
+    super(props);
     // explicitly bind "this" for all methods in constructors
-    this.storeEditorElementRef = this.storeEditorElementRef.bind(this)
-    this.handleFocusChange = this.handleFocusChange.bind(this)
-    this.updateInputContent = this.updateInputContent.bind(this)
-    this.storeEditorElementRef = this.storeEditorElementRef.bind(this)
+    this.storeEditorElementRef = this.storeEditorElementRef.bind(this);
+    this.handleFocusChange = this.handleFocusChange.bind(this);
+    this.updateInputContent = this.updateInputContent.bind(this);
+    this.storeEditorElementRef = this.storeEditorElementRef.bind(this);
   }
 
   componentDidMount() {
     if (this.props.thisCellBeingEdited
       && this.refs.hasOwnProperty('editor') // eslint-disable-line
     ) {
-      this.editor.focus()
+      this.editor.focus();
     }
   }
 
   componentDidUpdate() {
     if (this.props.thisCellBeingEdited) {
-      this.editor.focus()
+      this.editor.focus();
     } else {
-      this.editor.getCodeMirror().display.input.textarea.blur()
+      this.editor.getCodeMirror().display.input.textarea.blur();
     }
   }
 
   handleFocusChange(focused) {
     if (focused && this.props.viewMode === 'editor') {
       if (!this.props.thisCellBeingEdited) {
-        this.props.actions.selectCell(this.props.cellId)
-        this.props.actions.changeMode('edit')
+        this.props.actions.selectCell(this.props.cellId);
+        this.props.actions.changeMode('edit');
       }
     } else if (!focused && this.props.viewMode === 'editor') {
-      this.props.actions.changeMode('command')
+      this.props.actions.changeMode('command');
     }
   }
 
   storeEditorElementRef(editorElt) {
-    this.editor = editorElt
+    this.editor = editorElt;
     // pass this cm instance ref up to the parent cell with this callback
     if (this.props.inputRef) {
-      this.props.inputRef(editorElt)
+      this.props.inputRef(editorElt);
     }
   }
 
   updateInputContent(content) {
-    this.props.actions.updateInputContent(content)
+    this.props.actions.updateInputContent(content);
   }
 
   autoComplete = (cm) => {
-    const codeMirror = this.editor.getCodeMirrorInstance()
+    const codeMirror = this.editor.getCodeMirrorInstance();
     // hint options for specific plugin & general show-hint
     // Other general hint config, like 'completeSingle' and 'completeOnSingleClick'
     // should be specified here and will be honored
@@ -153,7 +153,7 @@ class CellEditor extends React.Component {
       disableKeywords: true,
       completeSingle: false,
       completeOnSingleClick: false,
-    }
+    };
     // Reference the hint function imported here when including other hint addons
     // or supply your own
     codeMirror.showHint(cm, codeMirror.hint.javascript, hintOptions);
@@ -174,7 +174,7 @@ class CellEditor extends React.Component {
       },
       comment: this.props.codeMirrorMode === 'javascript',
       readOnly: this.props.viewMode === 'presentation',
-    }, this.props.editorOptions)
+    }, this.props.editorOptions);
 
     return (
       <div
@@ -189,20 +189,20 @@ class CellEditor extends React.Component {
           onFocusChange={this.handleFocusChange}
         />
       </div>
-    )
+    );
   }
 }
 
 
 function mapStateToProps(state, ownProps) {
-  const { cellId } = ownProps
-  const cell = getCellById(state.cells, cellId)
+  const { cellId } = ownProps;
+  const cell = getCellById(state.cells, cellId);
   const languageModule = cell.language in state.languages ?
-    state.languages[cell.language].module : null
+    state.languages[cell.language].module : null;
 
   const codeMirrorMode = (
     cell.cellType === 'code' ? state.languages[cell.language].codeMirrorMode : cell.cellType
-  )
+  );
 
   return {
     thisCellBeingEdited: cell.selected && state.mode === 'edit',
@@ -212,13 +212,13 @@ function mapStateToProps(state, ownProps) {
     cellId,
     codeMirrorMode,
     languageIsAvailable: cell.cellType !== 'code' ? true : window[languageModule] !== undefined,
-  }
+  };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CellEditor)
+export default connect(mapStateToProps, mapDispatchToProps)(CellEditor);

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -1,14 +1,14 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import PropTypes from 'prop-types'
-import Tooltip from 'material-ui/Tooltip'
-import Menu from 'material-ui/Menu'
-import ArrowDropDown from 'material-ui-icons/ArrowDropDown'
-import CellMenu from './cell-menu'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import Tooltip from 'material-ui/Tooltip';
+import Menu from 'material-ui/Menu';
+import ArrowDropDown from 'material-ui-icons/ArrowDropDown';
+import CellMenu from './cell-menu';
 
-import * as actions from '../../actions/actions'
-import { getCellById } from '../../tools/notebook-utils'
+import * as actions from '../../actions/actions';
+import { getCellById } from '../../tools/notebook-utils';
 
 
 export class CellMenuContainerUnconnected extends React.Component {
@@ -19,24 +19,24 @@ export class CellMenuContainerUnconnected extends React.Component {
   }
 
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
       anchorElement: null,
-    }
-    this.handleClick = this.handleClick.bind(this)
-    this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
+    };
+    this.handleClick = this.handleClick.bind(this);
+    this.handleIconButtonClose = this.handleIconButtonClose.bind(this);
   }
 
   handleClick(event) {
-    this.setState({ anchorElement: event.currentTarget })
+    this.setState({ anchorElement: event.currentTarget });
   }
 
   handleIconButtonClose() {
-    this.setState({ anchorElement: null })
+    this.setState({ anchorElement: null });
   }
 
   render() {
-    const { anchorElement } = this.state
+    const { anchorElement } = this.state;
     const skipInRunAllIndicator = (
       this.props.skipInRunAll ?
         (
@@ -52,7 +52,7 @@ export class CellMenuContainerUnconnected extends React.Component {
           </Tooltip>
         ) :
         ''
-    )
+    );
 
     return (
       <div className="cell-menu-container">
@@ -90,38 +90,38 @@ export class CellMenuContainerUnconnected extends React.Component {
         </Tooltip>
         <div className="cell-status-indicators">{skipInRunAllIndicator}</div>
       </div>
-    )
+    );
   }
 }
 
 
 function mapStateToProps(state, ownProps) {
-  const { cellId } = ownProps
-  const cell = getCellById(state.cells, cellId)
-  let label
+  const { cellId } = ownProps;
+  const cell = getCellById(state.cells, cellId);
+  let label;
   if (cell.cellType === 'code') {
-    label = cell.language
+    label = cell.language;
   } else if (cell.cellType === 'markdown') {
-    label = 'md'
+    label = 'md';
   } else if (cell.cellType === 'css') {
-    label = 'css'
+    label = 'css';
   } else if (cell.cellType === 'plugin') {
-    label = 'plugin'
+    label = 'plugin';
   } else if (cell.cellType === 'external dependencies') {
-    label = 'resource'
+    label = 'resource';
   } else if (cell.cellType === 'raw') {
-    label = 'raw'
+    label = 'raw';
   }
   return {
     label,
     skipInRunAll: cell.skipInRunAll,
-  }
+  };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CellMenuContainerUnconnected)
+export default connect(mapStateToProps, mapDispatchToProps)(CellMenuContainerUnconnected);

--- a/src/components/cells/cell-menu.jsx
+++ b/src/components/cells/cell-menu.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-import NotebookMenuItem from '../menu/notebook-menu-item'
-import NotebookMenuDivider from '../menu/notebook-menu-divider'
-import { getCellById } from '../../tools/notebook-utils'
-import tasks from '../../actions/task-definitions'
+import NotebookMenuItem from '../menu/notebook-menu-item';
+import NotebookMenuDivider from '../menu/notebook-menu-divider';
+import { getCellById } from '../../tools/notebook-utils';
+import tasks from '../../actions/task-definitions';
 
 export class CellMenuUnconnected extends React.Component {
   static propTypes = {
@@ -54,15 +54,15 @@ export class CellMenuUnconnected extends React.Component {
           task={tasks.toggleSkipCellInRunAll}
         />
       </div>
-    )
+    );
   }
 }
 
 
 export function mapStateToProps(state, ownProps) {
-  const { cellId } = ownProps
-  const { skipInRunAll } = getCellById(state.cells, cellId)
-  return { skipInRunAll }
+  const { cellId } = ownProps;
+  const { skipInRunAll } = getCellById(state.cells, cellId);
+  return { skipInRunAll };
 }
 
-export default connect(mapStateToProps)(CellMenuUnconnected)
+export default connect(mapStateToProps)(CellMenuUnconnected);

--- a/src/components/cells/cell-output.jsx
+++ b/src/components/cells/cell-output.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import { getCellById } from '../../tools/notebook-utils'
-import { ValueRenderer } from '../reps/value-renderer'
+import { getCellById } from '../../tools/notebook-utils';
+import { ValueRenderer } from '../reps/value-renderer';
 
 export class CellOutputUnconnected extends React.Component {
   static propTypes = {
@@ -17,16 +17,16 @@ export class CellOutputUnconnected extends React.Component {
         render={this.props.render}
         valueToRender={this.props.valueToRender}
       />
-    )
+    );
   }
 }
 
 export function mapStateToProps(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
+  const cell = getCellById(state.cells, ownProps.cellId);
   return {
     valueToRender: cell.value,
     render: cell.rendered,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(CellOutputUnconnected)
+export default connect(mapStateToProps)(CellOutputUnconnected);

--- a/src/components/cells/cell-row.jsx
+++ b/src/components/cells/cell-row.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import PropTypes from 'prop-types'
-import Tooltip from 'material-ui/Tooltip'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+import Tooltip from 'material-ui/Tooltip';
 
-import { getCellById } from '../../tools/notebook-utils'
-import * as actions from '../../actions/actions'
-import { rowOverflowEnum, nextOverflow } from '../../state-prototypes'
+import { getCellById } from '../../tools/notebook-utils';
+import * as actions from '../../actions/actions';
+import { rowOverflowEnum, nextOverflow } from '../../state-prototypes';
 
 export class CellRowUnconnected extends React.Component {
   static propTypes = {
@@ -22,9 +22,9 @@ export class CellRowUnconnected extends React.Component {
   }
 
   constructor(props) {
-    super(props)
+    super(props);
     // explicitly bind "this" for all methods in constructors
-    this.handleCollapseButtonClick = this.handleCollapseButtonClick.bind(this)
+    this.handleCollapseButtonClick = this.handleCollapseButtonClick.bind(this);
   }
 
   componentDidUpdate() {
@@ -37,7 +37,7 @@ export class CellRowUnconnected extends React.Component {
         'editor',
         'input',
         rowOverflowEnum.SCROLL,
-      )
+      );
     }
   }
 
@@ -48,7 +48,7 @@ export class CellRowUnconnected extends React.Component {
         'editor',
         this.props.rowType,
         nextOverflow(this.props.rowOverflow),
-      )
+      );
     }
   }
 
@@ -71,27 +71,27 @@ export class CellRowUnconnected extends React.Component {
           {this.props.children}
         </div>
       </div>
-    )
+    );
   }
 }
 
 export function mapStateToPropsCellRows(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
-  let view
+  const cell = getCellById(state.cells, ownProps.cellId);
+  let view;
   // this block can be deprecated if we move to enums for VIEWs
   switch (state.viewMode) {
     case 'editor':
-      view = 'EXPLORE'
-      break
+      view = 'EXPLORE';
+      break;
     case 'presentation':
-      view = 'REPORT'
-      break
+      view = 'REPORT';
+      break;
     default:
-      throw Error(`Unsupported viewMode: ${state.viewMode}`)
+      throw Error(`Unsupported viewMode: ${state.viewMode}`);
   }
-  const rowOverflow = cell.rowSettings[view][ownProps.rowType]
+  const rowOverflow = cell.rowSettings[view][ownProps.rowType];
   const executionString = (ownProps.rowType === 'input'
-    && cell.cellType === 'code') ? `[${cell.executionStatus}]` : ''
+    && cell.cellType === 'code') ? `[${cell.executionStatus}]` : '';
   // if this is an input row, uncollapse
   // the editor upon entering edit mode.
   // note: entering editMode is only allowed from editor View
@@ -102,13 +102,13 @@ export function mapStateToPropsCellRows(state, ownProps) {
     state.mode === 'edit' &&
     ownProps.rowType === 'input' &&
     rowOverflow === rowOverflowEnum.HIDDEN
-  )
+  );
   const collapseTooltipPlacement = (
     rowOverflow === rowOverflowEnum.HIDDEN ? 'bottom' : 'right'
-  )
+  );
 
-  const nextOverflowString = { HIDDEN: 'expand', VISIBLE: 'scroll', SCROLL: 'collapse' }[rowOverflow]
-  const tooltipText = `click to ${nextOverflowString} this ${ownProps.rowType}`
+  const nextOverflowString = { HIDDEN: 'expand', VISIBLE: 'scroll', SCROLL: 'collapse' }[rowOverflow];
+  const tooltipText = `click to ${nextOverflowString} this ${ownProps.rowType}`;
   return {
     cellId: ownProps.cellId,
     viewMode: state.viewMode,
@@ -117,13 +117,13 @@ export function mapStateToPropsCellRows(state, ownProps) {
     rowOverflow,
     collapseTooltipPlacement,
     tooltipText,
-  }
+  };
 }
 
 function mapDispatchToPropsCellRows(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
-export default connect(mapStateToPropsCellRows, mapDispatchToPropsCellRows)(CellRowUnconnected)
+export default connect(mapStateToPropsCellRows, mapDispatchToPropsCellRows)(CellRowUnconnected);

--- a/src/components/cells/code-cell.jsx
+++ b/src/components/cells/code-cell.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
-import CellOutput from './cell-output'
-import CellEditor from './cell-editor'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
+import CellOutput from './cell-output';
+import CellEditor from './cell-editor';
 
 export class CodeCellUnconnected extends React.Component {
   static propTypes = {
@@ -26,8 +26,8 @@ export class CodeCellUnconnected extends React.Component {
           <CellOutput cellId={this.props.cellId} />
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
-export default connect()(CodeCellUnconnected)
+export default connect()(CodeCellUnconnected);

--- a/src/components/cells/css-cell.jsx
+++ b/src/components/cells/css-cell.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
-import CellEditor from './cell-editor'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
+import CellEditor from './cell-editor';
 
-import { getCellById } from '../../tools/notebook-utils'
+import { getCellById } from '../../tools/notebook-utils';
 
 export class CSSCellUnconnected extends React.Component {
   static propTypes = {
@@ -25,18 +25,18 @@ export class CSSCellUnconnected extends React.Component {
           </style>
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
 
 export function mapStateToProps(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
+  const cell = getCellById(state.cells, ownProps.cellId);
   return {
     cellId: cell.id,
     value: cell.value,
     rendered: cell.rendered,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(CSSCellUnconnected)
+export default connect(mapStateToProps)(CSSCellUnconnected);

--- a/src/components/cells/external-resource-cell.jsx
+++ b/src/components/cells/external-resource-cell.jsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
-import CellEditor from './cell-editor'
-import ExternalResourceOutputHandler from '../reps/output-handler-external-resource'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
+import CellEditor from './cell-editor';
+import ExternalResourceOutputHandler from '../reps/output-handler-external-resource';
 
-import { getCellById } from '../../tools/notebook-utils'
+import { getCellById } from '../../tools/notebook-utils';
 
 export class ExternalResourceCellUnconnected extends React.Component {
   static propTypes = {
@@ -25,17 +25,17 @@ export class ExternalResourceCellUnconnected extends React.Component {
           <ExternalResourceOutputHandler value={this.props.value} />
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
 
 export function mapStateToProps(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
+  const cell = getCellById(state.cells, ownProps.cellId);
   return {
     value: cell.value,
     cellId: cell.id,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(ExternalResourceCellUnconnected)
+export default connect(mapStateToProps)(ExternalResourceCellUnconnected);

--- a/src/components/cells/markdown-cell.jsx
+++ b/src/components/cells/markdown-cell.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import PropTypes from 'prop-types'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
 
-import CellEditor from './cell-editor'
+import CellEditor from './cell-editor';
 
-import * as actions from '../../actions/actions'
-import { getCellById } from '../../tools/notebook-utils'
+import * as actions from '../../actions/actions';
+import { getCellById } from '../../tools/notebook-utils';
 
 
 export class MarkdownCellUnconnected extends React.Component {
@@ -22,20 +22,20 @@ export class MarkdownCellUnconnected extends React.Component {
 
   enterEditMode = () => {
     if (this.props.viewMode === 'editor') {
-      this.props.actions.changeMode('edit')
-      this.props.actions.markCellNotRendered()
+      this.props.actions.changeMode('edit');
+      this.props.actions.markCellNotRendered();
     }
   }
 
   render() {
-    let resultDisplayStyle
-    let editorDisplayStyle
+    let resultDisplayStyle;
+    let editorDisplayStyle;
     if (this.props.showMarkdown) {
-      resultDisplayStyle = 'block'
-      editorDisplayStyle = 'none'
+      resultDisplayStyle = 'block';
+      editorDisplayStyle = 'none';
     } else {
-      resultDisplayStyle = 'none'
-      editorDisplayStyle = 'block'
+      resultDisplayStyle = 'none';
+      editorDisplayStyle = 'block';
     }
 
     return (
@@ -61,25 +61,25 @@ export class MarkdownCellUnconnected extends React.Component {
           />
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
 
 export function mapStateToProps(state, ownProps) {
-  const cell = getCellById(state.cells, ownProps.cellId)
-  const beingEdited = cell.selected && state.mode === 'edit'
+  const cell = getCellById(state.cells, ownProps.cellId);
+  const beingEdited = cell.selected && state.mode === 'edit';
   return {
     value: cell.value,
     showMarkdown: cell.rendered && !beingEdited,
     viewMode: state.viewMode,
-  }
+  };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MarkdownCellUnconnected)
+export default connect(mapStateToProps, mapDispatchToProps)(MarkdownCellUnconnected);

--- a/src/components/cells/plugin-definition-cell.js
+++ b/src/components/cells/plugin-definition-cell.js
@@ -1,11 +1,11 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
-import CellEditor from './cell-editor'
-import CellOutput from './cell-output'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
+import CellEditor from './cell-editor';
+import CellOutput from './cell-output';
 
 // import PluginProgressMonitor from './plugin-progress-monitor'
 
@@ -32,8 +32,8 @@ export class PluginDefCellUnconnected extends React.Component {
           </div>
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
-export default connect()(PluginDefCellUnconnected)
+export default connect()(PluginDefCellUnconnected);

--- a/src/components/cells/raw-cell.jsx
+++ b/src/components/cells/raw-cell.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import CellRow from './cell-row'
-import { CellContainer } from './cell-container'
-import CellEditor from './cell-editor'
+import CellRow from './cell-row';
+import { CellContainer } from './cell-container';
+import CellEditor from './cell-editor';
 
 
 export class RawCellUnconnected extends React.Component {
@@ -24,8 +24,8 @@ export class RawCellUnconnected extends React.Component {
           />
         </CellRow>
       </CellContainer>
-    )
+    );
   }
 }
 
-export default connect()(RawCellUnconnected)
+export default connect()(RawCellUnconnected);

--- a/src/components/menu/__tests__/notebook-menu-item.test.js
+++ b/src/components/menu/__tests__/notebook-menu-item.test.js
@@ -1,63 +1,63 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import MenuItem from 'material-ui/Menu/MenuItem'
-import { ListItemText } from 'material-ui/List'
+import MenuItem from 'material-ui/Menu/MenuItem';
+import { ListItemText } from 'material-ui/List';
 
-import NotebookMenuItem from '../notebook-menu-item'
-import UserTask from '../../../actions/user-task'
+import NotebookMenuItem from '../notebook-menu-item';
+import UserTask from '../../../actions/user-task';
 
 describe('NotebookMenuItem children', () => {
-  let props
-  let mountedComp
+  let props;
+  let mountedComp;
   const nbMenuItem = () => {
     if (!mountedComp) {
-      mountedComp = shallow(<NotebookMenuItem {...props} />)
+      mountedComp = shallow(<NotebookMenuItem {...props} />);
     }
-    return mountedComp
-  }
+    return mountedComp;
+  };
 
   beforeEach(() => {
     props = {
       task: new UserTask({ title: 'ok', callback: () => {}, displayKeybinding: 'a' }),
-    }
-    mountedComp = undefined
-  })
+    };
+    mountedComp = undefined;
+  });
 
   it('renders one MenuItem', () => {
-    expect(NotebookMenuItem.muiName).toBe('MenuItem')
-    expect(nbMenuItem().find(MenuItem).length).toBe(1)
-    expect(nbMenuItem().find(ListItemText).length).toBe(2)
-    expect(nbMenuItem().find(ListItemText).first().props().primary).toBe(props.task.title)
-  })
+    expect(NotebookMenuItem.muiName).toBe('MenuItem');
+    expect(nbMenuItem().find(MenuItem).length).toBe(1);
+    expect(nbMenuItem().find(ListItemText).length).toBe(2);
+    expect(nbMenuItem().find(ListItemText).first().props().primary).toBe(props.task.title);
+  });
 
   it('renders one MenuItem with keybinding', () => {
     expect(nbMenuItem().find(ListItemText).last()
-      .props().primary).toBe(props.task.displayKeybinding)
-  })
+      .props().primary).toBe(props.task.displayKeybinding);
+  });
   it('renders one MenuItem with secondaryText', () => {
-    const nb = shallow(<NotebookMenuItem task={new UserTask({ title: 'ok', callback: () => {}, secondaryText: 'neat' })} />)
+    const nb = shallow(<NotebookMenuItem task={new UserTask({ title: 'ok', callback: () => {}, secondaryText: 'neat' })} />);
     expect(nb.find(ListItemText).last()
-      .props().primary).toBe('neat')
-  })
-})
+      .props().primary).toBe('neat');
+  });
+});
 
 describe('NotebookMenuItem fires callback from task when clicked', () => {
-  let sentinel = false
-  const nb = shallow(<NotebookMenuItem task={new UserTask({ title: 'ok', callback: () => { sentinel = true } })} />)
+  let sentinel = false;
+  const nb = shallow(<NotebookMenuItem task={new UserTask({ title: 'ok', callback: () => { sentinel = true; } })} />);
   it('should upon click change the sentinel', () => {
-    nb.simulate('click')
-    expect(sentinel).toBe(true)
-  })
-})
+    nb.simulate('click');
+    expect(sentinel).toBe(true);
+  });
+});
 
 describe('NotebookMenuItem fires all additional onClick events', () => {
-  let sentinel = false
-  let innerSentinel = false
-  const nestedNB = shallow(<NotebookMenuItem onClick={() => { sentinel = true }} task={new UserTask({ title: 'ok', callback: () => { innerSentinel = true } })} />)
+  let sentinel = false;
+  let innerSentinel = false;
+  const nestedNB = shallow(<NotebookMenuItem onClick={() => { sentinel = true; }} task={new UserTask({ title: 'ok', callback: () => { innerSentinel = true; } })} />);
   it('should also fire the onClick event as well when NotebookMenuItem is clicked', () => {
-    nestedNB.simulate('click')
-    expect(sentinel).toBe(true)
-    expect(innerSentinel).toBe(true)
-  })
-})
+    nestedNB.simulate('click');
+    expect(sentinel).toBe(true);
+    expect(innerSentinel).toBe(true);
+  });
+});

--- a/src/components/menu/__tests__/notebook-menu-subsection.test.js
+++ b/src/components/menu/__tests__/notebook-menu-subsection.test.js
@@ -1,20 +1,20 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import MenuItem from 'material-ui/Menu/MenuItem'
-import Menu from 'material-ui/Menu/Menu'
+import MenuItem from 'material-ui/Menu/MenuItem';
+import Menu from 'material-ui/Menu/Menu';
 
-import NotebookMenuSubsection from '../notebook-menu-subsection'
-import NotebookMenuItem from '..//notebook-menu-item'
-import UserTask from '../../../actions/user-task'
+import NotebookMenuSubsection from '../notebook-menu-subsection';
+import NotebookMenuItem from '..//notebook-menu-item';
+import UserTask from '../../../actions/user-task';
 
 describe('barebones NotebookMenuSubsection', () => {
-  const nbSubsection = shallow(<NotebookMenuSubsection />)
+  const nbSubsection = shallow(<NotebookMenuSubsection />);
   it('has a MenuItem as a top-level child', () => {
-    expect(nbSubsection.find(MenuItem)).toHaveLength(1)
-    expect(nbSubsection.find(Menu)).toHaveLength(1)
-  })
-})
+    expect(nbSubsection.find(MenuItem)).toHaveLength(1);
+    expect(nbSubsection.find(Menu)).toHaveLength(1);
+  });
+});
 
 describe('A nested NotebookMenuSubsection', () => {
   // create a single nbmss with a single menu item in it.
@@ -22,7 +22,7 @@ describe('A nested NotebookMenuSubsection', () => {
   // test click events for inner elment and propagation upward
   // let innerSentinel = false
   // let outerSentinel = false
-  const outerClick = () => undefined /* outerSentinel = true */
+  const outerClick = () => undefined; /* outerSentinel = true */
   const nbSubsection = shallow((
     <NotebookMenuSubsection onClick={outerClick}>
       <NotebookMenuItem task={new UserTask({
@@ -31,10 +31,10 @@ describe('A nested NotebookMenuSubsection', () => {
 })}
       />
     </NotebookMenuSubsection>
-  ))
+  ));
   it('should contain more than one NotebookMenuItem now', () => {
-    expect(nbSubsection.find(NotebookMenuItem)).toHaveLength(1)
-  })
+    expect(nbSubsection.find(NotebookMenuItem)).toHaveLength(1);
+  });
   // .simulate actually really struggles to simulate the click.
   // We're not creating the right elements here.
   // it('should propagate the click events upward', () => {
@@ -43,4 +43,4 @@ describe('A nested NotebookMenuSubsection', () => {
   //   expect(innerSentinel).toBe(true)
   //   expect(outerSentinel).toBe(true)
   // })
-})
+});

--- a/src/components/menu/__tests__/notebook-task-button.test.js
+++ b/src/components/menu/__tests__/notebook-task-button.test.js
@@ -1,24 +1,24 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React from 'react';
+import { shallow } from 'enzyme';
 
-import IconButton from 'material-ui/IconButton'
+import IconButton from 'material-ui/IconButton';
 
-import NotebookTaskButton from '../notebook-task-button'
-import UserTask from '../../../actions/user-task'
+import NotebookTaskButton from '../notebook-task-button';
+import UserTask from '../../../actions/user-task';
 
 describe('NotebookTaskButton has one IconButton', () => {
-  const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => {}, secondaryText: 'neat' })}>ok</NotebookTaskButton>)
+  const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => {}, secondaryText: 'neat' })}>ok</NotebookTaskButton>);
   it('renders one NotebookTaskButton which contains an IconButton', () => {
-    expect(nbTask.find(IconButton).length).toBe(1)
-    expect(nbTask.find(IconButton).props().children).toBe('ok')
-  })
-})
+    expect(nbTask.find(IconButton).length).toBe(1);
+    expect(nbTask.find(IconButton).props().children).toBe('ok');
+  });
+});
 
 describe('NotebookTaskButton onClick', () => {
-  let sentinel = false
-  const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => { sentinel = true }, secondaryText: 'neat' })}>ok</NotebookTaskButton>)
+  let sentinel = false;
+  const nbTask = shallow(<NotebookTaskButton task={new UserTask({ title: 'ok', callback: () => { sentinel = true; }, secondaryText: 'neat' })}>ok</NotebookTaskButton>);
   it('uses callback via click to run sentinel', () => {
-    nbTask.find(IconButton).simulate('click')
-    expect(sentinel).toBe(true)
-  })
-})
+    nbTask.find(IconButton).simulate('click');
+    expect(sentinel).toBe(true);
+  });
+});

--- a/src/components/menu/cell-menu-subsection.jsx
+++ b/src/components/menu/cell-menu-subsection.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React from 'react';
 // import Paper from 'material-ui/Paper'
-import NotebookMenuItem from './notebook-menu-item'
-import NotebookMenuDivider from './notebook-menu-divider'
-import NotebookMenuHeader from './notebook-menu-header'
-import NotebookMenuSubsection from './notebook-menu-subsection'
+import NotebookMenuItem from './notebook-menu-item';
+import NotebookMenuDivider from './notebook-menu-divider';
+import NotebookMenuHeader from './notebook-menu-header';
+import NotebookMenuSubsection from './notebook-menu-subsection';
 
-import tasks from '../../actions/task-definitions'
+import tasks from '../../actions/task-definitions';
 
 export default class CellMenuSubsection extends React.Component {
   render() {
@@ -42,6 +42,6 @@ export default class CellMenuSubsection extends React.Component {
           key={tasks.changeToPluginCell.title}
           task={tasks.changeToPluginCell}
         />
-      </NotebookMenuSubsection>)
+      </NotebookMenuSubsection>);
   }
 }

--- a/src/components/menu/editor-mode-controls.jsx
+++ b/src/components/menu/editor-mode-controls.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
+import React from 'react';
 
-import AddButton from 'material-ui-icons/Add'
-import UpArrow from 'material-ui-icons/ArrowUpward'
-import DownArrow from 'material-ui-icons/ArrowDownward'
-import PlayButton from 'material-ui-icons/PlayArrow'
-import FastForward from 'material-ui-icons/FastForward'
+import AddButton from 'material-ui-icons/Add';
+import UpArrow from 'material-ui-icons/ArrowUpward';
+import DownArrow from 'material-ui-icons/ArrowDownward';
+import PlayButton from 'material-ui-icons/PlayArrow';
+import FastForward from 'material-ui-icons/FastForward';
 
-import EditorToolbarMenu from './editor-toolbar-menu'
-import NotebookTaskButton from './notebook-task-button'
+import EditorToolbarMenu from './editor-toolbar-menu';
+import NotebookTaskButton from './notebook-task-button';
 
-import tasks from '../../actions/task-definitions'
+import tasks from '../../actions/task-definitions';
 
 export default class EditorModeControls extends React.Component {
   render() {
@@ -32,6 +32,6 @@ export default class EditorModeControls extends React.Component {
           <FastForward />
         </NotebookTaskButton>
       </div>
-    )
+    );
   }
 }

--- a/src/components/menu/editor-mode-title.jsx
+++ b/src/components/menu/editor-mode-title.jsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Helmet from 'react-helmet'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
 
-import { connect } from 'react-redux'
+import { connect } from 'react-redux';
 
-import tasks from '../../actions/task-definitions'
+import tasks from '../../actions/task-definitions';
 
 export class TitleUnconnected extends React.Component {
   static propTypes = {
@@ -14,27 +14,27 @@ export class TitleUnconnected extends React.Component {
     hoverColor: PropTypes.string,
   }
   constructor(props) {
-    super(props)
-    this.onBlur = this.onBlur.bind(this)
-    this.onFocus = this.onFocus.bind(this)
-    this.getTitle = this.getTitle.bind(this)
+    super(props);
+    this.onBlur = this.onBlur.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.getTitle = this.getTitle.bind(this);
   }
 
   onBlur() {
-    if (this.props.pageMode === 'title-edit') tasks.changeMode.callback('command')
+    if (this.props.pageMode === 'title-edit') tasks.changeMode.callback('command');
   }
 
   onFocus() {
     if (!this.props.pageMode !== 'title-edit') {
-      tasks.changeMode.callback('title-edit')
+      tasks.changeMode.callback('title-edit');
     }
   }
 
   getTitle() {
     if (this.props.pageMode !== 'title-edit') {
-      return `${this.props.title || 'New Notebook'} - Iodide`
+      return `${this.props.title || 'New Notebook'} - Iodide`;
     }
-    return undefined
+    return undefined;
   }
 
   render() {
@@ -52,14 +52,14 @@ export class TitleUnconnected extends React.Component {
             placeholder="new notebook"
             onChange={(evt) => {
               tasks.changeMode.callback('title-edit');
-              tasks.changeTitle.callback(evt.target.value)
+              tasks.changeTitle.callback(evt.target.value);
             }}
           />
         </div>
       </div>
 
-    )
-    return elem
+    );
+    return elem;
   }
 }
 
@@ -67,7 +67,7 @@ function mapStateToProps(state) {
   return {
     title: state.title,
     pageMode: state.mode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(TitleUnconnected)
+export default connect(mapStateToProps)(TitleUnconnected);

--- a/src/components/menu/editor-mode-toolbar.jsx
+++ b/src/components/menu/editor-mode-toolbar.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import Toolbar from 'material-ui/Toolbar'
-import EditorModeControls from './editor-mode-controls'
-import ViewControls from './view-controls'
+import Toolbar from 'material-ui/Toolbar';
+import EditorModeControls from './editor-mode-controls';
+import ViewControls from './view-controls';
 
-import EditorModeTitle from './editor-mode-title'
+import EditorModeTitle from './editor-mode-title';
 
 export class EditorModeToolbarUnconnected extends React.Component {
   static propTypes = {
@@ -25,13 +25,13 @@ export class EditorModeToolbarUnconnected extends React.Component {
         </Toolbar>
       </div>
 
-    )
+    );
   }
 }
 
 export function mapStateToProps(state) {
-  return { viewMode: state.viewMode }
+  return { viewMode: state.viewMode };
 }
 
-const EditorModeToolbar = connect(mapStateToProps)(EditorModeToolbarUnconnected)
-export default EditorModeToolbar
+const EditorModeToolbar = connect(mapStateToProps)(EditorModeToolbarUnconnected);
+export default EditorModeToolbar;

--- a/src/components/menu/editor-toolbar-menu.jsx
+++ b/src/components/menu/editor-toolbar-menu.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import NotebookIconMenu from './icon-menu'
-import tasks from '../../actions/task-definitions'
-import NotebookMenuItem from './notebook-menu-item'
-import NotebookMenuDivider from './notebook-menu-divider'
+import NotebookIconMenu from './icon-menu';
+import tasks from '../../actions/task-definitions';
+import NotebookMenuItem from './notebook-menu-item';
+import NotebookMenuDivider from './notebook-menu-divider';
 
-import CellMenuSubsection from './cell-menu-subsection'
-import SavedNotebooksAndExamplesSubsection from './saved-notebooks-and-examples-subsection'
-import ViewModeToggleSubsection from './view-mode-toggle-subsection'
+import CellMenuSubsection from './cell-menu-subsection';
+import SavedNotebooksAndExamplesSubsection from './saved-notebooks-and-examples-subsection';
+import ViewModeToggleSubsection from './view-mode-toggle-subsection';
 
 export class EditorToolbarMenuUnconnected extends React.Component {
   static propTypes = {
@@ -41,15 +41,15 @@ export class EditorToolbarMenuUnconnected extends React.Component {
         <NotebookMenuItem task={tasks.fileAnIssue} />
       </NotebookIconMenu>
 
-    )
+    );
   }
 }
 
 export function mapStateToProps(state) {
-  const isAuthenticated = Boolean(state.userData.accessToken)
+  const isAuthenticated = Boolean(state.userData.accessToken);
   return {
     isAuthenticated,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(EditorToolbarMenuUnconnected)
+export default connect(mapStateToProps)(EditorToolbarMenuUnconnected);

--- a/src/components/menu/icon-menu.jsx
+++ b/src/components/menu/icon-menu.jsx
@@ -1,36 +1,36 @@
-import React from 'react'
+import React from 'react';
 // import IconMenu from 'material-ui/IconMenu'
 
-import IconButton from 'material-ui/IconButton'
-import Menu from 'material-ui/Menu'
-import MenuIcon from 'material-ui-icons/Menu'
-import Tooltip from 'material-ui/Tooltip'
+import IconButton from 'material-ui/IconButton';
+import Menu from 'material-ui/Menu';
+import MenuIcon from 'material-ui-icons/Menu';
+import Tooltip from 'material-ui/Tooltip';
 
 export default class NotebookIconMenu extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
       anchorElement: null,
-    }
-    this.handleClick = this.handleClick.bind(this)
-    this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
+    };
+    this.handleClick = this.handleClick.bind(this);
+    this.handleIconButtonClose = this.handleIconButtonClose.bind(this);
   }
 
   handleClick(event) {
-    this.setState({ anchorElement: event.currentTarget })
+    this.setState({ anchorElement: event.currentTarget });
   }
 
   handleIconButtonClose() {
-    this.setState({ anchorElement: null })
+    this.setState({ anchorElement: null });
     document.querySelectorAll('div[class^="MuiBackdrop-"]').forEach((backdrop) => {
       backdrop.click();
-    })
+    });
   }
 
   render() {
-    const { anchorElement } = this.state
+    const { anchorElement } = this.state;
     const children = React.Children.map(this.props.children.filter(c => c), c =>
-      React.cloneElement(c, { onClick: this.handleIconButtonClose }))
+      React.cloneElement(c, { onClick: this.handleIconButtonClose }));
     return (
       <Tooltip classes={{ tooltip: 'iodide-tooltip' }} title="Menu">
         <React.Fragment>
@@ -56,6 +56,6 @@ export default class NotebookIconMenu extends React.Component {
           </IconButton>
         </React.Fragment>
       </Tooltip>
-    )
+    );
   }
 }

--- a/src/components/menu/last-saved-text.jsx
+++ b/src/components/menu/last-saved-text.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Typography from 'material-ui/Typography'
-import { connect } from 'react-redux'
-import { prettyDate } from '../../tools/notebook-utils'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Typography from 'material-ui/Typography';
+import { connect } from 'react-redux';
+import { prettyDate } from '../../tools/notebook-utils';
 
 export class LastSavedTextUnconnected extends React.Component {
   static propTypes = {
@@ -15,14 +15,14 @@ export class LastSavedTextUnconnected extends React.Component {
         style={{ marginRight: '10px' }}
       >
         {this.props.lastSaved === undefined ? ' ' : `saved ${prettyDate(this.props.lastSaved)}`}
-      </Typography>)
+      </Typography>);
   }
 }
 
 function mapStateToProps(state) {
   return {
     lastSaved: state.lastSaved,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(LastSavedTextUnconnected)
+export default connect(mapStateToProps)(LastSavedTextUnconnected);

--- a/src/components/menu/notebook-header.jsx
+++ b/src/components/menu/notebook-header.jsx
@@ -1,14 +1,14 @@
-import React from 'react'
+import React from 'react';
 import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 
-import PresentationModeToolbar from './presentation-mode-toolbar'
-import EditorModeToolbar from './editor-mode-toolbar'
+import PresentationModeToolbar from './presentation-mode-toolbar';
+import EditorModeToolbar from './editor-mode-toolbar';
 
 const theme = createMuiTheme({
   palette: {
     type: 'dark',
   },
-})
+});
 
 export default class NotebookHeader extends React.Component {
   render() {
@@ -21,6 +21,6 @@ export default class NotebookHeader extends React.Component {
         <PresentationModeToolbar />
 
       </div>
-    )
+    );
   }
 }

--- a/src/components/menu/notebook-menu-divider.jsx
+++ b/src/components/menu/notebook-menu-divider.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import Divider from 'material-ui/Divider'
+import React from 'react';
+import Divider from 'material-ui/Divider';
 
 export default class NotebookMenuDivider extends React.Component {
   render() {
-    return (<Divider className="iodide-menu-divider" />)
+    return (<Divider className="iodide-menu-divider" />);
   }
 }

--- a/src/components/menu/notebook-menu-header.jsx
+++ b/src/components/menu/notebook-menu-header.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import Subheader from 'material-ui/List/ListSubheader'
+import React from 'react';
+import PropTypes from 'prop-types';
+import Subheader from 'material-ui/List/ListSubheader';
 
 export default class NotebookMenuHeader extends React.Component {
   static propTypes = { title: PropTypes.string, onClick: PropTypes.func }
@@ -9,6 +9,6 @@ export default class NotebookMenuHeader extends React.Component {
       <Subheader disableSticky={Boolean(true)} key={this.props.title}>
         {this.props.title}
       </Subheader>
-    )
+    );
   }
 }

--- a/src/components/menu/notebook-menu-item.jsx
+++ b/src/components/menu/notebook-menu-item.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import MenuItem from 'material-ui/Menu/MenuItem'
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuItem from 'material-ui/Menu/MenuItem';
 import { ListItemText } from 'material-ui/List';
-import UserTask from '../../actions/user-task'
-import ExternalLinkTask from '../../actions/external-link-task'
+import UserTask from '../../actions/user-task';
+import ExternalLinkTask from '../../actions/external-link-task';
 
 export default class NotebookMenuItem extends React.Component {
   static propTypes = {
@@ -18,13 +18,13 @@ export default class NotebookMenuItem extends React.Component {
   static muiName = 'MenuItem'
 
   constructor(props) {
-    super(props)
-    this.extraMenuProps = {}
+    super(props);
+    this.extraMenuProps = {};
     Object.keys(this.props).forEach((k) => {
       if (!['task', 'submenuOnClick', 'onClick'].includes(k)) {
-        this.extraMenuProps[k] = this.props[k]
+        this.extraMenuProps[k] = this.props[k];
       }
-    })
+    });
   }
 
   render() {
@@ -34,12 +34,12 @@ export default class NotebookMenuItem extends React.Component {
         classes={{ root: 'iodide-menu-item' }}
         key={this.props.task.title}
         onClick={() => {
-          this.props.task.callback()
-          if (this.props.onClick) this.props.onClick()
-          if (this.props.submenuOnClick) this.props.submenuOnClick()
+          this.props.task.callback();
+          if (this.props.onClick) this.props.onClick();
+          if (this.props.submenuOnClick) this.props.submenuOnClick();
           document.querySelectorAll('div[class^="MuiBackdrop-"]').forEach((backdrop) => {
-            backdrop.click()
-          })
+            backdrop.click();
+          });
           }}
       >
         <ListItemText
@@ -53,6 +53,6 @@ export default class NotebookMenuItem extends React.Component {
         />
 
       </MenuItem>
-    )
+    );
   }
 }

--- a/src/components/menu/notebook-menu-subsection.jsx
+++ b/src/components/menu/notebook-menu-subsection.jsx
@@ -1,48 +1,48 @@
-import React from 'react'
-import MenuItem from 'material-ui/Menu/MenuItem'
+import React from 'react';
+import MenuItem from 'material-ui/Menu/MenuItem';
 import { ListItemText } from 'material-ui/List';
-import Menu from 'material-ui/Menu'
+import Menu from 'material-ui/Menu';
 
-import ChevronRight from 'material-ui-icons/ChevronRight'
+import ChevronRight from 'material-ui-icons/ChevronRight';
 
 export default class NotebookMenuSubsection extends React.Component {
   constructor(props) {
-    super(props)
-    this.state = { anchorElement: null }
-    this.muiName = 'MenuItem'
-    this.handleClick = this.handleClick.bind(this)
-    this.handleClose = this.handleClose.bind(this)
+    super(props);
+    this.state = { anchorElement: null };
+    this.muiName = 'MenuItem';
+    this.handleClick = this.handleClick.bind(this);
+    this.handleClose = this.handleClose.bind(this);
   }
   handleClick(event) {
-    event.stopPropagation()
+    event.stopPropagation();
     if (this.state.anchorElement === null) {
-      this.setState({ anchorElement: event.currentTarget })
+      this.setState({ anchorElement: event.currentTarget });
     }
   }
 
   handleClose() {
-    this.setState({ anchorElement: null })
+    this.setState({ anchorElement: null });
     document.querySelectorAll('div[class^="MuiBackdrop-"]').forEach((backdrop) => {
       backdrop.click();
-    })
+    });
   }
   render() {
-    const { anchorElement } = this.state
+    const { anchorElement } = this.state;
     const children = React.Children.map(
       this.props.children,
       (c) => {
-        if (c === null || c === undefined) return undefined
+        if (c === null || c === undefined) return undefined;
         return React.cloneElement(c, {
           onClick: () => {
             // this.handleClose()
-            if (this.props.onClick) this.props.onClick()
+            if (this.props.onClick) this.props.onClick();
             // document.querySelectorAll('div[class^="MuiBackdrop-"]').forEach((backdrop) => {
             //   backdrop.click();
             // })
           },
-        })
+        });
       },
-    )
+    );
     return (
       <React.Fragment>
         <MenuItem
@@ -75,6 +75,6 @@ export default class NotebookMenuSubsection extends React.Component {
           {children}
         </Menu>
       </React.Fragment>
-    )
+    );
   }
 }

--- a/src/components/menu/notebook-task-button.jsx
+++ b/src/components/menu/notebook-task-button.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import IconButton from 'material-ui/IconButton'
-import Tooltip from 'material-ui/Tooltip'
-import UserTask from '../../actions/user-task'
-import ExternalLinkTask from '../../actions/external-link-task'
+import React from 'react';
+import PropTypes from 'prop-types';
+import IconButton from 'material-ui/IconButton';
+import Tooltip from 'material-ui/Tooltip';
+import UserTask from '../../actions/user-task';
+import ExternalLinkTask from '../../actions/external-link-task';
 
 
 // TODO - implement tooltip again
@@ -30,6 +30,6 @@ export default class NotebookTaskFunction extends React.Component {
         </IconButton>
       </Tooltip>
 
-    )
+    );
   }
 }

--- a/src/components/menu/presentation-mode-toolbar.jsx
+++ b/src/components/menu/presentation-mode-toolbar.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import ViewModeToggleButton from './view-mode-toggle-button'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import ViewModeToggleButton from './view-mode-toggle-button';
 
 export class PresentationModeToolbarUnconnected extends React.Component {
   static propTypes = {
@@ -18,14 +18,14 @@ export class PresentationModeToolbarUnconnected extends React.Component {
         </div>
       </div>
 
-    )
+    );
   }
 }
 
 export function mapStateToProps(state) {
   return {
     viewMode: state.viewMode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(PresentationModeToolbarUnconnected)
+export default connect(mapStateToProps)(PresentationModeToolbarUnconnected);

--- a/src/components/menu/saved-notebooks-and-examples-subsection.jsx
+++ b/src/components/menu/saved-notebooks-and-examples-subsection.jsx
@@ -1,14 +1,14 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import NotebookMenuItem from './notebook-menu-item'
-import NotebookMenuDivider from './notebook-menu-divider'
-import NotebookMenuHeader from './notebook-menu-header'
-import NotebookMenuSubsection from './notebook-menu-subsection'
+import NotebookMenuItem from './notebook-menu-item';
+import NotebookMenuDivider from './notebook-menu-divider';
+import NotebookMenuHeader from './notebook-menu-header';
+import NotebookMenuSubsection from './notebook-menu-subsection';
 
-import iodideExampleTasks from '../../iodide-examples'
-import tasks, { getLocalStorageNotebook } from '../../actions/task-definitions'
+import iodideExampleTasks from '../../iodide-examples';
+import tasks, { getLocalStorageNotebook } from '../../actions/task-definitions';
 
 class SavedNotebooksAndExamplesSubsection extends React.Component {
   static propTypes = {
@@ -17,35 +17,35 @@ class SavedNotebooksAndExamplesSubsection extends React.Component {
   }
 
   render() {
-    let autoSaveMenuItems
+    let autoSaveMenuItems;
     if (this.props.autoSave) {
-      const autoSave = getLocalStorageNotebook(this.props.autoSave)
+      const autoSave = getLocalStorageNotebook(this.props.autoSave);
       autoSaveMenuItems = (
         <div> {/* // FIXME: use React 16 fragments instead of useless container div */}
           <NotebookMenuHeader key="autosave" title="Auto-Saved" />
           <NotebookMenuItem task={autoSave} />
           <NotebookMenuDivider key="autosave-divider" />
         </div>
-      )
+      );
     }
 
-    let locallySavedMenuItems
+    let locallySavedMenuItems;
     if (this.props.locallySaved.length > 0) {
       locallySavedMenuItems = (
         <div> {/* // FIXME: use React 16 fragments instead of useless container div */}
           <NotebookMenuHeader key="local storage" title="Locally Saved Notebooks" />
           {
             this.props.locallySaved.map((l) => {
-              const task = getLocalStorageNotebook(l)
+              const task = getLocalStorageNotebook(l);
               if (task !== undefined) {
-                return (<NotebookMenuItem task={task} key={l} />)
+                return (<NotebookMenuItem task={task} key={l} />);
               }
-              return undefined
+              return undefined;
             })
           }
           <NotebookMenuDivider key="locals-divider" />
         </div>
-      )
+      );
     }
 
     return (
@@ -57,7 +57,7 @@ class SavedNotebooksAndExamplesSubsection extends React.Component {
         <NotebookMenuDivider key="examples-divider" />
         <NotebookMenuItem key={tasks.seeAllExamples.title} task={tasks.seeAllExamples} />
       </NotebookMenuSubsection>
-    )
+    );
   }
 }
 
@@ -65,7 +65,7 @@ function mapStateToProps(state) {
   return {
     locallySaved: state.locallySaved,
     autoSave: state.autoSave,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(SavedNotebooksAndExamplesSubsection)
+export default connect(mapStateToProps)(SavedNotebooksAndExamplesSubsection);

--- a/src/components/menu/view-controls.jsx
+++ b/src/components/menu/view-controls.jsx
@@ -1,22 +1,22 @@
 /* global IODIDE_BUILD_MODE */
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 // import { ToolbarGroup } from 'material-ui/Toolbar'
 
-import HistoryIcon from 'material-ui-icons/History'
-import ArrowDropDown from 'material-ui-icons/ArrowDropDown'
-import InfoIcon from 'material-ui-icons/InfoOutline'
-import AccountCircle from 'material-ui-icons/AccountCircle'
+import HistoryIcon from 'material-ui-icons/History';
+import ArrowDropDown from 'material-ui-icons/ArrowDropDown';
+import InfoIcon from 'material-ui-icons/InfoOutline';
+import AccountCircle from 'material-ui-icons/AccountCircle';
 
-import NotebookTaskButton from './notebook-task-button'
-import ViewModeToggleButton from './view-mode-toggle-button'
-import LastSavedText from './last-saved-text'
-import DeclaredVariablesPane from '../panes/declared-variables-pane'
-import HistoryPane from '../panes/history-pane'
-import AppInfoPane from '../panes/app-info-pane'
+import NotebookTaskButton from './notebook-task-button';
+import ViewModeToggleButton from './view-mode-toggle-button';
+import LastSavedText from './last-saved-text';
+import DeclaredVariablesPane from '../panes/declared-variables-pane';
+import HistoryPane from '../panes/history-pane';
+import AppInfoPane from '../panes/app-info-pane';
 
-import tasks from '../../actions/task-definitions'
+import tasks from '../../actions/task-definitions';
 
 
 export class ViewControlsUnconnected extends React.Component {
@@ -36,7 +36,7 @@ export class ViewControlsUnconnected extends React.Component {
         <NotebookTaskButton task={tasks.loginGithub}>
           <AccountCircle />
         </NotebookTaskButton>
-      )
+      );
 
     return (
       <div className="view-controls">
@@ -64,17 +64,17 @@ export class ViewControlsUnconnected extends React.Component {
         <ViewModeToggleButton />
 
       </div>
-    )
+    );
   }
 }
 
 export function mapStateToProps(state) {
-  const isAuthenticated = Boolean(state.userData.accessToken)
+  const isAuthenticated = Boolean(state.userData.accessToken);
   return {
     isAuthenticated,
     name: state.userData.name,
     avatar: state.userData.avatar,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(ViewControlsUnconnected)
+export default connect(mapStateToProps)(ViewControlsUnconnected);

--- a/src/components/menu/view-mode-toggle-button.jsx
+++ b/src/components/menu/view-mode-toggle-button.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import Button from 'material-ui/Button'
-import Tooltip from 'material-ui/Tooltip'
-import tasks from '../../actions/task-definitions'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Button from 'material-ui/Button';
+import Tooltip from 'material-ui/Tooltip';
+import tasks from '../../actions/task-definitions';
 
 export class ViewModeToggleButtonUnconnected extends React.Component {
   static propTypes = {
@@ -12,15 +12,15 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
     hoverColor: PropTypes.string,
   }
   constructor(props) {
-    super(props)
-    this.toggleViewMode = this.toggleViewMode.bind(this)
+    super(props);
+    this.toggleViewMode = this.toggleViewMode.bind(this);
   }
 
   toggleViewMode() {
     if (this.props.viewMode === 'presentation') {
-      tasks.setViewModeToEditor.callback()
+      tasks.setViewModeToEditor.callback();
     } else if (this.props.viewMode === 'editor') {
-      tasks.setViewModeToPresentation.callback()
+      tasks.setViewModeToPresentation.callback();
     }
   }
 
@@ -37,14 +37,14 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
           {this.props.viewMode === 'presentation' ? 'Edit' : 'View'}
         </Button>
       </Tooltip>
-    )
+    );
   }
 }
 export function mapStateToProps(state) {
   // get the viewMode from state
   return {
     viewMode: state.viewMode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(ViewModeToggleButtonUnconnected)
+export default connect(mapStateToProps)(ViewModeToggleButtonUnconnected);

--- a/src/components/menu/view-mode-toggle-subsection.jsx
+++ b/src/components/menu/view-mode-toggle-subsection.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import NotebookMenuSubsection from './notebook-menu-subsection'
-import NotebookMenuItem from './notebook-menu-item'
-import tasks from '../../actions/task-definitions'
+import React from 'react';
+import NotebookMenuSubsection from './notebook-menu-subsection';
+import NotebookMenuItem from './notebook-menu-item';
+import tasks from '../../actions/task-definitions';
 
 export default class ViewModeToggleSubsection extends React.Component {
   render() {
@@ -10,6 +10,6 @@ export default class ViewModeToggleSubsection extends React.Component {
         <NotebookMenuItem task={tasks.toggleHistoryPane} />
         <NotebookMenuItem task={tasks.toggleDeclaredVariablesPane} />
       </NotebookMenuSubsection>
-    )
+    );
   }
 }

--- a/src/components/page.jsx
+++ b/src/components/page.jsx
@@ -1,24 +1,24 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import deepEqual from 'deep-equal'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import deepEqual from 'deep-equal';
 
-import RawCell from './cells/raw-cell'
-import ExternalDependencyCell from './cells/external-resource-cell'
-import CSSCell from './cells/css-cell'
-import CodeCell from './cells/code-cell'
-import MarkdownCell from './cells/markdown-cell'
-import PluginDefinitionCell from './cells/plugin-definition-cell'
+import RawCell from './cells/raw-cell';
+import ExternalDependencyCell from './cells/external-resource-cell';
+import CSSCell from './cells/css-cell';
+import CodeCell from './cells/code-cell';
+import MarkdownCell from './cells/markdown-cell';
+import PluginDefinitionCell from './cells/plugin-definition-cell';
 
-import NotebookHeader from './menu/notebook-header'
-import AppMessages from './app-messages/app-messages'
+import NotebookHeader from './menu/notebook-header';
+import AppMessages from './app-messages/app-messages';
 
-import { initializeDefaultKeybindings } from '../keybindings'
-import * as actions from '../actions/actions'
+import { initializeDefaultKeybindings } from '../keybindings';
+import * as actions from '../actions/actions';
 
 
-const AUTOSAVE = 'AUTOSAVE: '
+const AUTOSAVE = 'AUTOSAVE: ';
 
 class Page extends React.Component {
   static propTypes = {
@@ -33,33 +33,33 @@ class Page extends React.Component {
     cellTypes: PropTypes.array,
   }
   constructor(props) {
-    super(props)
+    super(props);
 
-    initializeDefaultKeybindings()
+    initializeDefaultKeybindings();
     setInterval(() => {
       // clear whatever notebook is defined w/ "AUTOSAVE " as front tag
-      const notebooks = Object.keys(localStorage)
-      const autos = notebooks.filter(n => n.includes(AUTOSAVE))
+      const notebooks = Object.keys(localStorage);
+      const autos = notebooks.filter(n => n.includes(AUTOSAVE));
       if (autos.length) {
         autos.forEach((n) => {
-          this.props.actions.deleteNotebook(n)
-        })
+          this.props.actions.deleteNotebook(n);
+        });
       }
-      this.props.actions.saveNotebook(true)
-    }, 1000 * 60)
+      this.props.actions.saveNotebook(true);
+    }, 1000 * 60);
 
-    this.getPageWidth = this.getPageWidth.bind(this)
+    this.getPageWidth = this.getPageWidth.bind(this);
   }
 
   shouldComponentUpdate(nextProps) {
-    return !deepEqual(this.props, nextProps)
+    return !deepEqual(this.props, nextProps);
   }
 
   getPageWidth() {
-    let width = '100%'
-    if (this.props.viewMode === 'presentation') width = 'undefined'
-    else if (this.props.sidePane) width = `calc(100% - ${this.props.sidePaneWidth}px)`
-    return { width }
+    let width = '100%';
+    if (this.props.viewMode === 'presentation') width = 'undefined';
+    else if (this.props.sidePane) width = `calc(100% - ${this.props.sidePaneWidth}px)`;
+    return { width };
   }
 
   render() {
@@ -69,22 +69,22 @@ class Page extends React.Component {
       switch (this.props.cellTypes[i]) {
         case 'code':
         // return <JavascriptCell cellId={id} key={id}/>
-          return <CodeCell cellId={id} key={id} />
+          return <CodeCell cellId={id} key={id} />;
         case 'markdown':
-          return <MarkdownCell cellId={id} key={id} />
+          return <MarkdownCell cellId={id} key={id} />;
         case 'raw':
-          return <RawCell cellId={id} key={id} />
+          return <RawCell cellId={id} key={id} />;
         case 'external dependencies':
-          return <ExternalDependencyCell cellId={id} key={id} />
+          return <ExternalDependencyCell cellId={id} key={id} />;
         case 'css':
-          return <CSSCell cellId={id} key={id} />
+          return <CSSCell cellId={id} key={id} />;
         case 'plugin':
-          return <PluginDefinitionCell cellId={id} key={id} />
+          return <PluginDefinitionCell cellId={id} key={id} />;
         default:
           // TODO: Use better class for inline error
-          return <div>Unknown cell type {this.props.cellTypes[i]}</div>
+          return <div>Unknown cell type {this.props.cellTypes[i]}</div>;
       }
-    })
+    });
 
     return (
       <div
@@ -101,7 +101,7 @@ class Page extends React.Component {
         </div>
         <AppMessages />
       </div>
-    )
+    );
   }
 }
 
@@ -113,14 +113,14 @@ function mapStateToProps(state) {
     title: state.title,
     sidePane: state.sidePaneMode,
     sidePaneWidth: state.sidePaneWidth,
-  }
+  };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
-  }
+  };
 }
 
 
-export default connect(mapStateToProps, mapDispatchToProps)(Page)
+export default connect(mapStateToProps, mapDispatchToProps)(Page);

--- a/src/components/panes/__tests__/declared-variable.test.js
+++ b/src/components/panes/__tests__/declared-variable.test.js
@@ -1,55 +1,55 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { DeclaredVariable } from '../declared-variable'
-import { ValueRenderer } from '../../reps/value-renderer'
+import { DeclaredVariable } from '../declared-variable';
+import { ValueRenderer } from '../../reps/value-renderer';
 
 describe('DeclaredVariable React component', () => {
-  let props
-  let mountedVariable
+  let props;
+  let mountedVariable;
 
   const declaredVariable = () => {
     if (!mountedVariable) {
-      mountedVariable = shallow(<DeclaredVariable {...props} />)
+      mountedVariable = shallow(<DeclaredVariable {...props} />);
     }
-    return mountedVariable
-  }
+    return mountedVariable;
+  };
 
   beforeEach(() => {
     props = {
       value: 3,
       varName: 'a',
-    }
-    mountedVariable = undefined
-  })
+    };
+    mountedVariable = undefined;
+  });
 
   it('always renders one div with class declared-variable', () => {
     expect(declaredVariable().find('div.declared-variable').length)
-      .toBe(1)
-  })
+      .toBe(1);
+  });
 
   it('always renders one div with class declared-variable-name inside declared-variable', () => {
     expect(declaredVariable().wrap(declaredVariable().find('div.declared-variable'))
-      .find('div.declared-variable-name')).toHaveLength(1)
-  })
+      .find('div.declared-variable-name')).toHaveLength(1);
+  });
 
   it('always renders one div with class declared-variable-value inside declared-variable', () => {
     expect(declaredVariable().wrap(declaredVariable().find('div.declared-variable'))
-      .find('div.declared-variable-value')).toHaveLength(1)
-  })
+      .find('div.declared-variable-value')).toHaveLength(1);
+  });
 
   it('always renders one ValueRenderer inside declared-variable-value', () => {
     expect(declaredVariable().wrap(declaredVariable().find('div.declared-variable-value'))
-      .find(ValueRenderer)).toHaveLength(1)
-  })
+      .find(ValueRenderer)).toHaveLength(1);
+  });
 
   it("sets the ValueRenderer's render prop to be true", () => {
     expect(declaredVariable().find(ValueRenderer).props().render)
-      .toBe(true)
-  })
+      .toBe(true);
+  });
 
   it("sets the ValueRenderer's valueToRender prop to be declared variable's value prop", () => {
     expect(declaredVariable().find(ValueRenderer).props().valueToRender)
-      .toBe(props.value)
-  })
-})
+      .toBe(props.value);
+  });
+});

--- a/src/components/panes/__tests__/declared-variables-panes.test.js
+++ b/src/components/panes/__tests__/declared-variables-panes.test.js
@@ -1,23 +1,23 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import SidePane from '../side-pane'
-import { DeclaredVariable } from '../declared-variable'
-import { FrozenVariable } from '../frozen-variable'
+import SidePane from '../side-pane';
+import { DeclaredVariable } from '../declared-variable';
+import { FrozenVariable } from '../frozen-variable';
 
-import { DeclaredVariablesPaneUnconnected, mapStateToProps } from '../declared-variables-pane'
-import tasks from '../../../actions/task-definitions'
+import { DeclaredVariablesPaneUnconnected, mapStateToProps } from '../declared-variables-pane';
+import tasks from '../../../actions/task-definitions';
 
 describe('DeclaredVariablesPaneUnconnected React component', () => {
-  let props
-  let mountedPane
+  let props;
+  let mountedPane;
 
   const declaredVariablesPane = () => {
     if (!mountedPane) {
-      mountedPane = shallow(<DeclaredVariablesPaneUnconnected {...props} />)
+      mountedPane = shallow(<DeclaredVariablesPaneUnconnected {...props} />);
     }
-    return mountedPane
-  }
+    return mountedPane;
+  };
 
   beforeEach(() => {
     props = {
@@ -33,50 +33,50 @@ describe('DeclaredVariablesPaneUnconnected React component', () => {
           'JYewJsYKZA==',
         ],
       },
-    }
-    mountedPane = undefined
-  })
+    };
+    mountedPane = undefined;
+  });
 
   it('always renders one SidePane', () => {
-    expect(declaredVariablesPane().find(SidePane).length).toBe(1)
-  })
+    expect(declaredVariablesPane().find(SidePane).length).toBe(1);
+  });
 
   it("sets the HistoryPane's openOnMode prop to be history", () => {
     expect(declaredVariablesPane().find(SidePane).props().openOnMode)
-      .toBe('declared variables')
-  })
+      .toBe('declared variables');
+  });
 
   it("sets the HistoryPane's task prop to be toggleHistoryPane", () => {
     expect(declaredVariablesPane().find(SidePane).props().task)
-      .toBe(tasks.toggleDeclaredVariablesPane)
-  })
+      .toBe(tasks.toggleDeclaredVariablesPane);
+  });
 
   it('always renders two declared-variables-list when both variable types are non empty', () => {
     expect(declaredVariablesPane().wrap(declaredVariablesPane().find(SidePane))
-      .find('div.declared-variables-list')).toHaveLength(2)
-  })
+      .find('div.declared-variables-list')).toHaveLength(2);
+  });
 
   it('always renders correct number of DeclaredVariable', () => {
     expect(declaredVariablesPane().wrap(declaredVariablesPane().find(SidePane))
-      .find(DeclaredVariable)).toHaveLength(3)
-  })
+      .find(DeclaredVariable)).toHaveLength(3);
+  });
 
   it('always renders correct number of FrozenVariable', () => {
     expect(declaredVariablesPane().wrap(declaredVariablesPane().find(SidePane))
-      .find(FrozenVariable)).toHaveLength(2)
-  })
+      .find(FrozenVariable)).toHaveLength(2);
+  });
 
   it('never renders FrozenVariable when environmentVariables is empty', () => {
-    props.environmentVariables = {}
+    props.environmentVariables = {};
     expect(declaredVariablesPane().wrap(declaredVariablesPane().find(FrozenVariable)))
-      .toHaveLength(0)
-  })
+      .toHaveLength(0);
+  });
 
   it('never renders DeclaredVariable when userDefinedVarNames is empty', () => {
-    props.userDefinedVarNames = []
+    props.userDefinedVarNames = [];
     expect(declaredVariablesPane().wrap(declaredVariablesPane().find(DeclaredVariable)))
-      .toHaveLength(0)
-  })
+      .toHaveLength(0);
+  });
 
   it('always updates the component when props change', () => {
     const nextProps = {
@@ -92,10 +92,10 @@ describe('DeclaredVariablesPaneUnconnected React component', () => {
           'JYewJsYKZA==',
         ],
       },
-    }
+    };
     expect(declaredVariablesPane().instance().shouldComponentUpdate(nextProps))
-      .toBe(true)
-  })
+      .toBe(true);
+  });
 
   it('never updates the component when props are same', () => {
     const nextProps = {
@@ -111,22 +111,22 @@ describe('DeclaredVariablesPaneUnconnected React component', () => {
           'JYewJsYKZA==',
         ],
       },
-    }
+    };
     expect(declaredVariablesPane().instance().shouldComponentUpdate(nextProps))
-      .toBe(false)
-  })
-})
+      .toBe(false);
+  });
+});
 
 describe('DeclaredVariablesPane mapStateToProps', () => {
-  let state
+  let state;
 
   beforeEach(() => {
     state = {
       savedEnvironment: {},
       userDefinedVarNames: ['iodide', 'a'],
       sidePaneMode: 'declared variables',
-    }
-  })
+    };
+  });
 
   it('should return the correct basic info', () => {
     expect(mapStateToProps(state))
@@ -134,6 +134,6 @@ describe('DeclaredVariablesPane mapStateToProps', () => {
         environmentVariables: {},
         userDefinedVarNames: ['iodide', 'a'],
         sidePaneMode: 'declared variables',
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/panes/__tests__/frozen-variable.test.js
+++ b/src/components/panes/__tests__/frozen-variable.test.js
@@ -1,54 +1,54 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import { FrozenVariable } from '../frozen-variable'
+import { FrozenVariable } from '../frozen-variable';
 
 describe('FrozenVariable React component', () => {
-  let props
-  let mountedVariable
+  let props;
+  let mountedVariable;
 
   const frozenVariable = () => {
     if (!mountedVariable) {
-      mountedVariable = shallow(<FrozenVariable {...props} />)
+      mountedVariable = shallow(<FrozenVariable {...props} />);
     }
-    return mountedVariable
-  }
+    return mountedVariable;
+  };
 
   beforeEach(() => {
     props = {
       varName: 'x',
       byteLength: 42,
-    }
-    mountedVariable = undefined
-  })
+    };
+    mountedVariable = undefined;
+  });
 
   it('always renders one div with class frozen-variable-name', () => {
     expect(frozenVariable().find('div.frozen-variable-name').length)
-      .toBe(1)
-  })
+      .toBe(1);
+  });
 
   it('always renders one div with class frozen-variable-value', () => {
     expect(frozenVariable().find('div.frozen-variable-name').length)
-      .toBe(1)
-  })
+      .toBe(1);
+  });
 
   it('always renders variable name inside frozen-variable-name', () => {
     expect(frozenVariable().wrap(frozenVariable().find('div.frozen-variable-name'))
-      .text()).toBe('x')
-  })
+      .text()).toBe('x');
+  });
 
   const valueVariants = [
     { value: 42, size: '42 bytes' },
     { value: 4200, size: '4.2kb' },
     { value: 4200000, size: '4.2mb' },
     { value: 4200000000000, size: '4200gb' },
-  ]
+  ];
 
   valueVariants.forEach((variant) => {
     it('always renders correct size inside frozen-variable-value', () => {
-      props.byteLength = variant.value
+      props.byteLength = variant.value;
       expect(frozenVariable().wrap(frozenVariable().find('div.frozen-variable-value'))
-        .text()).toBe(variant.size)
-    })
-  })
-})
+        .text()).toBe(variant.size);
+    });
+  });
+});

--- a/src/components/panes/__tests__/history-item.test.js
+++ b/src/components/panes/__tests__/history-item.test.js
@@ -1,19 +1,19 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import CodeMirror from '@skidding/react-codemirror'
-import HistoryItem from '../history-item'
+import CodeMirror from '@skidding/react-codemirror';
+import HistoryItem from '../history-item';
 
 describe('HistoryItem React component', () => {
-  let props
-  let mountedItem
+  let props;
+  let mountedItem;
 
   const historyItem = () => {
     if (!mountedItem) {
-      mountedItem = shallow(<HistoryItem {...props} />)
+      mountedItem = shallow(<HistoryItem {...props} />);
     }
-    return mountedItem
-  }
+    return mountedItem;
+  };
 
   beforeEach(() => {
     props = {
@@ -24,54 +24,54 @@ describe('HistoryItem React component', () => {
         content: 'var a = 3',
       },
       display: true,
-    }
-    mountedItem = undefined
-  })
+    };
+    mountedItem = undefined;
+  });
 
   it('always renders one div with correct class and id', () => {
-    expect(historyItem().find('div.cell-container').length).toBe(1)
-    expect(historyItem().find('div#cell-0').length).toBe(1)
-  })
+    expect(historyItem().find('div.cell-container').length).toBe(1);
+    expect(historyItem().find('div#cell-0').length).toBe(1);
+  });
 
   it('always renders div with correct class when display is false', () => {
-    props.display = false
+    props.display = false;
     expect(historyItem().find('div.cell-container').hasClass('hidden-cell'))
-      .toBe(true)
-  })
+      .toBe(true);
+  });
 
   it('always renders div with correct class when display is true', () => {
-    props.display = true
+    props.display = true;
     expect(historyItem().find('div.cell-container').hasClass('hidden-cell'))
-      .toBe(false)
-  })
+      .toBe(false);
+  });
 
   it('always renders one div with classes cell and history-cell', () => {
     expect(historyItem().find('div.cell.history-cell').length)
-      .toBe(1)
-  })
+      .toBe(1);
+  });
 
   it('always renders one div with class history-content inside history-cell', () => {
     expect(historyItem().wrap(historyItem().find('div.history-cell'))
-      .find('div.history-content')).toHaveLength(1)
-  })
+      .find('div.history-content')).toHaveLength(1);
+  });
 
   it('always renders one div with class history-date inside history-cell', () => {
     expect(historyItem().wrap(historyItem().find('div.history-cell'))
-      .find('div.history-date')).toHaveLength(1)
-  })
+      .find('div.history-date')).toHaveLength(1);
+  });
 
   it('always renders one CodeMirror inside history-content', () => {
     expect(historyItem().wrap(historyItem().find('div.history-content'))
-      .find(CodeMirror)).toHaveLength(1)
-  })
+      .find(CodeMirror)).toHaveLength(1);
+  });
 
   it("sets the CodeMirror's value prop to be history item's cell's content", () => {
     expect(historyItem().find(CodeMirror).props().value)
-      .toBe(props.cell.content)
-  })
+      .toBe(props.cell.content);
+  });
 
   it('always renders one div with class cell-controls', () => {
     expect(historyItem().find('div.cell-controls').length)
-      .toBe(1)
-  })
-})
+      .toBe(1);
+  });
+});

--- a/src/components/panes/__tests__/history-pane.test.js
+++ b/src/components/panes/__tests__/history-pane.test.js
@@ -1,22 +1,22 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import SidePane from '../side-pane'
-import HistoryItem from '../history-item'
+import SidePane from '../side-pane';
+import HistoryItem from '../history-item';
 
-import { HistoryPaneUnconnected, mapStateToProps } from '../history-pane'
-import tasks from '../../../actions/task-definitions'
+import { HistoryPaneUnconnected, mapStateToProps } from '../history-pane';
+import tasks from '../../../actions/task-definitions';
 
 describe('HistoryPaneUnconnected React component', () => {
-  let props
-  let mountedPane
+  let props;
+  let mountedPane;
 
   const historyPane = () => {
     if (!mountedPane) {
-      mountedPane = shallow(<HistoryPaneUnconnected {...props} />)
+      mountedPane = shallow(<HistoryPaneUnconnected {...props} />);
     }
-    return mountedPane
-  }
+    return mountedPane;
+  };
 
   beforeEach(() => {
     props = {
@@ -25,39 +25,39 @@ describe('HistoryPaneUnconnected React component', () => {
         lastRan: new Date('2018-06-16T10:32:46.422Z'),
         content: 'var a = 3',
       }],
-    }
-    mountedPane = undefined
-  })
+    };
+    mountedPane = undefined;
+  });
 
   it('always renders one SidePane', () => {
-    expect(historyPane().find(SidePane).length).toBe(1)
-  })
+    expect(historyPane().find(SidePane).length).toBe(1);
+  });
 
   it("sets the HistoryPane's openOnMode prop to be history", () => {
     expect(historyPane().find(SidePane).props().openOnMode)
-      .toBe('history')
-  })
+      .toBe('history');
+  });
 
   it("sets the HistoryPane's task prop to be toggleHistoryPane", () => {
     expect(historyPane().find(SidePane).props().task)
-      .toBe(tasks.toggleHistoryPane)
-  })
+      .toBe(tasks.toggleHistoryPane);
+  });
 
   it('always renders one div with class history-cells inside HistoryPane', () => {
     expect(historyPane().wrap(historyPane().find(SidePane))
-      .find('div.history-cells')).toHaveLength(1)
-  })
+      .find('div.history-cells')).toHaveLength(1);
+  });
 
   it('always renders one div.no-history inside history-cells when history is empty', () => {
-    props.history = []
+    props.history = [];
     expect(historyPane().wrap(historyPane().find('div.history-cells'))
-      .find('div.no-history')).toHaveLength(1)
-  })
+      .find('div.no-history')).toHaveLength(1);
+  });
 
   it('always renders HistoryItem inside history-cells when history is non empty', () => {
     expect(historyPane().wrap(historyPane().find('div.history-cells'))
-      .find(HistoryItem)).toHaveLength(1)
-  })
+      .find(HistoryItem)).toHaveLength(1);
+  });
 
   it('always renders correct number of HistoryItem inside history-cells', () => {
     props.history = [
@@ -71,15 +71,15 @@ describe('HistoryPaneUnconnected React component', () => {
         lastRan: new Date('2018-06-16T10:32:47.422Z'),
         content: 'var b = 3',
       },
-    ]
+    ];
 
     expect(historyPane().wrap(historyPane().find('div.history-cells'))
-      .find(HistoryItem)).toHaveLength(2)
-  })
-})
+      .find(HistoryItem)).toHaveLength(2);
+  });
+});
 
 describe('HistoryPane mapStateToProps', () => {
-  let state
+  let state;
 
   beforeEach(() => {
     state = {
@@ -89,8 +89,8 @@ describe('HistoryPane mapStateToProps', () => {
         lastRan: '2018-06-16T10:32:46.422Z',
         content: 'var a = 3',
       }],
-    }
-  })
+    };
+  });
 
   it('should return the correct basic info', () => {
     expect(mapStateToProps(state))
@@ -101,6 +101,6 @@ describe('HistoryPane mapStateToProps', () => {
           lastRan: '2018-06-16T10:32:46.422Z',
           content: 'var a = 3',
         }],
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/panes/__tests__/side-pane.test.js
+++ b/src/components/panes/__tests__/side-pane.test.js
@@ -1,23 +1,23 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+import { shallow } from 'enzyme';
+import React from 'react';
 
-import Drawer from 'material-ui/Drawer'
-import { MuiThemeProvider } from 'material-ui/styles'
-import Resizable from 're-resizable'
+import Drawer from 'material-ui/Drawer';
+import { MuiThemeProvider } from 'material-ui/styles';
+import Resizable from 're-resizable';
 
-import { SidePaneUnconnected, mapStateToProps } from '../side-pane'
-import tasks from '../../../actions/task-definitions'
+import { SidePaneUnconnected, mapStateToProps } from '../side-pane';
+import tasks from '../../../actions/task-definitions';
 
 describe('SidePaneUnconnected React component', () => {
-  let props
-  let mountedPane
+  let props;
+  let mountedPane;
 
   const sidePane = () => {
     if (!mountedPane) {
-      mountedPane = shallow(<SidePaneUnconnected {...props} />)
+      mountedPane = shallow(<SidePaneUnconnected {...props} />);
     }
-    return mountedPane
-  }
+    return mountedPane;
+  };
 
   beforeEach(() => {
     props = {
@@ -26,75 +26,75 @@ describe('SidePaneUnconnected React component', () => {
       sidePaneWidth: 562,
       openOnMode: '_APP_INFO',
       task: tasks.toggleAppInfoPane,
-    }
-    mountedPane = undefined
-  })
+    };
+    mountedPane = undefined;
+  });
 
   it('always renders one MuiThemeProvider', () => {
-    expect(sidePane().find(MuiThemeProvider).length).toBe(1)
-  })
+    expect(sidePane().find(MuiThemeProvider).length).toBe(1);
+  });
 
   it('always renders one Drawer inside MuiThemeProvider', () => {
     expect(sidePane().wrap(sidePane().find(MuiThemeProvider))
-      .find(Drawer)).toHaveLength(1)
-  })
+      .find(Drawer)).toHaveLength(1);
+  });
 
   it("sets the Drawer's open prop to be true for correct props", () => {
-    props.sidePaneMode = '_APP_INFO'
-    props.openOnMode = '_APP_INFO'
+    props.sidePaneMode = '_APP_INFO';
+    props.openOnMode = '_APP_INFO';
     expect(sidePane().find(Drawer).props().open)
-      .toBe(true)
-  })
+      .toBe(true);
+  });
 
   it("sets the Drawer's open prop to be false for incorrect props", () => {
-    props.sidePaneMode = '_APP_INFO'
-    props.openOnMode = 'history'
+    props.sidePaneMode = '_APP_INFO';
+    props.openOnMode = 'history';
     expect(sidePane().find(Drawer).props().open)
-      .toBe(false)
-  })
+      .toBe(false);
+  });
 
   it('always renders one Resizable inside Drawer', () => {
     expect(sidePane().wrap(sidePane().find(Drawer))
-      .find(Resizable)).toHaveLength(1)
-  })
+      .find(Resizable)).toHaveLength(1);
+  });
 
   it("sets the Resizable's onResizeStop prop to correct function", () => {
     // const changeSidePaneWidth = jest.spyOn(tasks, 'changeSidePaneWidth.callback')
-    sidePane().find(Resizable).prop('onResizeStop')(1, 'left', 1, { width: 562 })
+    sidePane().find(Resizable).prop('onResizeStop')(1, 'left', 1, { width: 562 });
     // expect(changeSidePaneWidth.mock.calls.length).toBe(1)
-  })
+  });
 
   it('always renders one div with class pane-header inside Resizable', () => {
     expect(sidePane().wrap(sidePane().find(Resizable))
-      .find('div.pane-header')).toHaveLength(1)
-  })
+      .find('div.pane-header')).toHaveLength(1);
+  });
 
   it('always renders one div with class pane-title inside pane-header', () => {
     expect(sidePane().wrap(sidePane().find('div.pane-header'))
-      .find('div.pane-title')).toHaveLength(1)
-  })
+      .find('div.pane-title')).toHaveLength(1);
+  });
 
   it('always renders two children inside pane-title div', () => {
     expect(sidePane().find('div.pane-title').at(0).children()
-      .length).toBe(2)
-  })
-})
+      .length).toBe(2);
+  });
+});
 
 describe('SidePane mapStateToProps', () => {
-  let state
+  let state;
 
   beforeEach(() => {
     state = {
       sidePaneMode: 'history',
       sidePaneWidth: '562',
-    }
-  })
+    };
+  });
 
   it('should return the correct basic info', () => {
     expect(mapStateToProps(state))
       .toEqual({
         sidePaneMode: 'history',
         sidePaneWidth: '562',
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/panes/app-info-pane.jsx
+++ b/src/components/panes/app-info-pane.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import SidePane from './side-pane'
+import SidePane from './side-pane';
 
 // import DeclaredVariables from '../declared-variables'
-import tasks from '../../actions/task-definitions'
+import tasks from '../../actions/task-definitions';
 
 export class AppInfoPaneUnconnected extends React.Component {
   static propTypes = {
@@ -33,7 +33,7 @@ export class AppInfoPaneUnconnected extends React.Component {
       <SidePane task={tasks.toggleAppInfoPane} title="App info" openOnMode="_APP_INFO">
         {messageDivs}
       </SidePane>
-    )
+    );
   }
 }
 
@@ -41,7 +41,7 @@ function mapStateToProps(state) {
   return {
     appMessages: state.appMessages,
     sidePaneMode: state.sidePaneMode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(AppInfoPaneUnconnected)
+export default connect(mapStateToProps)(AppInfoPaneUnconnected);

--- a/src/components/panes/declared-variable.jsx
+++ b/src/components/panes/declared-variable.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
-import { ValueRenderer } from '../reps/value-renderer'
+import { ValueRenderer } from '../reps/value-renderer';
 
 export class DeclaredVariable extends React.Component {
   static propTypes = {
@@ -9,13 +9,13 @@ export class DeclaredVariable extends React.Component {
     varName: PropTypes.string,
   }
   render() {
-    const r = true
+    const r = true;
     return (
       <div className="declared-variable">
         <div className="declared-variable-name">{this.props.varName} = </div>
         <div className="declared-variable-value">
           <ValueRenderer render={r} valueToRender={this.props.value} />
         </div>
-      </div>)
+      </div>);
   }
 }

--- a/src/components/panes/declared-variables-pane.jsx
+++ b/src/components/panes/declared-variables-pane.jsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import deepEqual from 'deep-equal'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import deepEqual from 'deep-equal';
 
-import SidePane from './side-pane'
+import SidePane from './side-pane';
 
-import { DeclaredVariable } from './declared-variable'
-import { FrozenVariable } from './frozen-variable'
-import tasks from '../../actions/task-definitions'
+import { DeclaredVariable } from './declared-variable';
+import { FrozenVariable } from './frozen-variable';
+import tasks from '../../actions/task-definitions';
 
 
 export class DeclaredVariablesPaneUnconnected extends React.Component {
@@ -17,7 +17,7 @@ export class DeclaredVariablesPaneUnconnected extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return !deepEqual(this.props, nextProps)
+    return !deepEqual(this.props, nextProps);
   }
 
   render() {
@@ -33,7 +33,7 @@ export class DeclaredVariablesPaneUnconnected extends React.Component {
         />))}
         </div>
       </div>
-    ) : undefined
+    ) : undefined;
 
     const declaredVariables = this.props.userDefinedVarNames.length ? (
       <div className="declared-variables-list">
@@ -43,13 +43,13 @@ export class DeclaredVariablesPaneUnconnected extends React.Component {
           <DeclaredVariable value={window[varName]} varName={varName} key={varName} />)
         }
       </div>
-    ) : undefined
+    ) : undefined;
     return (
       <SidePane task={tasks.toggleDeclaredVariablesPane} title="Declared Variables" openOnMode="declared variables">
         {edvElem}
         {declaredVariables}
       </SidePane>
-    )
+    );
   }
 }
 
@@ -58,7 +58,7 @@ export function mapStateToProps(state) {
     environmentVariables: state.savedEnvironment,
     userDefinedVarNames: state.userDefinedVarNames,
     sidePaneMode: state.sidePaneMode,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(DeclaredVariablesPaneUnconnected)
+export default connect(mapStateToProps)(DeclaredVariablesPaneUnconnected);

--- a/src/components/panes/frozen-variable.jsx
+++ b/src/components/panes/frozen-variable.jsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function toSize(bytes) {
-  const KB = 1000
-  const MB = KB * 1000
-  const GB = MB * 1000
-  const roundToTwo = (v, mag) => Math.round((100 * v) / mag) / 100
-  if (Math.floor(bytes / GB) > 0) return `${roundToTwo(bytes, GB)}gb`
-  if (Math.floor(bytes / MB) > 0) return `${roundToTwo(bytes, MB)}mb`
-  if (Math.floor(bytes / KB) > 0) return `${roundToTwo(bytes, KB)}kb`
-  return `${bytes} bytes`
+  const KB = 1000;
+  const MB = KB * 1000;
+  const GB = MB * 1000;
+  const roundToTwo = (v, mag) => Math.round((100 * v) / mag) / 100;
+  if (Math.floor(bytes / GB) > 0) return `${roundToTwo(bytes, GB)}gb`;
+  if (Math.floor(bytes / MB) > 0) return `${roundToTwo(bytes, MB)}mb`;
+  if (Math.floor(bytes / KB) > 0) return `${roundToTwo(bytes, KB)}kb`;
+  return `${bytes} bytes`;
 }
 
 export class FrozenVariable extends React.Component {
@@ -30,7 +30,7 @@ export class FrozenVariable extends React.Component {
                 toSize(this.props.byteLength)
           }
           </div>
-        </React.Fragment>)
+        </React.Fragment>);
     }
 }
 

--- a/src/components/panes/history-item.jsx
+++ b/src/components/panes/history-item.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React from 'react';
 
-import CodeMirror from '@skidding/react-codemirror'
+import CodeMirror from '@skidding/react-codemirror';
 import PropTypes from 'prop-types';
 
 export default class HistoryItem extends React.Component {
@@ -19,12 +19,12 @@ export default class HistoryItem extends React.Component {
       readOnly: true,
       mode: this.props.cell.cellType,
       theme: 'eclipse',
-    }
+    };
     const mainElem = (<CodeMirror
       ref="editor" // eslint-disable-line
       value={this.props.cell.content}
       options={options}
-    />)
+    />);
 
     return (
       <div
@@ -37,6 +37,6 @@ export default class HistoryItem extends React.Component {
         </div>
         <div className="cell-controls" />
       </div>
-    )
+    );
   }
 }

--- a/src/components/panes/history-pane.jsx
+++ b/src/components/panes/history-pane.jsx
@@ -1,31 +1,31 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import SidePane from './side-pane'
-import tasks from '../../actions/task-definitions'
-import HistoryItem from './history-item'
+import SidePane from './side-pane';
+import tasks from '../../actions/task-definitions';
+import HistoryItem from './history-item';
 
 export class HistoryPaneUnconnected extends React.Component {
   static propTypes = {
     history: PropTypes.array,
   }
   render() {
-    let histContents = []
+    let histContents = [];
     if (this.props.history.length) {
       histContents = this.props.history.filter(cell => cell.content.length).map((cell, i) => {
       // TODO: Don't use array indices in keys (See react/no-array-index-key linter)
       const cellComponent = <HistoryItem display ref={`cell${cell.id}`} cell={cell} id={`${i}-${cell.id}`} key={`history${i}`} />  // eslint-disable-line
-        return cellComponent
-      })
+        return cellComponent;
+      });
     } else {
-      histContents.push(<div className="no-history" key="history_empty">No History</div>)
+      histContents.push(<div className="no-history" key="history_empty">No History</div>);
     }
     return (
       <SidePane task={tasks.toggleHistoryPane} title="History" openOnMode="history">
         <div className="history-cells"> {histContents} </div>
       </SidePane>
-    )
+    );
   }
 }
 
@@ -33,7 +33,7 @@ export function mapStateToProps(state) {
   return {
     sidePaneMode: state.sidePaneMode,
     history: state.history,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(HistoryPaneUnconnected)
+export default connect(mapStateToProps)(HistoryPaneUnconnected);

--- a/src/components/panes/side-pane.jsx
+++ b/src/components/panes/side-pane.jsx
@@ -1,23 +1,23 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import Drawer from 'material-ui/Drawer'
-import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles'
-import Typography from 'material-ui/Typography'
-import Close from 'material-ui-icons/Close'
-import Resizable from 're-resizable'
-import NotebookTaskButton from '../menu/notebook-task-button'
-import NotebookMenuDivider from '../menu/notebook-menu-divider'
+import Drawer from 'material-ui/Drawer';
+import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
+import Typography from 'material-ui/Typography';
+import Close from 'material-ui-icons/Close';
+import Resizable from 're-resizable';
+import NotebookTaskButton from '../menu/notebook-task-button';
+import NotebookMenuDivider from '../menu/notebook-menu-divider';
 
-import UserTask from '../../actions/user-task'
-import tasks from '../../actions/task-definitions'
+import UserTask from '../../actions/user-task';
+import tasks from '../../actions/task-definitions';
 
 const theme = createMuiTheme({
   palette: {
     type: 'light',
   },
-})
+});
 
 export class SidePaneUnconnected extends React.Component {
     static propTypes = {
@@ -60,7 +60,7 @@ export class SidePaneUnconnected extends React.Component {
                 height: '999999px',
               }}
               onResizeStop={(e, direction, ref, d) => {
-                tasks.changeSidePaneWidth.callback(d.width)
+                tasks.changeSidePaneWidth.callback(d.width);
               }}
               style={{ overflow: 'scroll' }}
             >
@@ -83,7 +83,7 @@ export class SidePaneUnconnected extends React.Component {
           </Drawer>
         </MuiThemeProvider>
 
-      )
+      );
     }
 }
 
@@ -91,7 +91,7 @@ export function mapStateToProps(state) {
   return {
     sidePaneMode: state.sidePaneMode,
     sidePaneWidth: state.sidePaneWidth,
-  }
+  };
 }
 
-export default connect(mapStateToProps)(SidePaneUnconnected)
+export default connect(mapStateToProps)(SidePaneUnconnected);

--- a/src/components/reps/__tests__/array-handler.test.js
+++ b/src/components/reps/__tests__/array-handler.test.js
@@ -1,25 +1,25 @@
-import arrayHandler from '../array-handler'
+import arrayHandler from '../array-handler';
 
 describe('dateHandler shouldHandle', () => {
   it('rejects non-scalar values', () => {
-    expect(arrayHandler.shouldHandle(undefined)).toBe(false)
-    expect(arrayHandler.shouldHandle({})).toBe(false)
-    expect(arrayHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(arrayHandler.shouldHandle('string')).toBe(false)
-    expect(arrayHandler.shouldHandle(4000)).toBe(false)
-  })
+    expect(arrayHandler.shouldHandle(undefined)).toBe(false);
+    expect(arrayHandler.shouldHandle({})).toBe(false);
+    expect(arrayHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(arrayHandler.shouldHandle('string')).toBe(false);
+    expect(arrayHandler.shouldHandle(4000)).toBe(false);
+  });
   it('accepts array objects', () => {
-    expect(arrayHandler.shouldHandle([])).toBe(true)
-    expect(arrayHandler.shouldHandle(new Array(10000))).toBe(true)
-    expect(arrayHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(true)
-    expect(arrayHandler.shouldHandle(new Int8Array([-127, 127]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Uint8Array([0, 255]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Uint8ClampedArray([0, 257]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Int16Array([-32768, 32767]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Uint16Array([0, 65535]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Int32Array([-2147483648, 2147483647]))).toBe(true)
-    expect(arrayHandler.shouldHandle(new Float32Array([-230430430.2343, 20]))).toBe(true)
+    expect(arrayHandler.shouldHandle([])).toBe(true);
+    expect(arrayHandler.shouldHandle(new Array(10000))).toBe(true);
+    expect(arrayHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(true);
+    expect(arrayHandler.shouldHandle(new Int8Array([-127, 127]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Uint8Array([0, 255]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Uint8ClampedArray([0, 257]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Int16Array([-32768, 32767]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Uint16Array([0, 65535]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Int32Array([-2147483648, 2147483647]))).toBe(true);
+    expect(arrayHandler.shouldHandle(new Float32Array([-230430430.2343, 20]))).toBe(true);
     expect(arrayHandler.shouldHandle(new Float64Array([-230430430.2343, 20, 1230230230.2343])))
-      .toBe(true)
-  })
-})
+      .toBe(true);
+  });
+});

--- a/src/components/reps/__tests__/dataframe-handler.test.js
+++ b/src/components/reps/__tests__/dataframe-handler.test.js
@@ -1,16 +1,16 @@
-import dataframeHandler from '../dataframe-handler'
+import dataframeHandler from '../dataframe-handler';
 
 describe('dateHandler shouldHandle', () => {
   it('rejects non-scalar values', () => {
-    expect(dataframeHandler.shouldHandle(undefined)).toBe(false)
-    expect(dataframeHandler.shouldHandle({})).toBe(false)
-    expect(dataframeHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(dataframeHandler.shouldHandle('string')).toBe(false)
-    expect(dataframeHandler.shouldHandle(4000)).toBe(false)
-    expect(dataframeHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(false)
-  })
+    expect(dataframeHandler.shouldHandle(undefined)).toBe(false);
+    expect(dataframeHandler.shouldHandle({})).toBe(false);
+    expect(dataframeHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(dataframeHandler.shouldHandle('string')).toBe(false);
+    expect(dataframeHandler.shouldHandle(4000)).toBe(false);
+    expect(dataframeHandler.shouldHandle([1, 2, 3, 4, 5])).toBe(false);
+  });
   it('accepts array objects of same size and key composition', () => {
-    expect(dataframeHandler.shouldHandle([{ a: 10, b: 20 }])).toBe(true)
+    expect(dataframeHandler.shouldHandle([{ a: 10, b: 20 }])).toBe(true);
     expect(dataframeHandler.shouldHandle([
       {
         a: 10, b: 'a', c: new Date(), e: [], f: undefined, g: null,
@@ -18,8 +18,8 @@ describe('dateHandler shouldHandle', () => {
       {
         a: 20, b: 'b', c: new Date(), e: [], f: undefined, g: null,
       },
-    ])).toBe(true)
-  })
+    ])).toBe(true);
+  });
   it('accepts arrays of objects of same key composition but differing data types', () => {
     expect(dataframeHandler.shouldHandle([
       {
@@ -28,8 +28,8 @@ describe('dateHandler shouldHandle', () => {
       {
         a: '20', b: 4, c: +(new Date()), e: {}, f: undefined, g: null,
       },
-    ])).toBe(true)
-  })
+    ])).toBe(true);
+  });
   it('rejects heterogeneous arrays of objects of differing keys', () => {
     expect(dataframeHandler.shouldHandle([
       {
@@ -38,8 +38,8 @@ describe('dateHandler shouldHandle', () => {
       {
         a: '20', b: 4, c: +(new Date()), e: {}, f: undefined, h: null,
       },
-    ])).toBe(false)
-  })
+    ])).toBe(false);
+  });
   it('rejects heterogeneous arrays of objects of differing sizes', () => {
     expect(dataframeHandler.shouldHandle([
       {
@@ -48,6 +48,6 @@ describe('dateHandler shouldHandle', () => {
       {
         a: '20', b: 4, c: +(new Date()), e: {},
       },
-    ])).toBe(false)
-  })
-})
+    ])).toBe(false);
+  });
+});

--- a/src/components/reps/__tests__/date-handler.test.js
+++ b/src/components/reps/__tests__/date-handler.test.js
@@ -1,18 +1,18 @@
-import dateHandler from '../date-handler'
+import dateHandler from '../date-handler';
 
 describe('dateHandler shouldHandle', () => {
   it('rejects non-scalar values', () => {
-    expect(dateHandler.shouldHandle(undefined)).toBe(false)
-    expect(dateHandler.shouldHandle([])).toBe(false)
-    expect(dateHandler.shouldHandle({})).toBe(false)
-    expect(dateHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(dateHandler.shouldHandle('string')).toBe(false)
-    expect(dateHandler.shouldHandle(4000)).toBe(false)
-    expect(dateHandler.shouldHandle('2010-01-01')).toBe(false)
-  })
+    expect(dateHandler.shouldHandle(undefined)).toBe(false);
+    expect(dateHandler.shouldHandle([])).toBe(false);
+    expect(dateHandler.shouldHandle({})).toBe(false);
+    expect(dateHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(dateHandler.shouldHandle('string')).toBe(false);
+    expect(dateHandler.shouldHandle(4000)).toBe(false);
+    expect(dateHandler.shouldHandle('2010-01-01')).toBe(false);
+  });
   it('accepts Date objects', () => {
-    expect(dateHandler.shouldHandle(new Date())).toBe(true)
-    expect(dateHandler.shouldHandle(new Date('2020-04-04'))).toBe(true)
-    expect(dateHandler.shouldHandle(new Date('invalid date string'))).toBe(true)
-  })
-})
+    expect(dateHandler.shouldHandle(new Date())).toBe(true);
+    expect(dateHandler.shouldHandle(new Date('2020-04-04'))).toBe(true);
+    expect(dateHandler.shouldHandle(new Date('invalid date string'))).toBe(true);
+  });
+});

--- a/src/components/reps/__tests__/matrix-handler.test.js
+++ b/src/components/reps/__tests__/matrix-handler.test.js
@@ -1,23 +1,23 @@
-import matrixHandler from '../matrix-handler'
+import matrixHandler from '../matrix-handler';
 
 describe('dateHandler shouldHandle', () => {
   it('rejects non-matrix values', () => {
-    expect(matrixHandler.shouldHandle(undefined)).toBe(false)
-    expect(matrixHandler.shouldHandle([])).toBe(false)
-    expect(matrixHandler.shouldHandle({})).toBe(false)
-    expect(matrixHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(matrixHandler.shouldHandle('string')).toBe(false)
-    expect(matrixHandler.shouldHandle(4000)).toBe(false)
-    expect(matrixHandler.shouldHandle('2010-01-01')).toBe(false)
-  })
+    expect(matrixHandler.shouldHandle(undefined)).toBe(false);
+    expect(matrixHandler.shouldHandle([])).toBe(false);
+    expect(matrixHandler.shouldHandle({})).toBe(false);
+    expect(matrixHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(matrixHandler.shouldHandle('string')).toBe(false);
+    expect(matrixHandler.shouldHandle(4000)).toBe(false);
+    expect(matrixHandler.shouldHandle('2010-01-01')).toBe(false);
+  });
   it('accepts arrays of arrays of same length', () => {
-    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 2, 1, 2]])).toBe(true)
+    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 2, 1, 2]])).toBe(true);
     // this should be true
-    expect(matrixHandler.shouldHandle([[1], [3]])).toBe(true)
-  })
+    expect(matrixHandler.shouldHandle([[1], [3]])).toBe(true);
+  });
   it('accepts arrays of arrays of differing length', () => {
-    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 1, 2]])).toBe(true)
+    expect(matrixHandler.shouldHandle([[1, 2, 3, 4], [3, 1, 2]])).toBe(true);
     // this should be true
-    expect(matrixHandler.shouldHandle([[1], []])).toBe(true)
-  })
-})
+    expect(matrixHandler.shouldHandle([[1], []])).toBe(true);
+  });
+});

--- a/src/components/reps/__tests__/null-handler.test.js
+++ b/src/components/reps/__tests__/null-handler.test.js
@@ -1,17 +1,17 @@
-import nullHandler from '../null-handler'
+import nullHandler from '../null-handler';
 
 describe('nullHandler shouldHandle', () => {
   it('rejects non-null values', () => {
-    expect(nullHandler.shouldHandle('hello')).toBe(false)
-    expect(nullHandler.shouldHandle('')).toBe(false)
-    expect(nullHandler.shouldHandle(undefined)).toBe(false)
-    expect(nullHandler.shouldHandle(new Date())).toBe(false)
-    expect(nullHandler.shouldHandle([])).toBe(false)
-    expect(nullHandler.shouldHandle({})).toBe(false)
-    expect(nullHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(nullHandler.shouldHandle('null')).toBe(false)
-  })
+    expect(nullHandler.shouldHandle('hello')).toBe(false);
+    expect(nullHandler.shouldHandle('')).toBe(false);
+    expect(nullHandler.shouldHandle(undefined)).toBe(false);
+    expect(nullHandler.shouldHandle(new Date())).toBe(false);
+    expect(nullHandler.shouldHandle([])).toBe(false);
+    expect(nullHandler.shouldHandle({})).toBe(false);
+    expect(nullHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(nullHandler.shouldHandle('null')).toBe(false);
+  });
   it('accepts null values', () => {
-    expect(nullHandler.shouldHandle(null)).toBe(true)
-  })
-})
+    expect(nullHandler.shouldHandle(null)).toBe(true);
+  });
+});

--- a/src/components/reps/__tests__/promise-handler.test.jsx
+++ b/src/components/reps/__tests__/promise-handler.test.jsx
@@ -1,49 +1,49 @@
-import { shallow } from 'enzyme'
-import React from 'react'
-import promiseHandler, { PromiseRep } from '../promise-handler'
+import { shallow } from 'enzyme';
+import React from 'react';
+import promiseHandler, { PromiseRep } from '../promise-handler';
 
 describe('promiseHandler shouldHandle', () => {
   it('rejects non-promise values', () => {
-    expect(promiseHandler.shouldHandle(undefined)).toBe(false)
-    expect(promiseHandler.shouldHandle([])).toBe(false)
-    expect(promiseHandler.shouldHandle({})).toBe(false)
-    expect(promiseHandler.shouldHandle('string')).toBe(false)
-    expect(promiseHandler.shouldHandle(4000)).toBe(false)
-    expect(promiseHandler.shouldHandle('2010-01-01')).toBe(false)
-  })
+    expect(promiseHandler.shouldHandle(undefined)).toBe(false);
+    expect(promiseHandler.shouldHandle([])).toBe(false);
+    expect(promiseHandler.shouldHandle({})).toBe(false);
+    expect(promiseHandler.shouldHandle('string')).toBe(false);
+    expect(promiseHandler.shouldHandle(4000)).toBe(false);
+    expect(promiseHandler.shouldHandle('2010-01-01')).toBe(false);
+  });
   it('accepts Promise objects', () => {
-    expect(promiseHandler.shouldHandle(Promise.resolve())).toBe(true)
-    expect(promiseHandler.shouldHandle(Promise.reject())).toBe(true)
+    expect(promiseHandler.shouldHandle(Promise.resolve())).toBe(true);
+    expect(promiseHandler.shouldHandle(Promise.reject())).toBe(true);
     expect(promiseHandler.shouldHandle(Promise.all([
       Promise.resolve(), Promise.resolve(),
-    ]))).toBe(true)
-  })
-})
+    ]))).toBe(true);
+  });
+});
 
 
 describe('PromiseRep', () => {
   it('resolves correctly', () => {
-    const val = 'test value'
+    const val = 'test value';
     const pr = new Promise((resolve) => {
-      const newValue = val
-      resolve(newValue)
-    })
-    const rep = shallow(<PromiseRep promise={pr} />)
+      const newValue = val;
+      resolve(newValue);
+    });
+    const rep = shallow(<PromiseRep promise={pr} />);
     rep.state().promise.then((v) => {
-      expect(v).toBe(val)
-      expect(rep.state().status).toBe('resolved')
+      expect(v).toBe(val);
+      expect(rep.state().status).toBe('resolved');
     })
-      .catch(() => {})
-  })
+      .catch(() => {});
+  });
   it('rejects correctly', () => {
-    const val = 'test value'
-    const pr = Promise.reject(val)
-    const rep = shallow(<PromiseRep promise={pr} />)
+    const val = 'test value';
+    const pr = Promise.reject(val);
+    const rep = shallow(<PromiseRep promise={pr} />);
     rep.state().promise.then((v) => {
-      expect(v).toBe(val)
-      expect(rep.state().status).toBe('rejected')
+      expect(v).toBe(val);
+      expect(rep.state().status).toBe('rejected');
     })
       .catch(() => {
-      })
-  })
-})
+      });
+  });
+});

--- a/src/components/reps/__tests__/scalar-handler.test.js
+++ b/src/components/reps/__tests__/scalar-handler.test.js
@@ -1,18 +1,18 @@
-import scalarHandler from '../scalar-handler'
+import scalarHandler from '../scalar-handler';
 
 describe('scalarHandler shouldHandle', () => {
   it('rejects non-scalar values', () => {
-    expect(scalarHandler.shouldHandle(undefined)).toBe(false)
-    expect(scalarHandler.shouldHandle(new Date())).toBe(false)
-    expect(scalarHandler.shouldHandle([])).toBe(false)
-    expect(scalarHandler.shouldHandle({})).toBe(false)
-    expect(scalarHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-  })
+    expect(scalarHandler.shouldHandle(undefined)).toBe(false);
+    expect(scalarHandler.shouldHandle(new Date())).toBe(false);
+    expect(scalarHandler.shouldHandle([])).toBe(false);
+    expect(scalarHandler.shouldHandle({})).toBe(false);
+    expect(scalarHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+  });
   it('accepts scalar values', () => {
-    expect(scalarHandler.shouldHandle(1)).toBe(true)
-    expect(scalarHandler.shouldHandle(Infinity)).toBe(true)
-    expect(scalarHandler.shouldHandle(NaN)).toBe(true)
-    expect(scalarHandler.shouldHandle('string')).toBe(true)
-    expect(scalarHandler.shouldHandle('')).toBe(true)
-  })
-})
+    expect(scalarHandler.shouldHandle(1)).toBe(true);
+    expect(scalarHandler.shouldHandle(Infinity)).toBe(true);
+    expect(scalarHandler.shouldHandle(NaN)).toBe(true);
+    expect(scalarHandler.shouldHandle('string')).toBe(true);
+    expect(scalarHandler.shouldHandle('')).toBe(true);
+  });
+});

--- a/src/components/reps/__tests__/undefined-handler.test.js
+++ b/src/components/reps/__tests__/undefined-handler.test.js
@@ -1,16 +1,16 @@
-import undefinedHandler from '../undefined-handler'
+import undefinedHandler from '../undefined-handler';
 
 describe('nullHandler shouldHandle', () => {
   it('rejects non-undefined values', () => {
-    expect(undefinedHandler.shouldHandle('hello')).toBe(false)
-    expect(undefinedHandler.shouldHandle('')).toBe(false)
-    expect(undefinedHandler.shouldHandle(new Date())).toBe(false)
-    expect(undefinedHandler.shouldHandle([])).toBe(false)
-    expect(undefinedHandler.shouldHandle({})).toBe(false)
-    expect(undefinedHandler.shouldHandle(new Promise(() => {}))).toBe(false)
-    expect(undefinedHandler.shouldHandle(null)).toBe(false)
-  })
+    expect(undefinedHandler.shouldHandle('hello')).toBe(false);
+    expect(undefinedHandler.shouldHandle('')).toBe(false);
+    expect(undefinedHandler.shouldHandle(new Date())).toBe(false);
+    expect(undefinedHandler.shouldHandle([])).toBe(false);
+    expect(undefinedHandler.shouldHandle({})).toBe(false);
+    expect(undefinedHandler.shouldHandle(new Promise(() => {}))).toBe(false);
+    expect(undefinedHandler.shouldHandle(null)).toBe(false);
+  });
   it('accepts undefined values', () => {
-    expect(undefinedHandler.shouldHandle(undefined)).toBe(true)
-  })
-})
+    expect(undefinedHandler.shouldHandle(undefined)).toBe(true);
+  });
+});

--- a/src/components/reps/array-handler.jsx
+++ b/src/components/reps/array-handler.jsx
@@ -1,13 +1,13 @@
-import React from 'react'
-import _ from 'lodash'
-import { renderValue } from './value-renderer'
+import React from 'react';
+import _ from 'lodash';
+import { renderValue } from './value-renderer';
 
 export const isTypedArray = arr => (
   typeof arr === 'object' &&
   arr.BYTES_PER_ELEMENT !== undefined &&
-  Object.prototype.toString.call(arr.buffer) === '[object ArrayBuffer]')
+  Object.prototype.toString.call(arr.buffer) === '[object ArrayBuffer]');
 
-export const typedArrayType = arr => Object.prototype.toString.call(arr).split(' ')[1].slice(0, -1)
+export const typedArrayType = arr => Object.prototype.toString.call(arr).split(' ')[1].slice(0, -1);
 
 export default {
   shouldHandle: (value, inContainer) => !inContainer && (
@@ -16,38 +16,38 @@ export default {
   ),
 
   render: (value) => {
-    const arrayType = isTypedArray(value) ? typedArrayType(value) : 'array'
-    const dataSetInfo = `${value.length} element ${arrayType}`
-    const len = value.length
-    let arrayElements
+    const arrayType = isTypedArray(value) ? typedArrayType(value) : 'array';
+    const dataSetInfo = `${value.length} element ${arrayType}`;
+    const len = value.length;
+    let arrayElements;
     if (len > 0) {
       arrayElements = _.range(len > 200 ? 100 : len - 1).map(i => (
         <span key={`array_elt_${i}`} title={`array index: ${i}`}>
           {renderValue(value[i], true)}{', '}
         </span>
-      ))
+      ));
       if (len > 200) {
-        arrayElements.push(<span key="array_elts omitted">…, </span>)
+        arrayElements.push(<span key="array_elts omitted">…, </span>);
         arrayElements = arrayElements
           .concat(_.range(len - 100, len - 1)
             .map(i => (
               <span key={`array_elt_${i}`} title={`array index: ${i}`}>
                 {renderValue(value[i], true)}{', '}
               </span>
-            )))
+            )));
       }
       // final element has no trailing comma
       arrayElements.push((
         <span key={`array_elt_${len - 1}`} title={`array index: ${len - 1}`}>
           {renderValue(value[len - 1], true)}
         </span>
-      ))
+      ));
     } else {
       arrayElements = (
         <span key="array_elt_empty" title="array index: none">
           {renderValue('', true)}
         </span>
-      )
+      );
     }
     return (
       <div className="array-rep">
@@ -56,6 +56,6 @@ export default {
             [{arrayElements}]
         </div>
       </div>
-    )
+    );
   },
-}
+};

--- a/src/components/reps/dataframe-handler.jsx
+++ b/src/components/reps/dataframe-handler.jsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import ReactTable from 'react-table'
+import React from 'react';
+import ReactTable from 'react-table';
 
-import { renderValue } from './value-renderer'
-import nb from '../../tools/nb'
+import { renderValue } from './value-renderer';
+import nb from '../../tools/nb';
 
 export default {
   shouldHandle: (value, inContainer) => !inContainer && nb.isRowDf(value),
@@ -13,9 +13,9 @@ export default {
         Header: k,
         accessor: k,
         Cell: cell => renderValue(cell.value, true),
-      }))
-    const dataSetInfo = `array of objects: ${value.length} rows, ${columns.length} columns`
-    const pageSize = value.length > 10 ? 10 : value.length
+      }));
+    const dataSetInfo = `array of objects: ${value.length} rows, ${columns.length} columns`;
+    const pageSize = value.length > 10 ? 10 : value.length;
     return (
       <div>
         <div className="data-set-info">{dataSetInfo}</div>
@@ -29,6 +29,6 @@ export default {
           defaultPageSize={pageSize}
         />
       </div>
-    )
+    );
   },
-}
+};

--- a/src/components/reps/date-handler.jsx
+++ b/src/components/reps/date-handler.jsx
@@ -1,4 +1,4 @@
 export default {
   shouldHandle: value => Object.prototype.toString.call(value) === '[object Date]',
   render: value => value.toString(),
-}
+};

--- a/src/components/reps/default-handler.jsx
+++ b/src/components/reps/default-handler.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import JSONTree from 'react-json-tree'
+import React from 'react';
+import JSONTree from 'react-json-tree';
 
 export default {
   shouldHandle: () => true,
@@ -30,5 +30,5 @@ export default {
         }}
     />
   ),
-}
+};
 

--- a/src/components/reps/dom-element-handler.jsx
+++ b/src/components/reps/dom-element-handler.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import DOMInspector from 'react-inspector'
+import React from 'react';
+import DOMInspector from 'react-inspector';
 // taken from https://stackoverflow.com/questions/384286/javascript-isdom-how-do-you-check-if-a-javascript-object-is-a-dom-object
 function isNode(o) {
   return (
@@ -18,4 +18,4 @@ function isElement(o) {
 export default {
   shouldHandle: value => isNode(value) || isElement(value),
   render: value => <DOMInspector data={value} />,
-}
+};

--- a/src/components/reps/matrix-handler.jsx
+++ b/src/components/reps/matrix-handler.jsx
@@ -1,19 +1,19 @@
-import React from 'react'
-import { SimpleTable, makeMatrixText } from './pretty-matrix'
-import nb from '../../tools/nb'
+import React from 'react';
+import { SimpleTable, makeMatrixText } from './pretty-matrix';
+import nb from '../../tools/nb';
 
 export default {
   shouldHandle: (value, inContainer) => !inContainer && nb.isMatrix(value),
 
   render: (value) => {
-    const shape = nb.shape(value)
-    const dataSetInfo = `${shape[0]} × ${shape[1]} matrix (array of arrays)`
-    const tabledata = makeMatrixText(value, [10, 10])
+    const shape = nb.shape(value);
+    const dataSetInfo = `${shape[0]} × ${shape[1]} matrix (array of arrays)`;
+    const tabledata = makeMatrixText(value, [10, 10]);
     return (
       <div>
         <div className="data-set-info">{dataSetInfo}</div>
         <SimpleTable tabledata={tabledata} />
       </div>
-    )
+    );
   },
-}
+};

--- a/src/components/reps/null-handler.jsx
+++ b/src/components/reps/null-handler.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React from 'react';
 
 export default {
   shouldHandle: value => (value === null),
 
   render: () => <pre className="null-rep">null</pre>,
-}
+};

--- a/src/components/reps/output-handler-external-resource.jsx
+++ b/src/components/reps/output-handler-external-resource.jsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 // import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
 // import getMuiTheme from 'material-ui/styles/getMuiTheme'
-import CheckCircle from 'material-ui-icons/CheckCircle'
-import ErrorCircle from 'material-ui-icons/Error'
-import UnloadedCircle from 'material-ui-icons/Remove'
+import CheckCircle from 'material-ui-icons/CheckCircle';
+import ErrorCircle from 'material-ui-icons/Error';
+import UnloadedCircle from 'material-ui-icons/Remove';
 
 // this is merely a presentational component, and as such can be passed
 // all the data it needs.
@@ -16,13 +16,13 @@ export default class ExternalResourceOutput extends React.Component {
   }
 
   render() {
-    if (this.props.value === undefined) return <div />
+    if (this.props.value === undefined) return <div />;
 
     const outs = this.props.value.filter(d => d.src !== '').map((d) => {
-      let statusExplanation
-      let statusIcon
-      let source = d.src.split('/')
-      source = source[source.length - 1]
+      let statusExplanation;
+      let statusIcon;
+      let source = d.src.split('/');
+      source = source[source.length - 1];
 
       const introducedVariables = (d.variables || []).map(v =>
         (
@@ -37,13 +37,13 @@ export default class ExternalResourceOutput extends React.Component {
                 }}
           >{v}
           </div>
-        ))
+        ));
 
-      if (d.status === undefined) statusIcon = <UnloadedCircle />
-      else statusIcon = (d.status === 'loaded' ? <CheckCircle color="primary" /> : <ErrorCircle color="error" />)
+      if (d.status === undefined) statusIcon = <UnloadedCircle />;
+      else statusIcon = (d.status === 'loaded' ? <CheckCircle color="primary" /> : <ErrorCircle color="error" />);
 
       if (Object.prototype.hasOwnProperty.call(d, 'statusExplanation')) {
-        statusExplanation = <div key={d.src} className="dependency-status-explanation">{d.statusExplanation}</div>
+        statusExplanation = <div key={d.src} className="dependency-status-explanation">{d.statusExplanation}</div>;
       }
       return (
         <div className="dependency-container" key={d.src}>
@@ -59,12 +59,12 @@ export default class ExternalResourceOutput extends React.Component {
 
 
         </div>
-      )
-    })
+      );
+    });
     return (
       <div className="dependency-output">
         {outs}
       </div>
-    )
+    );
   }
 }

--- a/src/components/reps/pretty-matrix.jsx
+++ b/src/components/reps/pretty-matrix.jsx
@@ -1,42 +1,42 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import _ from 'lodash'
-import nb from '../../tools/nb'
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import nb from '../../tools/nb';
 
 function cellText(matrixLike, i, j) {
-  const [numRows, numCols] = nb.shape(matrixLike)
-  let text = ''
+  const [numRows, numCols] = nb.shape(matrixLike);
+  let text = '';
   if (_.isNumber(i) && _.isNumber(j)) {
-    text = nb.prettyFormatNumber(matrixLike[i][j], 6)
+    text = nb.prettyFormatNumber(matrixLike[i][j], 6);
   } else if (_.isString(i) && _.isString(j)) {
-    text = '⋱'
+    text = '⋱';
   } else if (_.isString(i) && (j === 0 || j === numCols - 1)) {
-    text = i
+    text = i;
   } else if (_.isString(j) && (i === 0 || i === numRows - 1)) {
-    text = j
+    text = j;
   }
-  return text
+  return text;
 }
 
 function makeMatrixText(matrixLike, maxDims) {
-  const [numRows, numCols] = nb.shape(matrixLike)
-  let rowInds
-  let colInds
+  const [numRows, numCols] = nb.shape(matrixLike);
+  let rowInds;
+  let colInds;
 
   if (numRows > maxDims[0]) {
-    const halfDim = Math.round(maxDims[0] / 2)
-    rowInds = _.range(0, halfDim).concat('⋮', _.range(numRows - halfDim, numRows))
+    const halfDim = Math.round(maxDims[0] / 2);
+    rowInds = _.range(0, halfDim).concat('⋮', _.range(numRows - halfDim, numRows));
   } else {
-    rowInds = _.range(numRows)
+    rowInds = _.range(numRows);
   }
   if (numCols > maxDims[1]) {
-    const halfDim = Math.round(maxDims[1] / 2)
-    colInds = _.range(0, halfDim).concat('⋯', _.range(numCols - halfDim, numCols))
+    const halfDim = Math.round(maxDims[1] / 2);
+    colInds = _.range(0, halfDim).concat('⋯', _.range(numCols - halfDim, numCols));
   } else {
-    colInds = _.range(numCols)
+    colInds = _.range(numCols);
   }
 
-  return rowInds.map(i => colInds.map(j => cellText(matrixLike, i, j)))
+  return rowInds.map(i => colInds.map(j => cellText(matrixLike, i, j)));
 }
 
 class PrettyMatrix extends React.Component {
@@ -45,42 +45,42 @@ class PrettyMatrix extends React.Component {
     maxDims: PropTypes.array,
   }
   constructor(props) {
-    super(props)
-    this.matrix = this.props.matrix
+    super(props);
+    this.matrix = this.props.matrix;
     this.maxDims = this.props.maxDims === undefined ? [10, 10] : this.props.maxDims;
-    [this.numRows, this.numCols] = nb.shape(this.matrix)
+    [this.numRows, this.numCols] = nb.shape(this.matrix);
   }
 
   cellText(i, j) {
-    let text = ''
+    let text = '';
     if (_.isNumber(i) && _.isNumber(j)) {
-      text = nb.prettyFormatNumber(this.matrix[i][j], 6)
+      text = nb.prettyFormatNumber(this.matrix[i][j], 6);
     } else if (_.isString(i) && _.isString(j)) {
-      text = '⋱'
+      text = '⋱';
     } else if (_.isString(i) && (j === 0 || j === this.numCols - 1)) {
-      text = i
+      text = i;
     } else if (_.isString(j) && (i === 0 || i === this.numRows - 1)) {
-      text = j
+      text = j;
     }
-    return text
+    return text;
   }
 
   render() {
-    const { maxDims, numRows, numCols } = this
-    let rowInds
-    let colInds
+    const { maxDims, numRows, numCols } = this;
+    let rowInds;
+    let colInds;
 
     if (numRows > maxDims[0]) {
-      const halfDim = Math.round(maxDims[0] / 2)
-      rowInds = _.range(0, halfDim).concat('⋮', _.range(numRows - halfDim, numRows))
+      const halfDim = Math.round(maxDims[0] / 2);
+      rowInds = _.range(0, halfDim).concat('⋮', _.range(numRows - halfDim, numRows));
     } else {
-      rowInds = _.range(numRows)
+      rowInds = _.range(numRows);
     }
     if (numCols > maxDims[1]) {
-      const halfDim = Math.round(maxDims[1] / 2)
-      colInds = _.range(0, halfDim).concat('⋯', _.range(numCols - halfDim, numCols))
+      const halfDim = Math.round(maxDims[1] / 2);
+      colInds = _.range(0, halfDim).concat('⋯', _.range(numCols - halfDim, numCols));
     } else {
-      colInds = _.range(numCols)
+      colInds = _.range(numCols);
     }
 
     /* eslint-disable */
@@ -121,4 +121,4 @@ class SimpleTable extends React.Component {
 }
 
 
-export { PrettyMatrix, SimpleTable, makeMatrixText }
+export { PrettyMatrix, SimpleTable, makeMatrixText };

--- a/src/components/reps/promise-handler.jsx
+++ b/src/components/reps/promise-handler.jsx
@@ -1,45 +1,45 @@
-import React from 'react'
+import React from 'react';
 
-import { renderValue } from './value-renderer'
+import { renderValue } from './value-renderer';
 
 export class PromiseRep extends React.Component {
   constructor(props) {
-    super(props)
+    super(props);
     this.state = {
       status: 'pending',
       value: undefined,
       runTime: 0,
-    }
+    };
     this.state.promise = props.promise
       .then(
         (val) => {
-          this.setState({ status: 'fulfilled', value: val })
-          return val
+          this.setState({ status: 'fulfilled', value: val });
+          return val;
         },
         (val) => {
-          this.setState({ status: 'rejected', value: val })
-          return val
+          this.setState({ status: 'rejected', value: val });
+          return val;
         },
       ).catch((e) => {
-        this.setState({ status: 'rejected', value: e })
-      })
+        this.setState({ status: 'rejected', value: e });
+      });
     const runTimer = setInterval(() => {
       if (this.state.status === 'pending') {
-        this.setState({ runTime: this.state.runTime + 1 })
+        this.setState({ runTime: this.state.runTime + 1 });
       } else {
-        clearInterval(runTimer)
+        clearInterval(runTimer);
       }
-    }, 1000)
+    }, 1000);
   }
 
   render() {
-    const { value, status, runTime } = this.state
-    let outputValue
-    let statusDisplay = status
+    const { value, status, runTime } = this.state;
+    let outputValue;
+    let statusDisplay = status;
     if (status === 'fulfilled' || status === 'rejected') {
-      outputValue = <div className="promise-handler-value">{renderValue(value)}</div>
+      outputValue = <div className="promise-handler-value">{renderValue(value)}</div>;
     } else if (status === 'pending') {
-      statusDisplay = `pending (${runTime} sec)`
+      statusDisplay = `pending (${runTime} sec)`;
     }
     return (
       <div>
@@ -53,7 +53,7 @@ export class PromiseRep extends React.Component {
         </div>
         {outputValue}
       </div>
-    )
+    );
   }
 }
 
@@ -65,11 +65,11 @@ export default {
      see if we should update, I propose that every time we have render called here,
      we simply put in a key that forces an update. This should only happen when
      we have  return value, at any rate. */
-    const promiseRep = <PromiseRep promise={value} key={new Date().toString()} />
+    const promiseRep = <PromiseRep promise={value} key={new Date().toString()} />;
     return (
       <div>
         {promiseRep}
       </div>
-    )
+    );
   },
-}
+};

--- a/src/components/reps/scalar-handler.jsx
+++ b/src/components/reps/scalar-handler.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 
 const scalarHandler = {
   scalarTypes: {
@@ -12,6 +12,6 @@ const scalarHandler = {
   // TODO: This probably needs a new CSS class
     <span className="array-output">{value}</span>,
 
-}
+};
 
-export default scalarHandler
+export default scalarHandler;

--- a/src/components/reps/undefined-handler.jsx
+++ b/src/components/reps/undefined-handler.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React from 'react';
 
 export default {
   shouldHandle: value => value === undefined,
   render: () => <pre className="undefined-rep">undefined</pre>,
-}
+};

--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -1,39 +1,39 @@
 /* Output handlers */
 
-import React from 'react'
-import PropTypes from 'prop-types'
+import React from 'react';
+import PropTypes from 'prop-types';
 
 
-import nullHandler from './null-handler'
-import undefinedHandler from './undefined-handler'
-import dataFrameHandler from './dataframe-handler'
-import matrixHandler from './matrix-handler'
-import arrayHandler from './array-handler'
-import dateHandler from './date-handler'
-import scalarHandler from './scalar-handler'
-import promiseHandler from './promise-handler'
-import domElementHandler from './dom-element-handler'
-import defaultHandler from './default-handler'
+import nullHandler from './null-handler';
+import undefinedHandler from './undefined-handler';
+import dataFrameHandler from './dataframe-handler';
+import matrixHandler from './matrix-handler';
+import arrayHandler from './array-handler';
+import dateHandler from './date-handler';
+import scalarHandler from './scalar-handler';
+import promiseHandler from './promise-handler';
+import domElementHandler from './dom-element-handler';
+import defaultHandler from './default-handler';
 
 export function renderValue(value, inContainer = false) {
   for (const handler of handlers) {
     if (handler.shouldHandle(value, inContainer)) {
-      const resultElem = handler.render(value, inContainer)
+      const resultElem = handler.render(value, inContainer);
       if (typeof resultElem === 'string') {
-        return (<div>{ resultElem }</div>)
+        return (<div>{ resultElem }</div>);
       } else if (resultElem.tagName !== undefined) {
         // custom output handlers may return HTMLElements,
         // so this checks for that, and if present dangerouslySetInnerHTML's it in
         // a container.
         return <div dangerouslySetInnerHTML={{ __html: resultElem.outerHTML }} /> // eslint-disable-line
       } else if (resultElem.type !== undefined) {
-        return resultElem
+        return resultElem;
       }
-      console.warn(`Unknown output handler result type from ${handler}`)
+      console.warn(`Unknown output handler result type from ${handler}`);
       // Fallback to other handlers if it's something invalid
     }
   }
-  return undefined
+  return undefined;
 }
 
 
@@ -41,23 +41,23 @@ const renderMethodHandler = {
   shouldHandle: value => (value !== undefined && typeof value.iodideRender === 'function'),
 
   render: (value, inContainer) => {
-    const output = value.iodideRender(inContainer)
+    const output = value.iodideRender(inContainer);
     if (typeof output === 'string') {
       return <div dangerouslySetInnerHTML={{ __html: output }} /> // eslint-disable-line
     }
-    return undefined
+    return undefined;
   },
-}
+};
 
 
 const errorHandler = {
   shouldHandle: value => value instanceof Error,
   render: (e) => {
-    let { stack } = e
+    let { stack } = e;
     if (e.lineNumber) {
       // this is firefox
       // prepend the name and message
-      stack = `${e.name}: ${e.message}\n${stack}`
+      stack = `${e.name}: ${e.message}\n${stack}`;
       // lines after the line beginning with "cellReducer@" can
       // be discarded, because they refer to app state not notebook state
       // stack = stack.slice(0, stack.indexOf('cellReducer@'))
@@ -70,9 +70,9 @@ const errorHandler = {
       <div className="error-output">
         <pre>{stack}</pre>
       </div>
-    )
+    );
   },
-}
+};
 
 const handlers = [
   errorHandler,
@@ -87,13 +87,13 @@ const handlers = [
   domElementHandler,
   promiseHandler,
   defaultHandler,
-]
+];
 
 export function addOutputHandler(handler) {
   // TODO: We may want to be smarter about inserting handlers at
   // certain places in the handler array.  Right now, this just
   // puts the new handler at the front.
-  handlers.unshift(handler)
+  handlers.unshift(handler);
 }
 
 
@@ -107,14 +107,14 @@ export class ValueRenderer extends React.Component {
     // console.log(`CellOutput rendered: ${this.props.cellId}`)
     if (!this.props.render ||
         this.props.valueToRender === undefined) {
-      return <div className="empty-resultset" />
+      return <div className="empty-resultset" />;
     }
 
-    const value = this.props.valueToRender
-    const resultElem = renderValue(value)
+    const value = this.props.valueToRender;
+    const resultElem = renderValue(value);
     if (resultElem !== undefined) {
-      return <div className="rep-container">{resultElem}</div>
+      return <div className="rep-container">{resultElem}</div>;
     }
-    return <div className="empty-resultset" />
+    return <div className="empty-resultset" />;
   }
 }

--- a/src/html-template.js
+++ b/src/html-template.js
@@ -12,6 +12,6 @@ const template = `<!DOCTYPE html>
 <div id='page'></div>
 <script src='<%= APP_PATH_STRING %>iodide.<%= APP_VERSION_STRING %>.js'></script>
 </body>
-</html>`
+</html>`;
 
-module.exports = template
+module.exports = template;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,36 +1,36 @@
-import React from 'react'
-import { Provider } from 'react-redux'
-import { render } from 'react-dom'
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from 'react-dom';
 
 // external styles
-import 'font-awesome/css/font-awesome.css'
-import 'opensans-npm-webfont/style.css'
-import 'codemirror/theme/eclipse.css'
-import 'codemirror/lib/codemirror.css'
-import 'codemirror/addon/hint/show-hint.css'
-import 'react-table/react-table.css'
-import '../node_modules/katex/dist/katex.min.css'
+import 'font-awesome/css/font-awesome.css';
+import 'opensans-npm-webfont/style.css';
+import 'codemirror/theme/eclipse.css';
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/addon/hint/show-hint.css';
+import 'react-table/react-table.css';
+import '../node_modules/katex/dist/katex.min.css';
 
 // iodide styles
-import './style/page.css'
-import './style/side-panes.css'
-import './style/menu-styles.css'
-import './style/cell-styles.css'
-import './style/default-presentation.css'
+import './style/page.css';
+import './style/side-panes.css';
+import './style/menu-styles.css';
+import './style/cell-styles.css';
+import './style/default-presentation.css';
 
-import Page from './components/page'
-import { store } from './store'
-import handleUrlQuery from './tools/handle-url-query'
+import Page from './components/page';
+import { store } from './store';
+import handleUrlQuery from './tools/handle-url-query';
 
-import { iodide } from './iodide-api/api'
+import { iodide } from './iodide-api/api';
 
-window.iodide = iodide
+window.iodide = iodide;
 
 render(
   <Provider store={store}>
     <Page />
   </Provider>,
   document.getElementById('page'),
-)
+);
 
-handleUrlQuery()
+handleUrlQuery();

--- a/src/initialize-notebook.js
+++ b/src/initialize-notebook.js
@@ -1,18 +1,18 @@
-import { stateFromJsmd } from './tools/jsmd-tools'
-import { newNotebook } from './state-prototypes'
-import { getSavedNotebooks } from './reducers/notebook-reducer'
+import { stateFromJsmd } from './tools/jsmd-tools';
+import { newNotebook } from './state-prototypes';
+import { getSavedNotebooks } from './reducers/notebook-reducer';
 
 function initializeNotebook() {
-  const jsmdElt = document.getElementById('jsmd')
-  let state
+  const jsmdElt = document.getElementById('jsmd');
+  let state;
   if (jsmdElt &&
       jsmdElt.innerHTML &&
       jsmdElt.innerHTML.trim() !== '') {
-    state = stateFromJsmd(jsmdElt.innerHTML)
+    state = stateFromJsmd(jsmdElt.innerHTML);
   } else {
-    state = newNotebook()
+    state = newNotebook();
   }
-  return Object.assign(state, getSavedNotebooks())
+  return Object.assign(state, getSavedNotebooks());
 }
 
-export { initializeNotebook }
+export { initializeNotebook };

--- a/src/iodide-api/__test__/environment.test.js
+++ b/src/iodide-api/__test__/environment.test.js
@@ -1,94 +1,94 @@
 // import LZString from 'lz-string'
 // import _ from 'lodash'
 
-import { environment } from '../environment'
-import { store } from '../../store'
+import { environment } from '../environment';
+import { store } from '../../store';
 // import { newNotebook } from '../../state-prototypes'
-import { newNotebook } from '../../actions/actions'
+import { newNotebook } from '../../actions/actions';
 
 
 describe('environment methods (integration test)', () => {
   beforeEach(() => {
-    store.dispatch(newNotebook())
-  })
+    store.dispatch(newNotebook());
+  });
 
   it('freeze an environment with an object', () => {
-    environment.freeze({ foo: { a: 1 } })
+    environment.freeze({ foo: { a: 1 } });
     expect(store.getState().savedEnvironment.foo)
-      .toEqual(['object', 'N4IghiBcCMC+Q==='])
-  })
+      .toEqual(['object', 'N4IghiBcCMC+Q===']);
+  });
 
   it('freeze an environment with a string', () => {
-    environment.freeze({ foo: 'a test string' })
+    environment.freeze({ foo: 'a test string' });
     expect(store.getState().savedEnvironment.foo)
-      .toEqual(['string', 'IYAgLgpgzmIwTgSwHYHMg==='])
-  })
+      .toEqual(['string', 'IYAgLgpgzmIwTgSwHYHMg===']);
+  });
 
   it('freeze an environment with a rawString', () => {
-    environment.freezeRawString({ foo: 'a test string' })
+    environment.freezeRawString({ foo: 'a test string' });
     expect(store.getState().savedEnvironment.foo)
-      .toEqual(['rawString', 'a test string'])
-  })
+      .toEqual(['rawString', 'a test string']);
+  });
 
   it('freeze a non-string as rawString should throw', () => {
-    expect(() => { environment.freezeRawString({ foo: 123 }) }).toThrow()
-  })
+    expect(() => { environment.freezeRawString({ foo: 123 }); }).toThrow();
+  });
 
   it('appending a string object', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freeze({ bar: 'a test string' })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freeze({ bar: 'a test string' });
     expect(store.getState().savedEnvironment)
       .toEqual({
         foo: ['object', 'N4IghiBcCMC+Q==='],
         bar: ['string', 'IYAgLgpgzmIwTgSwHYHMg==='],
-      })
-  })
+      });
+  });
 
   it('appending a rawString object', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
     expect(store.getState().savedEnvironment)
       .toEqual({
         foo: ['object', 'N4IghiBcCMC+Q==='],
         bar: ['rawString', 'a test string'],
-      })
-  })
+      });
+  });
 
   it('clearing resets to an empty object', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
-    environment.clear()
-    expect(store.getState().savedEnvironment).toEqual({})
-  })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
+    environment.clear();
+    expect(store.getState().savedEnvironment).toEqual({});
+  });
 
   it('env.getting a single key returns original value stand alone (not in array)', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
-    environment.freeze({ bat: 123 })
-    expect(environment.get('foo')).toEqual({ a: 1 })
-  })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
+    environment.freeze({ bat: 123 });
+    expect(environment.get('foo')).toEqual({ a: 1 });
+  });
 
   it('env.getting multiple keys returns original values in array', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
-    environment.freeze({ bat: 123, boop: { b: 'string 2' } })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
+    environment.freeze({ bat: 123, boop: { b: 'string 2' } });
     expect(environment.get('foo', 'bat', 'boop', 'bar'))
-      .toEqual([{ a: 1 }, 123, { b: 'string 2' }, 'a test string'])
-  })
+      .toEqual([{ a: 1 }, 123, { b: 'string 2' }, 'a test string']);
+  });
 
   it('env.get params must be strings (not an array)', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
-    environment.freeze({ bat: 123, boop: { b: 'string 2' } })
-    expect(() => { environment.get(['foo', 'bat']) }).toThrow()
-  })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
+    environment.freeze({ bat: 123, boop: { b: 'string 2' } });
+    expect(() => { environment.get(['foo', 'bat']); }).toThrow();
+  });
 
   it('env.list returns array of keys in environment', () => {
-    environment.freeze({ foo: { a: 1 } })
-    environment.freezeRawString({ bar: 'a test string' })
-    environment.freeze({ bat: 123 })
+    environment.freeze({ foo: { a: 1 } });
+    environment.freezeRawString({ bar: 'a test string' });
+    environment.freeze({ bat: 123 });
     // inclusion in both directions for set equality
-    expect(environment.list()).toEqual(expect.arrayContaining(['bar', 'foo', 'bat']))
-    expect(['bar', 'foo', 'bat']).toEqual(expect.arrayContaining(environment.list()))
-  })
-})
+    expect(environment.list()).toEqual(expect.arrayContaining(['bar', 'foo', 'bat']));
+    expect(['bar', 'foo', 'bat']).toEqual(expect.arrayContaining(environment.list()));
+  });
+});

--- a/src/iodide-api/__test__/evalQueue.test.js
+++ b/src/iodide-api/__test__/evalQueue.test.js
@@ -5,95 +5,95 @@ import {
   waitForExplicitContinuationStatusResolution,
   evalQueue,
   getRunningCellAsyncProcessStatus,
-} from '../evalQueue'
-import { store } from '../../store'
-import { temporarilySaveRunningCellID, newNotebook } from '../../actions/actions'
+} from '../evalQueue';
+import { store } from '../../store';
+import { temporarilySaveRunningCellID, newNotebook } from '../../actions/actions';
 
-jest.useFakeTimers()
+jest.useFakeTimers();
 
 describe('getRunningCellID', () => {
   beforeEach(() => {
-    store.dispatch(newNotebook())
-    store.dispatch(temporarilySaveRunningCellID(0))
-  })
+    store.dispatch(newNotebook());
+    store.dispatch(temporarilySaveRunningCellID(0));
+  });
   it('properly retrieves the running cell ID', () => {
-    const id = getRunningCellID()
-    expect(id).toBe(0)
-  })
-})
+    const id = getRunningCellID();
+    expect(id).toBe(0);
+  });
+});
 
 describe('flow API', () => {
   beforeEach(() => {
-    store.dispatch(newNotebook())
-    store.dispatch(temporarilySaveRunningCellID(0))
-  })
+    store.dispatch(newNotebook());
+    store.dispatch(temporarilySaveRunningCellID(0));
+  });
 
-  const runningEvalStatus = () => store.getState().cells[0].evalStatus
+  const runningEvalStatus = () => store.getState().cells[0].evalStatus;
   it('allows for explicit setting of cell continuation', () => {
-    evalQueue.requireExplicitContinuation()
-    expect(runningEvalStatus()).toBe('ASYNC_PENDING')
-    expect(getRunningCellAsyncProcessStatus()).toBe(1)
-    evalQueue.continue()
-    expect(getRunningCellAsyncProcessStatus()).toBe(0)
-  })
+    evalQueue.requireExplicitContinuation();
+    expect(runningEvalStatus()).toBe('ASYNC_PENDING');
+    expect(getRunningCellAsyncProcessStatus()).toBe(1);
+    evalQueue.continue();
+    expect(getRunningCellAsyncProcessStatus()).toBe(0);
+  });
   it('accepts only valid setExplicitContinuationStatus arguments', () => {
-    expect(() => setRunningCellEvalStatus('whatever')).toThrow()
-    expect(() => setRunningCellEvalStatus()).toThrow()
-    expect(() => setRunningCellEvalStatus(1000)).toThrow()
-    expect(() => setRunningCellEvalStatus(new Date())).toThrow()
-    setRunningCellEvalStatus('ASYNC_PENDING')
-    expect(runningEvalStatus()).toBe('ASYNC_PENDING')
-    setRunningCellEvalStatus('SUCCESS')
-    expect(runningEvalStatus()).toBe('SUCCESS')
-    setRunningCellEvalStatus('ERROR')
-    expect(runningEvalStatus()).toBe('ERROR')
-  })
+    expect(() => setRunningCellEvalStatus('whatever')).toThrow();
+    expect(() => setRunningCellEvalStatus()).toThrow();
+    expect(() => setRunningCellEvalStatus(1000)).toThrow();
+    expect(() => setRunningCellEvalStatus(new Date())).toThrow();
+    setRunningCellEvalStatus('ASYNC_PENDING');
+    expect(runningEvalStatus()).toBe('ASYNC_PENDING');
+    setRunningCellEvalStatus('SUCCESS');
+    expect(runningEvalStatus()).toBe('SUCCESS');
+    setRunningCellEvalStatus('ERROR');
+    expect(runningEvalStatus()).toBe('ERROR');
+  });
 
   it('correctly waits until waitForExplicitContinuationStatusResolution has resolved (async)', () => {
-    jest.clearAllTimers()
-    evalQueue.requireExplicitContinuation()
+    jest.clearAllTimers();
+    evalQueue.requireExplicitContinuation();
     waitForExplicitContinuationStatusResolution()
       .then(() => {
-        expect(getRunningCellEvalStatus()).toBe('SUCCESS')
+        expect(getRunningCellEvalStatus()).toBe('SUCCESS');
       })
-      .catch((err) => { throw new Error(err) })
-    expect(setInterval).toHaveBeenCalledTimes(1)
-    evalQueue.continue()
+      .catch((err) => { throw new Error(err); });
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    evalQueue.continue();
 
-    jest.runAllTimers()
-  })
+    jest.runAllTimers();
+  });
 
   it('correctly waits until waitForExplicitContinuationStatusResolution has resolved (sync)', () => {
-    jest.clearAllTimers()
+    jest.clearAllTimers();
     waitForExplicitContinuationStatusResolution()
       .then(() => {
-        expect(getRunningCellEvalStatus()).toBe('UNEVALUATED')
+        expect(getRunningCellEvalStatus()).toBe('UNEVALUATED');
       })
-      .catch((err) => { throw new Error(err) })
+      .catch((err) => { throw new Error(err); });
     // setInterval was called once before - the test above this one.
-    expect(setInterval).toHaveBeenCalledTimes(1)
-    jest.runAllTimers()
-  })
+    expect(setInterval).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+  });
 
   it('correctly awaits for Promises to resolve', () => {
-    jest.clearAllTimers()
+    jest.clearAllTimers();
     evalQueue.await([
       Promise.resolve(10),
       Promise.resolve(20),
     ]).then((d) => {
-      expect(d).toEqual([10, 20])
-      expect(getRunningCellAsyncProcessStatus()).toBe(0)
-      expect(getRunningCellEvalStatus()).toBe('SUCCESS')
+      expect(d).toEqual([10, 20]);
+      expect(getRunningCellAsyncProcessStatus()).toBe(0);
+      expect(getRunningCellEvalStatus()).toBe('SUCCESS');
     })
       .catch((err) => {
-        throw new Error(err)
-      })
-    jest.runAllTimers()
-  })
+        throw new Error(err);
+      });
+    jest.runAllTimers();
+  });
 
   it('tests error with async/await', async () => {
     await expect(evalQueue.await([
       Promise.resolve(10).then(d => d.json()),
-    ])).rejects.toThrowError()
-  })
-})
+    ])).rejects.toThrowError();
+  });
+});

--- a/src/iodide-api/api.js
+++ b/src/iodide-api/api.js
@@ -1,16 +1,16 @@
 // The "Public API" for notebooks. This lets notebooks and third-party plugins
 // extend and manipulate the notebook
 
-import { addOutputHandler } from '../components/reps/value-renderer'
-import { environment } from './environment'
-import { evalQueue } from './evalQueue'
-import { output } from './output'
+import { addOutputHandler } from '../components/reps/value-renderer';
+import { environment } from './environment';
+import { evalQueue } from './evalQueue';
+import { output } from './output';
 
 function getDataSync(url) {
-  const re = new XMLHttpRequest()
-  re.open('GET', url, false)
-  re.send(null)
-  return re.response
+  const re = new XMLHttpRequest();
+  re.open('GET', url, false);
+  re.send(null);
+  return re.response;
 }
 
 export const iodide = {
@@ -19,6 +19,6 @@ export const iodide = {
   environment,
   evalQueue,
   output,
-}
+};
 
-export default iodide
+export default iodide;

--- a/src/iodide-api/environment.js
+++ b/src/iodide-api/environment.js
@@ -1,58 +1,58 @@
-import LZString from 'lz-string'
-import _ from 'lodash'
+import LZString from 'lz-string';
+import _ from 'lodash';
 
-import { saveEnvironment } from '../actions/actions'
-import { store } from '../store'
+import { saveEnvironment } from '../actions/actions';
+import { store } from '../store';
 
 
 //  FIXME replace all "throws" with iodide.print (when `print` is ready)
 
 function saveToEnvironment(obj, options) {
   if (!_.isObject(obj)) {
-    throw new TypeError('variables to be saved must be wrapped in object with var name for bundle')
+    throw new TypeError('variables to be saved must be wrapped in object with var name for bundle');
   }
 
-  const envObj = {}
+  const envObj = {};
   Object.keys(obj).forEach((k) => {
-    const v = obj[k]
+    const v = obj[k];
     if (options.raw === true) {
       if (typeof v === 'string') {
-        envObj[k] = ['rawString', v]
+        envObj[k] = ['rawString', v];
       } else {
-        throw new TypeError('only strings can be bundled as raw strings')
+        throw new TypeError('only strings can be bundled as raw strings');
       }
     } else if (typeof v === 'string') {
-      envObj[k] = ['string', LZString.compressToBase64(v)]
+      envObj[k] = ['string', LZString.compressToBase64(v)];
     } else {
-      envObj[k] = ['object', LZString.compressToBase64(JSON.stringify(v))]
+      envObj[k] = ['object', LZString.compressToBase64(JSON.stringify(v))];
     }
-  })
-  store.dispatch(saveEnvironment(envObj, options.update))
+  });
+  store.dispatch(saveEnvironment(envObj, options.update));
 }
 
 function decodeEnvObj(encoding, str) {
   switch (encoding) {
     case 'rawString':
-      return str
+      return str;
     case 'object':
-      return JSON.parse(LZString.decompressFromBase64(str))
+      return JSON.parse(LZString.decompressFromBase64(str));
     case 'string':
-      return LZString.decompressFromBase64(str)
+      return LZString.decompressFromBase64(str);
     default:
-      throw new TypeError('JSMD env variables must have encoding "object", "string" or "rawString"')
+      throw new TypeError('JSMD env variables must have encoding "object", "string" or "rawString"');
   }
 }
 
 function loadFromEnvironment(varList) {
   varList.forEach((v) => {
     if (typeof v !== 'string') {
-      throw new TypeError('environment.get only accepts one or more strings as parameters')
+      throw new TypeError('environment.get only accepts one or more strings as parameters');
     }
-  })
-  const env = store.getState().savedEnvironment
-  const valsOut = varList.map(v => decodeEnvObj(...env[v]))
-  if (valsOut.length === 1) { return valsOut[0] }
-  return valsOut
+  });
+  const env = store.getState().savedEnvironment;
+  const valsOut = varList.map(v => decodeEnvObj(...env[v]));
+  if (valsOut.length === 1) { return valsOut[0]; }
+  return valsOut;
 }
 
 export const environment = {
@@ -66,4 +66,4 @@ export const environment = {
   get: (...vars) => loadFromEnvironment(vars),
 
   list: () => Object.keys(store.getState().savedEnvironment),
-}
+};

--- a/src/iodide-api/evalQueue.js
+++ b/src/iodide-api/evalQueue.js
@@ -1,88 +1,88 @@
-import { store } from '../store'
-import { updateCellProperties } from '../actions/actions'
-import { getCellById } from '../tools/notebook-utils'
+import { store } from '../store';
+import { updateCellProperties } from '../actions/actions';
+import { getCellById } from '../tools/notebook-utils';
 
-export const getRunningCellID = () => store.getState().runningCellID
+export const getRunningCellID = () => store.getState().runningCellID;
 
 export const resetAsyncProcessCount = () => {
-  const cellId = getRunningCellID()
+  const cellId = getRunningCellID();
   store.dispatch(updateCellProperties(cellId, {
     asyncProcessCount: 0,
-  }))
-}
+  }));
+};
 
 export const incrementAsyncProcessCount = (n = 1) => {
-  const cellId = getRunningCellID()
-  const cell = getCellById(store.getState().cells, cellId)
+  const cellId = getRunningCellID();
+  const cell = getCellById(store.getState().cells, cellId);
   store.dispatch(updateCellProperties(cellId, {
     asyncProcessCount: cell.asyncProcessCount + n,
-  }))
-}
+  }));
+};
 
 export const getRunningCellAsyncProcessStatus = () => {
-  const cellId = getRunningCellID()
-  const cell = getCellById(store.getState().cells, cellId)
+  const cellId = getRunningCellID();
+  const cell = getCellById(store.getState().cells, cellId);
   if (cell !== undefined) {
-    return cell.asyncProcessCount
+    return cell.asyncProcessCount;
   }
-  return undefined
-}
+  return undefined;
+};
 
 export const getRunningCellEvalStatus = () => {
-  const cellId = getRunningCellID()
-  const cell = getCellById(store.getState().cells, cellId)
+  const cellId = getRunningCellID();
+  const cell = getCellById(store.getState().cells, cellId);
   if (cell !== undefined) {
-    return cell.evalStatus
+    return cell.evalStatus;
   }
-  return undefined
-}
+  return undefined;
+};
 
 export const setRunningCellEvalStatus = (evalStatus) => {
-  if (evalStatus === undefined) throw new Error('status must be defined')
-  const cellId = getRunningCellID()
+  if (evalStatus === undefined) throw new Error('status must be defined');
+  const cellId = getRunningCellID();
   store.dispatch(updateCellProperties(cellId, {
     evalStatus,
-  }))
-}
+  }));
+};
 
 export const waitForExplicitContinuationStatusResolution = () => new Promise((resolve) => {
   if (getRunningCellAsyncProcessStatus() > 0) {
     const interval = setInterval(() => {
       if (getRunningCellAsyncProcessStatus() === 0) {
-        setRunningCellEvalStatus('SUCCESS')
-        resolve()
-        clearInterval(interval)
+        setRunningCellEvalStatus('SUCCESS');
+        resolve();
+        clearInterval(interval);
       }
-    }, 50)
+    }, 50);
   } else {
-    resolve()
+    resolve();
   }
-})
+});
 
 const awaitPromises = (promises) => {
-  setRunningCellEvalStatus('ASYNC_PENDING')
-  incrementAsyncProcessCount()
+  setRunningCellEvalStatus('ASYNC_PENDING');
+  incrementAsyncProcessCount();
   return Promise.resolve().then(() => Promise.all(promises).catch((err) => {
-    resetAsyncProcessCount()
-    setRunningCellEvalStatus('ERROR')
-    throw Error(err)
+    resetAsyncProcessCount();
+    setRunningCellEvalStatus('ERROR');
+    throw Error(err);
   }))
     .then((resolutions) => {
-      incrementAsyncProcessCount(-1)
+      incrementAsyncProcessCount(-1);
       if (getRunningCellAsyncProcessStatus() === 0) {
-        setRunningCellEvalStatus('SUCCESS')
+        setRunningCellEvalStatus('SUCCESS');
       }
-      return resolutions
-    })
-}
+      return resolutions;
+    });
+};
 
 export const evalQueue = {
   requireExplicitContinuation: () => {
-    setRunningCellEvalStatus('ASYNC_PENDING')
-    incrementAsyncProcessCount(1)
+    setRunningCellEvalStatus('ASYNC_PENDING');
+    incrementAsyncProcessCount(1);
   },
   continue: () => {
-    if (getRunningCellAsyncProcessStatus() > 0) incrementAsyncProcessCount(-1)
+    if (getRunningCellAsyncProcessStatus() > 0) incrementAsyncProcessCount(-1);
   },
   await: awaitPromises,
-}
+};

--- a/src/iodide-api/output.js
+++ b/src/iodide-api/output.js
@@ -1,4 +1,4 @@
-import { store } from '../store'
+import { store } from '../store';
 
 /*
 These functions operate outside of the normal React/redux update cycle
@@ -14,28 +14,28 @@ things out.
 
 function sideEffectDiv(sideEffectClass, reportSideEffect) {
   // appends a side effect div to the side effect area
-  const cellId = store.getState().runningCellID
-  const div = document.createElement('div')
-  const printClass = (reportSideEffect === true) ? sideEffectClass : `${sideEffectClass} hide-side-effect`
-  div.setAttribute('class', printClass)
-  document.getElementById(`cell-${cellId}-side-effect-target`).append(div)
-  return div
+  const cellId = store.getState().runningCellID;
+  const div = document.createElement('div');
+  const printClass = (reportSideEffect === true) ? sideEffectClass : `${sideEffectClass} hide-side-effect`;
+  div.setAttribute('class', printClass);
+  document.getElementById(`cell-${cellId}-side-effect-target`).append(div);
+  return div;
 }
 
 export const output = {
   text: (s, reportSideEffect = false) => {
     // dumbly puts a string in a side effect div
-    const div = sideEffectDiv('side-effect-print', reportSideEffect)
-    div.innerHTML = s.toString()
+    const div = sideEffectDiv('side-effect-print', reportSideEffect);
+    div.innerHTML = s.toString();
   },
   element: (nodeType, reportSideEffect = true) => {
     // const cellId = store.getState().runningCellID
-    const div = sideEffectDiv('side-effect-element', reportSideEffect)
-    const node = document.createElement(nodeType)
-    div.append(node)
-    return node
+    const div = sideEffectDiv('side-effect-element', reportSideEffect);
+    const node = document.createElement(nodeType);
+    div.append(node);
+    return node;
   },
-}
+};
 
 
 // export function html(s) {

--- a/src/iodide-examples.js
+++ b/src/iodide-examples.js
@@ -1,6 +1,6 @@
-import ExternalLinkTask from './actions/external-link-task'
+import ExternalLinkTask from './actions/external-link-task';
 
-const BASE_URL = 'https://iodide-project.github.io/iodide-examples'
+const BASE_URL = 'https://iodide-project.github.io/iodide-examples';
 
 export const iodideExamples = [
   {
@@ -15,6 +15,6 @@ export const iodideExamples = [
     title: 'Output Handling',
     url: `${BASE_URL}/output-handling.html`,
   },
-]
+];
 
-export default iodideExamples.map(e => new ExternalLinkTask({ title: e.title, url: e.url }))
+export default iodideExamples.map(e => new ExternalLinkTask({ title: e.title, url: e.url }));

--- a/src/keybindings.js
+++ b/src/keybindings.js
@@ -1,19 +1,19 @@
-import Mousetrap from 'mousetrap'
-import tasks from './actions/task-definitions'
+import Mousetrap from 'mousetrap';
+import tasks from './actions/task-definitions';
 // for now, let's just keep the keybindings here.
 
-Mousetrap.prototype.stopCallback = () => false
+Mousetrap.prototype.stopCallback = () => false;
 
 
 export function initializeDefaultKeybindings() {
   Object.keys(tasks).forEach((t) => {
-    const task = tasks[t]
+    const task = tasks[t];
     if (task.hasKeybinding()) {
-      Mousetrap.bind(task.keybindings, task.keybindingCallback)
+      Mousetrap.bind(task.keybindings, task.keybindingCallback);
     }
-  })
+  });
 }
 
 export function addLanguageKeybinding(keys, callback) {
-  Mousetrap.bind(keys, callback)
+  Mousetrap.bind(keys, callback);
 }

--- a/src/reducers/__tests__/cell-reducer.test.js
+++ b/src/reducers/__tests__/cell-reducer.test.js
@@ -1,14 +1,14 @@
-import cellReducer from '../cell-reducer'
-import { newNotebook } from '../../state-prototypes'
+import cellReducer from '../cell-reducer';
+import { newNotebook } from '../../state-prototypes';
 
 describe('add cells', () => {
-  const state = newNotebook()
-  const nextState = cellReducer(state, { type: 'ADD_CELL', cellType: 'code' })
+  const state = newNotebook();
+  const nextState = cellReducer(state, { type: 'ADD_CELL', cellType: 'code' });
   it('should add a cell to the end of the current notebook', () => {
-    expect(nextState.cells.length).toEqual(newNotebook().cells.length + 1)
-    expect(nextState.cells[nextState.cells.length - 1].cellType).toEqual('code')
-  })
-})
+    expect(nextState.cells.length).toEqual(newNotebook().cells.length + 1);
+    expect(nextState.cells[nextState.cells.length - 1].cellType).toEqual('code');
+  });
+});
 
 // describe('insert cells', ()=> {
 //     var state = NB.newNotebook()

--- a/src/reducers/__tests__/notebook-reducer.test.js
+++ b/src/reducers/__tests__/notebook-reducer.test.js
@@ -1,20 +1,20 @@
-import notebookReducer from '../notebook-reducer'
-import { newNotebook, blankState, addNewCellToState } from '../../state-prototypes'
+import notebookReducer from '../notebook-reducer';
+import { newNotebook, blankState, addNewCellToState } from '../../state-prototypes';
 import {
   // exportJsmdBundle, we'll need to test this
   // stringifyStateToJsmd, we'll need to test this
   stateFromJsmd,
-} from '../../tools/jsmd-tools'
+} from '../../tools/jsmd-tools';
 
-const EXAMPLE_NOTEBOOK_1 = 'example notebook with content'
+const EXAMPLE_NOTEBOOK_1 = 'example notebook with content';
 
 function exampleNotebookWithContent(title = EXAMPLE_NOTEBOOK_1) {
-  let state = newNotebook()
-  state = addNewCellToState(state, 'code')
-  state = addNewCellToState(state, 'markdown')
-  state.cells[0].selected = true
-  state.title = title
-  return state
+  let state = newNotebook();
+  state = addNewCellToState(state, 'code');
+  state = addNewCellToState(state, 'markdown');
+  state.cells[0].selected = true;
+  state.title = title;
+  return state;
 }
 
 beforeEach(() => {
@@ -23,62 +23,62 @@ beforeEach(() => {
 
 describe('blank-state-reducer', () => {
   it('should return the initial state', () => {
-    expect(notebookReducer(blankState(), {})).toEqual(blankState())
-  })
-})
+    expect(notebookReducer(blankState(), {})).toEqual(blankState());
+  });
+});
 
 describe('new notebooks', () => {
-  const nextState = newNotebook()
+  const nextState = newNotebook();
 
   it('should create newNotebook() on NEW_NOTEBOOK', () => {
-    expect(notebookReducer(nextState, { type: 'NEW_NOTEBOOK' })).toEqual(newNotebook())
-  })
-})
+    expect(notebookReducer(nextState, { type: 'NEW_NOTEBOOK' })).toEqual(newNotebook());
+  });
+});
 
 describe('misc. notebook operations that don\'t belong elsewhere', () => {
-  const state = exampleNotebookWithContent()
-  const NEW_NAME = 'changed notebook name'
+  const state = exampleNotebookWithContent();
+  const NEW_NAME = 'changed notebook name';
   it('should change title', () => {
-    expect(notebookReducer(state, { type: 'CHANGE_PAGE_TITLE', title: NEW_NAME }).title).toEqual(NEW_NAME)
-  })
-})
+    expect(notebookReducer(state, { type: 'CHANGE_PAGE_TITLE', title: NEW_NAME }).title).toEqual(NEW_NAME);
+  });
+});
 
 describe('importing a notebook via state', () => {
-  const state = newNotebook()
-  const nextState = exampleNotebookWithContent()
+  const state = newNotebook();
+  const nextState = exampleNotebookWithContent();
 
   it('should import a notebook correctly on IMPORT_NOTEBOOK', () => {
-    expect(notebookReducer(state, { type: 'IMPORT_NOTEBOOK', newState: nextState })).toEqual(nextState)
-  })
-})
+    expect(notebookReducer(state, { type: 'IMPORT_NOTEBOOK', newState: nextState })).toEqual(nextState);
+  });
+});
 
 
 describe('saving / deleting localStorage-saved notebooks', () => {
   // this will do enough for now.
-  const SAVE_DELETE_NOTEBOOK_NAME = 'save-delete-notebook-tests'
-  const state = exampleNotebookWithContent(SAVE_DELETE_NOTEBOOK_NAME)
+  const SAVE_DELETE_NOTEBOOK_NAME = 'save-delete-notebook-tests';
+  const state = exampleNotebookWithContent(SAVE_DELETE_NOTEBOOK_NAME);
 
-  notebookReducer(state, { type: 'SAVE_NOTEBOOK' })
-  const savedNotebook = stateFromJsmd(localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME))
+  notebookReducer(state, { type: 'SAVE_NOTEBOOK' });
+  const savedNotebook = stateFromJsmd(localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME));
 
   it('saved notebook should have correct title', () => {
-    expect(savedNotebook.title).toEqual(state.title)
-  })
+    expect(savedNotebook.title).toEqual(state.title);
+  });
 
   it('saved notebook should have lastSaved time', () => {
-    expect(savedNotebook.lastSaved).toBeDefined()
-  })
+    expect(savedNotebook.lastSaved).toBeDefined();
+  });
 
   it('saved notebook should have correct cell, up to cell ids', () => {
     // note that cellIds may change between save/load, because jsmd does not store cellIds
     // let's reset all the cellIds in both
     savedNotebook.cells.forEach((c, i) => { c.id = i }) // eslint-disable-line
     state.cells.forEach((c, i) => { c.id = i }) // eslint-disable-line
-    expect(savedNotebook.cells).toEqual(state.cells)
-  })
+    expect(savedNotebook.cells).toEqual(state.cells);
+  });
 
   it('should delete via DELETE_NOTEBOOK', () => {
-    notebookReducer(state, { type: 'DELETE_NOTEBOOK', title: SAVE_DELETE_NOTEBOOK_NAME })
-    expect(localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME)).toEqual(null)
-  })
-})
+    notebookReducer(state, { type: 'DELETE_NOTEBOOK', title: SAVE_DELETE_NOTEBOOK_NAME });
+    expect(localStorage.getItem(SAVE_DELETE_NOTEBOOK_NAME)).toEqual(null);
+  });
+});

--- a/src/reducers/cell-reducer-utils.js
+++ b/src/reducers/cell-reducer-utils.js
@@ -1,42 +1,42 @@
 function moveCell(cells, cellID, dir) {
-  const cellsSlice = cells.slice()
-  const index = cellsSlice.findIndex(c => c.id === cellID)
+  const cellsSlice = cells.slice();
+  const index = cellsSlice.findIndex(c => c.id === cellID);
 
-  let moveIndex
-  let moveCondition
+  let moveIndex;
+  let moveCondition;
   if (dir === 'up') {
-    moveIndex = -1
-    moveCondition = index > 0
+    moveIndex = -1;
+    moveCondition = index > 0;
   } else {
-    moveIndex = 1
-    moveCondition = index < cellsSlice.length - 1
+    moveIndex = 1;
+    moveCondition = index < cellsSlice.length - 1;
   }
   if (moveCondition) {
-    const elem = cellsSlice[index + moveIndex]
-    cellsSlice[index + moveIndex] = cellsSlice[index]
-    cellsSlice[index] = elem
+    const elem = cellsSlice[index + moveIndex];
+    cellsSlice[index + moveIndex] = cellsSlice[index];
+    cellsSlice[index] = elem;
   }
-  return cellsSlice
+  return cellsSlice;
 }
 
 function scrollToCellIfNeeded(cellID) {
-  const elem = document.getElementById(`cell-${cellID}`)
-  const rect = elem.getBoundingClientRect()
-  const viewportRect = document.getElementById('cells').getBoundingClientRect()
-  const windowHeight = (window.innerHeight || document.documentElement.clientHeight)
-  const tallerThanWindow = (rect.bottom - rect.top) > windowHeight
-  let cellPosition
+  const elem = document.getElementById(`cell-${cellID}`);
+  const rect = elem.getBoundingClientRect();
+  const viewportRect = document.getElementById('cells').getBoundingClientRect();
+  const windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+  const tallerThanWindow = (rect.bottom - rect.top) > windowHeight;
+  let cellPosition;
   // verbose but readable
   if (rect.bottom <= viewportRect.top) {
-    cellPosition = 'ABOVE_VIEWPORT'
+    cellPosition = 'ABOVE_VIEWPORT';
   } else if (rect.top >= viewportRect.bottom) {
-    cellPosition = 'BELOW_VIEWPORT'
+    cellPosition = 'BELOW_VIEWPORT';
   } else if ((rect.top <= viewportRect.top) && (viewportRect.top <= rect.bottom)) {
-    cellPosition = 'BOTTOM_IN_VIEWPORT'
+    cellPosition = 'BOTTOM_IN_VIEWPORT';
   } else if ((rect.top <= viewportRect.bottom) && (viewportRect.bottom <= rect.bottom)) {
-    cellPosition = 'TOP_IN_VIEWPORT'
+    cellPosition = 'TOP_IN_VIEWPORT';
   } else {
-    cellPosition = 'IN_VIEWPORT'
+    cellPosition = 'IN_VIEWPORT';
   }
 
   if ((cellPosition === 'ABOVE_VIEWPORT')
@@ -47,160 +47,160 @@ function scrollToCellIfNeeded(cellID) {
     elem.scrollIntoView({
       behavior: 'smooth',
       block: 'start',
-    })
+    });
   } else if (((cellPosition === 'BELOW_VIEWPORT') && !(tallerThanWindow))
     || ((cellPosition === 'TOP_IN_VIEWPORT') && !(tallerThanWindow))
   ) { // in these cases, scroll the window such that the cell bottom is at the window bottom
     elem.scrollIntoView({
       behavior: 'smooth',
       block: 'end',
-    })
+    });
   }
 }
 
 
 function addExternalDependency(dep) {
   // FIXME there must be a better way to do this with promises etc...
-  const head = document.getElementsByTagName('head')[0]
-  let elem
-  const outElem = {}
+  const head = document.getElementsByTagName('head')[0];
+  let elem;
+  const outElem = {};
   // check for js: or css:
-  let src
-  let depType
+  let src;
+  let depType;
 
   if (dep.trim().slice(0, 2) === '//') {
-    return undefined
+    return undefined;
   }
 
   if (dep.slice(0, 4) === 'css:') {
-    depType = 'css'
-    src = dep.slice(4)
+    depType = 'css';
+    src = dep.slice(4);
   } else if (dep.slice(0, 3) === 'js:') {
-    depType = 'js'
-    src = dep.slice(3)
+    depType = 'js';
+    src = dep.slice(3);
   } else if (dep.slice(dep.length - 2) === 'js') {
-    depType = 'js'
-    src = dep
+    depType = 'js';
+    src = dep;
   } else if (dep.slice(dep.length - 3) === 'css') {
-    depType = 'css'
-    src = dep
+    depType = 'css';
+    src = dep;
   } else {
-    src = dep
+    src = dep;
   }
 
-  src = src.trim()
+  src = src.trim();
 
   if (depType === 'js') {
-    elem = document.createElement('script')
-    elem.type = 'text/javascript'
-    const xhrObj = new XMLHttpRequest()
-    xhrObj.open('GET', src, false)
+    elem = document.createElement('script');
+    elem.type = 'text/javascript';
+    const xhrObj = new XMLHttpRequest();
+    xhrObj.open('GET', src, false);
     try {
-      xhrObj.send('')
-      elem.text = xhrObj.responseText
-      outElem.status = 'loaded'
+      xhrObj.send('');
+      elem.text = xhrObj.responseText;
+      outElem.status = 'loaded';
     } catch (err) {
-      outElem.status = 'error'
-      outElem.statusExplanation = err.message
+      outElem.status = 'error';
+      outElem.statusExplanation = err.message;
     }
   } else if (depType === 'css') {
-    elem = document.createElement('link')
-    elem.rel = 'stylesheet'
-    elem.type = 'text/css'
-    elem.href = src
-    outElem.status = 'loaded'
+    elem = document.createElement('link');
+    elem.rel = 'stylesheet';
+    elem.type = 'text/css';
+    elem.href = src;
+    outElem.status = 'loaded';
   } else {
-    outElem.status = 'error'
-    outElem.statusExplanation = 'unknown dependency type.'
-    outElem.src = src
-    outElem.dependencyType = depType
-    return outElem
+    outElem.status = 'error';
+    outElem.statusExplanation = 'unknown dependency type.';
+    outElem.src = src;
+    outElem.dependencyType = depType;
+    return outElem;
   }
 
-  const initialWindow = Object.keys(window)
+  const initialWindow = Object.keys(window);
 
-  head.appendChild(elem)
+  head.appendChild(elem);
 
-  const newWindow = Object.keys(window)
+  const newWindow = Object.keys(window);
 
-  outElem.variables = newWindow.filter(v => !initialWindow.includes(v))
+  outElem.variables = newWindow.filter(v => !initialWindow.includes(v));
 
-  outElem.src = src
-  outElem.dependencyType = depType
+  outElem.src = src;
+  outElem.dependencyType = depType;
 
-  return outElem
+  return outElem;
 }
 
 function getSelectedCellId(state) {
-  const { cells } = state
-  const index = cells.findIndex(c => c.selected)
+  const { cells } = state;
+  const index = cells.findIndex(c => c.selected);
   if (index > -1) {
-    return cells[index].id
+    return cells[index].id;
   }
-  return undefined // for now
+  return undefined; // for now
 }
 
 function getCellBelowSelectedId(state) {
-  const { cells } = state
-  const index = cells.findIndex(c => c.selected)
+  const { cells } = state;
+  const index = cells.findIndex(c => c.selected);
   if (index === cells.length - 1) {
     // if there is no cell below, return this cell's id
-    return cells[index].id
+    return cells[index].id;
   } else if (index >= 0 && index < (cells.length - 1)) {
-    return cells[index + 1].id
+    return cells[index + 1].id;
   }
-  throw new Error('no cell currently selected')
+  throw new Error('no cell currently selected');
 }
 
 function getSelectedCell(state) {
-  const { cells } = state
-  const index = cells.findIndex(c => c.selected)
+  const { cells } = state;
+  const index = cells.findIndex(c => c.selected);
   if (index > -1) {
-    return cells[index]
+    return cells[index];
   }
-  return undefined // for now
+  return undefined; // for now
 }
 
 function newStateWithSelectedCellPropertySet(state, cellPropToSet, newValue) {
-  const cells = state.cells.slice()
-  const thisCell = getSelectedCell(state)
-  thisCell[cellPropToSet] = newValue
-  return Object.assign({}, state, { cells })
+  const cells = state.cells.slice();
+  const thisCell = getSelectedCell(state);
+  thisCell[cellPropToSet] = newValue;
+  return Object.assign({}, state, { cells });
 }
 
 function newStateWithPropsAssignedForCell(state, cellId, cellPropsToSet) {
-  const cells = state.cells.slice()
-  const index = cells.findIndex(c => c.id === cellId)
-  cells[index] = Object.assign({}, cells[index], cellPropsToSet)
-  return Object.assign({}, state, { cells })
+  const cells = state.cells.slice();
+  const index = cells.findIndex(c => c.id === cellId);
+  cells[index] = Object.assign({}, cells[index], cellPropsToSet);
+  return Object.assign({}, state, { cells });
 }
 
 function newStateWithSelectedCellPropsAssigned(state, cellPropsToSet) {
-  return newStateWithPropsAssignedForCell(state, getSelectedCellId(state), cellPropsToSet)
+  return newStateWithPropsAssignedForCell(state, getSelectedCellId(state), cellPropsToSet);
 }
 
 function newStateWithRowOverflowSet(state, cellId, rowType, viewModeToSet, rowOverflow) {
-  const cells = state.cells.slice()
-  const cellIndex = cells.findIndex(c => c.id === cellId)
-  const cell = cells[cellIndex]
+  const cells = state.cells.slice();
+  const cellIndex = cells.findIndex(c => c.id === cellId);
+  const cell = cells[cellIndex];
   // this block can be deprecated if we move to enums for VIEWs
-  let view
+  let view;
   switch (viewModeToSet) {
     case 'editor':
-      view = 'EXPLORE'
-      break
+      view = 'EXPLORE';
+      break;
     case 'presentation':
-      view = 'REPORT'
-      break
+      view = 'REPORT';
+      break;
     default:
-      throw Error(`Unsupported viewMode: ${viewModeToSet}`)
+      throw Error(`Unsupported viewMode: ${viewModeToSet}`);
   }
-  cell.rowSettings[view][rowType] = rowOverflow
+  cell.rowSettings[view][rowType] = rowOverflow;
 
-  cells[cellIndex] = Object.assign({}, cells[cellIndex])
+  cells[cellIndex] = Object.assign({}, cells[cellIndex]);
 
 
-  return Object.assign({}, state, { cells })
+  return Object.assign({}, state, { cells });
 }
 
 
@@ -215,4 +215,4 @@ export {
   newStateWithSelectedCellPropsAssigned,
   newStateWithRowOverflowSet,
   newStateWithPropsAssignedForCell,
-}
+};

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -1,8 +1,8 @@
-import MarkdownIt from 'markdown-it'
-import MarkdownItKatex from 'markdown-it-katex'
-import MarkdownItAnchor from 'markdown-it-anchor'
+import MarkdownIt from 'markdown-it';
+import MarkdownItKatex from 'markdown-it-katex';
+import MarkdownItAnchor from 'markdown-it-anchor';
 
-import { newCell, newCellID, newNotebook } from '../state-prototypes'
+import { newCell, newCellID, newNotebook } from '../state-prototypes';
 
 import {
   moveCell, scrollToCellIfNeeded,
@@ -12,79 +12,79 @@ import {
   newStateWithSelectedCellPropsAssigned,
   newStateWithRowOverflowSet,
   newStateWithPropsAssignedForCell,
-} from './cell-reducer-utils'
+} from './cell-reducer-utils';
 
 const MD = MarkdownIt({ html: true }) // eslint-disable-line
-MD.use(MarkdownItKatex).use(MarkdownItAnchor)
+MD.use(MarkdownItKatex).use(MarkdownItAnchor);
 
 const cellReducer = (state = newNotebook(), action) => {
-  let nextState
+  let nextState;
   switch (action.type) {
     case 'INSERT_CELL': {
-      const cells = state.cells.slice()
-      const index = cells.findIndex(c => c.id === getSelectedCellId(state))
-      const direction = (action.direction === 'above') ? 0 : 1
-      const nextCell = newCell(newCellID(state.cells), 'code', state.languageLastUsed)
-      cells.splice(index + direction, 0, nextCell)
-      nextState = Object.assign({}, state, { cells })
-      return nextState
+      const cells = state.cells.slice();
+      const index = cells.findIndex(c => c.id === getSelectedCellId(state));
+      const direction = (action.direction === 'above') ? 0 : 1;
+      const nextCell = newCell(newCellID(state.cells), 'code', state.languageLastUsed);
+      cells.splice(index + direction, 0, nextCell);
+      nextState = Object.assign({}, state, { cells });
+      return nextState;
     }
     case 'ADD_CELL': {
-      nextState = Object.assign({}, state)
-      const language = state.languageLastUsed
-      const cells = nextState.cells.slice()
-      const nextCell = newCell(newCellID(nextState.cells), action.cellType, language)
+      nextState = Object.assign({}, state);
+      const language = state.languageLastUsed;
+      const cells = nextState.cells.slice();
+      const nextCell = newCell(newCellID(nextState.cells), action.cellType, language);
       nextState = Object.assign(
         {},
         nextState,
         { cells: [...cells, nextCell] },
         { languageLastUsed: language },
-      )
-      return nextState
+      );
+      return nextState;
     }
 
     case 'SELECT_CELL': {
-      const cells = state.cells.slice()
+      const cells = state.cells.slice();
       cells.forEach((c) => { c.selected = false })  // eslint-disable-line
-      const index = cells.findIndex(c => c.id === action.id)
-      const thisCell = cells[index]
-      thisCell.selected = true
-      if (action.scrollToCell) { scrollToCellIfNeeded(thisCell.id) }
-      nextState = Object.assign({}, state, { cells })
-      return nextState
+      const index = cells.findIndex(c => c.id === action.id);
+      const thisCell = cells[index];
+      thisCell.selected = true;
+      if (action.scrollToCell) { scrollToCellIfNeeded(thisCell.id); }
+      nextState = Object.assign({}, state, { cells });
+      return nextState;
     }
 
     case 'CELL_UP':
-      scrollToCellIfNeeded(getSelectedCellId(state))
+      scrollToCellIfNeeded(getSelectedCellId(state));
       return Object.assign(
         {}, state,
         { cells: moveCell(state.cells, getSelectedCellId(state), 'up') },
-      )
+      );
 
     case 'CELL_DOWN':
-      scrollToCellIfNeeded(getCellBelowSelectedId(state))
+      scrollToCellIfNeeded(getCellBelowSelectedId(state));
       return Object.assign(
         {}, state,
         { cells: moveCell(state.cells, getSelectedCellId(state), 'down') },
-      )
+      );
 
     case 'UPDATE_CELL_PROPERTIES':
-      return newStateWithPropsAssignedForCell(state, action.cellId, action.updatedProperties)
+      return newStateWithPropsAssignedForCell(state, action.cellId, action.updatedProperties);
 
     case 'UPDATE_INPUT_CONTENT':
-      return newStateWithSelectedCellPropertySet(state, 'content', action.content)
+      return newStateWithSelectedCellPropertySet(state, 'content', action.content);
 
     case 'CHANGE_ELEMENT_TYPE':
-      return newStateWithSelectedCellPropertySet(state, 'elementType', action.elementType)
+      return newStateWithSelectedCellPropertySet(state, 'elementType', action.elementType);
 
     case 'CHANGE_DOM_ELEMENT_ID':
-      return newStateWithSelectedCellPropertySet(state, 'domElementID', action.elemID)
+      return newStateWithSelectedCellPropertySet(state, 'domElementID', action.elemID);
 
     case 'CHANGE_CELL_TYPE': {
       // create a newCell of the given type to get the defaults that
       // will need to be updated for the new cell type
-      const { language } = action
-      const { rowSettings } = newCell(-1, action.cellType)
+      const { language } = action;
+      const { rowSettings } = newCell(-1, action.cellType);
       const newState = newStateWithSelectedCellPropsAssigned(
         state,
         {
@@ -94,51 +94,51 @@ const cellReducer = (state = newNotebook(), action) => {
           rowSettings,
           language,
         },
-      )
-      return Object.assign(newState, { languageLastUsed: language })
+      );
+      return Object.assign(newState, { languageLastUsed: language });
     }
 
     case 'SET_CELL_ROW_COLLAPSE_STATE': {
-      let { cellId } = action
-      if (cellId === undefined) { cellId = getSelectedCellId(state) }
+      let { cellId } = action;
+      if (cellId === undefined) { cellId = getSelectedCellId(state); }
       return newStateWithRowOverflowSet(
         state,
         cellId,
         action.rowType,
         action.viewMode,
         action.rowOverflow,
-      )
+      );
     }
 
     case 'MARK_CELL_NOT_RENDERED':
       return newStateWithSelectedCellPropertySet(
         state,
         'rendered', false,
-      )
+      );
 
     case 'DELETE_CELL': {
-      const selectedId = getSelectedCellId(state)
-      const cells = state.cells.slice()
-      if (!cells.length) return state
-      const index = cells.findIndex(c => c.id === selectedId)
-      const thisCell = state.cells[index]
+      const selectedId = getSelectedCellId(state);
+      const cells = state.cells.slice();
+      if (!cells.length) return state;
+      const index = cells.findIndex(c => c.id === selectedId);
+      const thisCell = state.cells[index];
       if (thisCell.selected) {
-        let nextIndex = 0
+        let nextIndex = 0;
         if (cells.length > 1) {
-          if (index === cells.length - 1) nextIndex = cells.length - 2
-          else nextIndex = index + 1
-          cells[nextIndex].selected = true
+          if (index === cells.length - 1) nextIndex = cells.length - 2;
+          else nextIndex = index + 1;
+          cells[nextIndex].selected = true;
         }
       }
       nextState = Object.assign({}, state, {
         cells: cells.filter(cell => cell.id !== selectedId),
-      })
-      return nextState
+      });
+      return nextState;
     }
 
     default:
-      return state
+      return state;
   }
-}
+};
 
-export default cellReducer
+export default cellReducer;

--- a/src/reducers/create-validated-reducer.js
+++ b/src/reducers/create-validated-reducer.js
@@ -1,30 +1,30 @@
 // adapted from https://github.com/Prismatik/redux-json-schema
 // but npm wouldn't load the package correctly. No idea why.
 // MIT licensed
-import Ajv from 'ajv'
+import Ajv from 'ajv';
 
 class SchemaValidationError extends Error {
   constructor(message) {
-    super(message)
-    this.message = message
-    this.name = 'SchemaValidationError'
+    super(message);
+    this.message = message;
+    this.name = 'SchemaValidationError';
   }
 }
 
 const createValidatedReducer =
   (reducer, schema, options) => {
-    const ajv = new Ajv(options)
-    const validate = ajv.compile(schema)
+    const ajv = new Ajv(options);
+    const validate = ajv.compile(schema);
     const validatedReducer = (state, action) => {
-      const futureState = reducer(state, action)
+      const futureState = reducer(state, action);
 
       if (!validate(futureState)) {
-        throw new SchemaValidationError(ajv.errorsText(validate.errors, { verbose: true }))
+        throw new SchemaValidationError(ajv.errorsText(validate.errors, { verbose: true }));
       }
 
-      return futureState
-    }
-    return validatedReducer
-  }
+      return futureState;
+    };
+    return validatedReducer;
+  };
 
-export default createValidatedReducer
+export default createValidatedReducer;

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,14 +1,14 @@
 import copy from 'copy-to-clipboard';
-import { newNotebook, newCell, blankState, newCellID } from '../state-prototypes'
+import { newNotebook, newCell, blankState, newCellID } from '../state-prototypes';
 import {
   exportJsmdBundle,
   exportJsmdToString,
   stringifyStateToJsmd,
   stateFromJsmd,
   titleToHtmlFilename,
-} from '../tools/jsmd-tools'
+} from '../tools/jsmd-tools';
 
-const AUTOSAVE = 'AUTOSAVE: '
+const AUTOSAVE = 'AUTOSAVE: ';
 
 function newAppMessage(appMessageId, appMessageText, appMessageDetails, appMessageWhen) {
   return {
@@ -16,37 +16,37 @@ function newAppMessage(appMessageId, appMessageText, appMessageDetails, appMessa
     message: appMessageText,
     details: appMessageDetails,
     when: appMessageWhen,
-  }
+  };
 }
 
 function addAppMessageToState(state, appMessage) {
-  const nextAppMessageId = newCellID(state.appMessages)
+  const nextAppMessageId = newCellID(state.appMessages);
   state.appMessages
-    .push(newAppMessage(nextAppMessageId, appMessage.message, appMessage.details, appMessage.when))
-  return state
+    .push(newAppMessage(nextAppMessageId, appMessage.message, appMessage.details, appMessage.when));
+  return state;
 }
 
 function getLoginData() {
-  const userData = JSON.parse(sessionStorage.getItem('TOKEN')) || {}
-  return { userData }
+  const userData = JSON.parse(sessionStorage.getItem('TOKEN')) || {};
+  return { userData };
 }
 
 function getSavedNotebooks() {
-  const autoSave = Object.keys(localStorage).filter(n => n.includes(AUTOSAVE))[0]
-  const locallySaved = Object.keys(localStorage).filter(n => !n.includes(AUTOSAVE))
+  const autoSave = Object.keys(localStorage).filter(n => n.includes(AUTOSAVE))[0];
+  const locallySaved = Object.keys(localStorage).filter(n => !n.includes(AUTOSAVE));
   locallySaved.sort((a, b) => {
     const p = (_) => {
-      let ls = localStorage.getItem(_)
-      if (!ls) return -1
-      ls = stateFromJsmd(ls)
-      return Date.parse(ls.lastSaved)
-    }
-    return p(b) - p(a)
-  })
+      let ls = localStorage.getItem(_);
+      if (!ls) return -1;
+      ls = stateFromJsmd(ls);
+      return Date.parse(ls.lastSaved);
+    };
+    return p(b) - p(a);
+  });
   return {
     autoSave,
     locallySaved,
-  }
+  };
 }
 
 function clearHistory(loadedState) {
@@ -70,198 +70,198 @@ function clearUserDefinedVars(userDefinedVarNames) {
   // remove user defined variables when loading/importing a new/saved NB
   userDefinedVarNames.forEach((varName) => {
     try {
-      delete window[varName]
+      delete window[varName];
     } catch (e) {
-      console.log(e)
+      console.log(e);
     }
-  })
+  });
 }
 
-const initialVariables = new Set(Object.keys(window)) // gives all global variables
-initialVariables.add('__core-js_shared__')
-initialVariables.add('Mousetrap')
-initialVariables.add('CodeMirror')
+const initialVariables = new Set(Object.keys(window)); // gives all global variables
+initialVariables.add('__core-js_shared__');
+initialVariables.add('Mousetrap');
+initialVariables.add('CodeMirror');
 
 const notebookReducer = (state = newNotebook(), action) => {
-  let nextState
-  let title
-  let cells
+  let nextState;
+  let title;
+  let cells;
 
   switch (action.type) {
     case 'NEW_NOTEBOOK':
-      clearUserDefinedVars(state.userDefinedVarNames)
-      return Object.assign(newNotebook(), getSavedNotebooks(), getLoginData())
+      clearUserDefinedVars(state.userDefinedVarNames);
+      return Object.assign(newNotebook(), getSavedNotebooks(), getLoginData());
 
     case 'EXPORT_NOTEBOOK': {
       const exportState = Object.assign(
         {},
         state,
         { viewMode: action.exportAsReport ? 'presentation' : 'editor' },
-      )
+      );
       if (action.exportToClipboard) {
-        const jsmdStr = encodeURIComponent(exportJsmdToString(exportState))
-        copy(`${window.location.href.split('?')[0]}?jsmd=${jsmdStr}`)
+        const jsmdStr = encodeURIComponent(exportJsmdToString(exportState));
+        copy(`${window.location.href.split('?')[0]}?jsmd=${jsmdStr}`);
       } else {
-        const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(exportJsmdBundle(exportState))}`
-        const dlAnchorElem = document.getElementById('export-anchor')
-        dlAnchorElem.setAttribute('href', dataStr)
-        title = exportState.title === undefined ? 'new-notebook' : exportState.title
-        dlAnchorElem.setAttribute('download', titleToHtmlFilename(title))
-        dlAnchorElem.click()
+        const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(exportJsmdBundle(exportState))}`;
+        const dlAnchorElem = document.getElementById('export-anchor');
+        dlAnchorElem.setAttribute('href', dataStr);
+        title = exportState.title === undefined ? 'new-notebook' : exportState.title;
+        dlAnchorElem.setAttribute('download', titleToHtmlFilename(title));
+        dlAnchorElem.click();
       }
 
-      return state
+      return state;
     }
 
     case 'IMPORT_NOTEBOOK': {
     // note: loading a NB should always assign to a copy of the latest global
     // and per-cell state for backwards compatibility
-      nextState = action.newState
-      clearUserDefinedVars(state.userDefinedVarNames)
-      clearHistory(nextState)
+      nextState = action.newState;
+      clearUserDefinedVars(state.userDefinedVarNames);
+      clearHistory(nextState);
       cells = nextState.cells.map((cell, i) =>
-        Object.assign(newCell(i, cell.cellType), cell))
-      return Object.assign(blankState(), nextState, { cells }, getSavedNotebooks(), getLoginData())
+        Object.assign(newCell(i, cell.cellType), cell));
+      return Object.assign(blankState(), nextState, { cells }, getSavedNotebooks(), getLoginData());
     }
 
     case 'SAVE_NOTEBOOK': {
-      ({ title } = state)
-      let lastSaved
+      ({ title } = state);
+      let lastSaved;
       if (!action.autosave) {
-        lastSaved = (new Date()).toISOString()
+        lastSaved = (new Date()).toISOString();
       } else {
-        ({ lastSaved } = state)
-        title = AUTOSAVE + title
+        ({ lastSaved } = state);
+        title = AUTOSAVE + title;
       }
       nextState = Object.assign({}, state, { lastSaved }, {
         cells: state.cells.slice().map((c) => {
-          const newC = Object.assign({}, c)
-          newC.evalStatus = undefined
+          const newC = Object.assign({}, c);
+          newC.evalStatus = undefined;
           if (newC.cellType === 'code' || newC.cellType === 'external dependencies') {
-            newC.value = undefined
+            newC.value = undefined;
           }
-          return newC
+          return newC;
         }),
-      }, { title: state.title })
-      clearHistory(nextState)
-      window.localStorage.setItem(title, stringifyStateToJsmd(nextState))
-      return Object.assign({}, state, { lastSaved }, getSavedNotebooks())
+      }, { title: state.title });
+      clearHistory(nextState);
+      window.localStorage.setItem(title, stringifyStateToJsmd(nextState));
+      return Object.assign({}, state, { lastSaved }, getSavedNotebooks());
     }
 
     case 'LOAD_NOTEBOOK': {
-      clearUserDefinedVars(state.userDefinedVarNames)
-      nextState = stateFromJsmd(window.localStorage.getItem(action.title))
-      clearHistory(nextState)
+      clearUserDefinedVars(state.userDefinedVarNames);
+      nextState = stateFromJsmd(window.localStorage.getItem(action.title));
+      clearHistory(nextState);
       // note: loading a NB should always assign to a copy of the latest global
       // and per-cell state for backwards compatibility
       cells = nextState.cells.map((cell, i) =>
-        Object.assign(newCell(i, cell.cellType), cell))
-      return Object.assign(blankState(), nextState, getSavedNotebooks(), getLoginData())
+        Object.assign(newCell(i, cell.cellType), cell));
+      return Object.assign(blankState(), nextState, getSavedNotebooks(), getLoginData());
     }
 
     case 'DELETE_NOTEBOOK': {
-      ({ title } = action)
+      ({ title } = action);
 
       // FIXME: for some reason, airbnb-eslint doesn't like using hasOwnProperty
       // but changing to the recommended syntax breaks a test b/c our localStorage
       // mock is bare-bones. We could upgrade the mock or change the approach
       if (window.localStorage.hasOwnProperty(title)) { // eslint-disable-line
-        window.localStorage.removeItem(title)
+        window.localStorage.removeItem(title);
       }
       nextState = (
         (title === state.title) ?
           Object.assign({}, newNotebook()) :
           Object.assign({}, state)
-      )
-      return nextState
+      );
+      return nextState;
     }
 
     case 'CLEAR_VARIABLES': {
-      clearUserDefinedVars(state.userDefinedVarNames)
-      nextState = Object.assign({}, state)
-      nextState.userDefinedVarNames = {}
-      nextState.externalDependencies = []
-      return nextState
+      clearUserDefinedVars(state.userDefinedVarNames);
+      nextState = Object.assign({}, state);
+      nextState.userDefinedVarNames = {};
+      nextState.externalDependencies = [];
+      return nextState;
     }
 
     case 'CHANGE_PAGE_TITLE':
-      return Object.assign({}, state, { title: action.title })
+      return Object.assign({}, state, { title: action.title });
 
     case 'SET_VIEW_MODE': {
-      const { viewMode } = action
-      return Object.assign({}, state, { viewMode })
+      const { viewMode } = action;
+      return Object.assign({}, state, { viewMode });
     }
 
     case 'CHANGE_MODE': {
-      const { mode } = action
-      return Object.assign({}, state, { mode })
+      const { mode } = action;
+      return Object.assign({}, state, { mode });
     }
 
     case 'CHANGE_SIDE_PANE_MODE': {
-      return Object.assign({}, state, { sidePaneMode: action.mode })
+      return Object.assign({}, state, { sidePaneMode: action.mode });
     }
 
     case 'CHANGE_SIDE_PANE_WIDTH': {
-      const width = state.sidePaneWidth + action.widthShift
-      return Object.assign({}, state, { sidePaneWidth: width })
+      const width = state.sidePaneWidth + action.widthShift;
+      return Object.assign({}, state, { sidePaneWidth: width });
     }
 
     case 'INCREMENT_EXECUTION_NUMBER': {
-      let { executionNumber } = state
-      executionNumber += 1
-      return Object.assign({}, state, { executionNumber })
+      let { executionNumber } = state;
+      executionNumber += 1;
+      return Object.assign({}, state, { executionNumber });
     }
 
     case 'LOGIN_SUCCESS': {
-      const { userData } = action
-      sessionStorage.setItem('TOKEN', JSON.stringify(userData))
-      return Object.assign({}, state, { userData })
+      const { userData } = action;
+      sessionStorage.setItem('TOKEN', JSON.stringify(userData));
+      return Object.assign({}, state, { userData });
     }
 
     case 'LOGOUT': {
-      const userData = {}
-      sessionStorage.removeItem('TOKEN')
-      return Object.assign({}, state, { userData })
+      const userData = {};
+      sessionStorage.removeItem('TOKEN');
+      return Object.assign({}, state, { userData });
     }
 
     case 'APPEND_TO_EVAL_HISTORY': {
-      const history = [...state.history]
+      const history = [...state.history];
       history.push({
         cellID: action.cellId,
         lastRan: new Date(),
         content: action.content,
-      })
-      return Object.assign({}, state, { history })
+      });
+      return Object.assign({}, state, { history });
     }
 
     case 'UPDATE_USER_VARIABLES': {
-      const userDefinedVarNames = []
+      const userDefinedVarNames = [];
       Object.keys(window)
         .filter(g => !initialVariables.has(g))
-        .forEach((g) => { userDefinedVarNames.push(g) })
-      return Object.assign({}, state, { userDefinedVarNames })
+        .forEach((g) => { userDefinedVarNames.push(g); });
+      return Object.assign({}, state, { userDefinedVarNames });
     }
 
     case 'UPDATE_APP_MESSAGES': {
-      nextState = Object.assign({}, state)
-      nextState.appMessages = nextState.appMessages.slice()
-      return addAppMessageToState(nextState, Object.assign({}, action.message))
+      nextState = Object.assign({}, state);
+      nextState.appMessages = nextState.appMessages.slice();
+      return addAppMessageToState(nextState, Object.assign({}, action.message));
     }
 
     case 'TEMPORARILY_SAVE_RUNNING_CELL_ID': {
-      const { cellID } = action
-      return Object.assign({}, state, { runningCellID: cellID })
+      const { cellID } = action;
+      return Object.assign({}, state, { runningCellID: cellID });
     }
 
     case 'SAVE_ENVIRONMENT': {
-      let newSavedEnvironment
+      let newSavedEnvironment;
       if (action.update) {
         newSavedEnvironment = Object
-          .assign({}, state.savedEnvironment, action.updateObj)
+          .assign({}, state.savedEnvironment, action.updateObj);
       } else {
-        newSavedEnvironment = action.updateObj
+        newSavedEnvironment = action.updateObj;
       }
-      return Object.assign({}, state, { savedEnvironment: newSavedEnvironment })
+      return Object.assign({}, state, { savedEnvironment: newSavedEnvironment });
     }
 
     case 'ADD_LANGUAGE': {
@@ -269,16 +269,16 @@ const notebookReducer = (state = newNotebook(), action) => {
         {},
         state.languages,
         { [action.languageDefinition.languageId]: action.languageDefinition },
-      )
-      return Object.assign({}, state, { languages })
+      );
+      return Object.assign({}, state, { languages });
     }
 
     default: {
-      return state
+      return state;
     }
   }
-}
+};
 
-export { getSavedNotebooks }
+export { getSavedNotebooks };
 
-export default notebookReducer
+export default notebookReducer;

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1,6 +1,6 @@
 // import { combineReducers } from 'redux'
-import notebookReducer from './notebook-reducer'
-import cellReducer from './cell-reducer'
+import notebookReducer from './notebook-reducer';
+import cellReducer from './cell-reducer';
 
 /*
 It is suggested that using combineReducers, and following the standard
@@ -15,7 +15,7 @@ function reduceReducers(...reducers) {
     reducers.reduce(
       (p, r) => r(p, current),
       previous,
-    )
+    );
 }
 
-export default reduceReducers(notebookReducer, cellReducer)
+export default reduceReducers(notebookReducer, cellReducer);

--- a/src/state-prototypes.js
+++ b/src/state-prototypes.js
@@ -5,16 +5,16 @@
 const StringEnum = class {
   constructor(...vals) {
     vals.forEach((v) => {
-      if (v === 'values' || v === 'contains') { throw Error(`disallowed enum name: ${v}`) }
-      this[v] = v
-    })
-    Object.freeze(this)
+      if (v === 'values' || v === 'contains') { throw Error(`disallowed enum name: ${v}`); }
+      this[v] = v;
+    });
+    Object.freeze(this);
   }
-  values() { return Object.keys(this) }
-  contains(key) { return Object.keys(this).indexOf(key) >= 0 }
-}
+  values() { return Object.keys(this); }
+  contains(key) { return Object.keys(this).indexOf(key) >= 0; }
+};
 
-const rowOverflowEnum = new StringEnum('VISIBLE', 'SCROLL', 'HIDDEN')
+const rowOverflowEnum = new StringEnum('VISIBLE', 'SCROLL', 'HIDDEN');
 // const rowTypeEnum = new StringEnum('input', 'output')
 export const cellTypeEnum = new StringEnum(
   'code',
@@ -23,11 +23,11 @@ export const cellTypeEnum = new StringEnum(
   'css',
   'external dependencies',
   'plugin',
-)
+);
 // const appViewEnum = new StringEnum('EXPLORE', 'REPORT') //was: 'editor', 'presentation'
 // const appModeEnum = new StringEnum('COMMAND', 'EDIT', 'TITLE', 'MENU')
 
-export const cellEvalStatusEnum = new StringEnum('UNEVALUATED', 'PENDING', 'ASYNC_PENDING', 'SUCCESS', 'ERROR')
+export const cellEvalStatusEnum = new StringEnum('UNEVALUATED', 'PENDING', 'ASYNC_PENDING', 'SUCCESS', 'ERROR');
 
 const appMessageSchema = {
   type: 'object',
@@ -38,7 +38,7 @@ const appMessageSchema = {
     id: { type: 'integer', minimum: 0 },
   },
   additionalProperties: false,
-}
+};
 
 const cellSchema = {
   type: 'object',
@@ -63,7 +63,7 @@ const cellSchema = {
     skipInRunAll: { type: 'boolean' },
   },
   additionalProperties: false,
-}
+};
 // cellSchema.required = Object.keys(cellSchema.properties)
 // cellSchema.minProperties = Object.keys(cellSchema.properties).length
 
@@ -80,7 +80,7 @@ const languageSchema = {
     url: { type: 'string' },
   },
   additionalProperties: false,
-}
+};
 
 const environmentVariableSchema = {
   type: 'array',
@@ -88,7 +88,7 @@ const environmentVariableSchema = {
     { type: 'string', enum: ['object', 'string', 'rawString'] },
     { type: 'string' },
   ],
-}
+};
 
 const stateSchema = {
   type: 'object',
@@ -141,13 +141,13 @@ const stateSchema = {
     runningCellID: { type: 'integer' },
   },
   additionalProperties: false,
-}
+};
 // stateSchema.required = Object.keys(stateSchema.properties)
 // stateSchema.minProperties = Object.keys(stateSchema.properties).length
 
 
 function nextOverflow(currentOverflow) {
-  return { HIDDEN: 'VISIBLE', VISIBLE: 'SCROLL', SCROLL: 'HIDDEN' }[currentOverflow]
+  return { HIDDEN: 'VISIBLE', VISIBLE: 'SCROLL', SCROLL: 'HIDDEN' }[currentOverflow];
 }
 
 function newCellRowSettings(cellType) {
@@ -156,34 +156,34 @@ function newCellRowSettings(cellType) {
       return {
         EXPLORE: { input: 'VISIBLE', sideeffect: 'VISIBLE', output: 'VISIBLE' },
         REPORT: { input: 'HIDDEN', sideeffect: 'VISIBLE', output: 'HIDDEN' },
-      }
+      };
     case 'markdown':
       return {
         EXPLORE: { input: 'VISIBLE', output: 'VISIBLE' },
         REPORT: { input: 'VISIBLE', output: 'VISIBLE' },
-      }
+      };
     case 'external dependencies':
       return {
         EXPLORE: { input: 'VISIBLE', output: 'VISIBLE' },
         REPORT: { input: 'HIDDEN', output: 'HIDDEN' },
-      }
+      };
     case 'plugin':
       return {
         EXPLORE: { input: 'VISIBLE', output: 'VISIBLE' },
         REPORT: { input: 'HIDDEN', output: 'HIDDEN' },
-      }
+      };
     case 'css':
       return {
         EXPLORE: { input: 'VISIBLE' },
         REPORT: { input: 'HIDDEN' },
-      }
+      };
     case 'raw':
       return {
         EXPLORE: { input: 'VISIBLE' },
         REPORT: { input: 'HIDDEN' },
-      }
+      };
     default:
-      throw Error(`Unsupported cellType: ${cellType}`)
+      throw Error(`Unsupported cellType: ${cellType}`);
   }
 }
 
@@ -196,7 +196,7 @@ const pluginCellDefaultContent = `{
   "url": "",
   "module": "",
   "evaluator": ""
-}`
+}`;
 
 function newCell(cellId, cellType, language = 'js') {
   return {
@@ -212,7 +212,7 @@ function newCell(cellId, cellType, language = 'js') {
     rowSettings: newCellRowSettings(cellType),
     skipInRunAll: false,
     language, // default language is js, but it only matters the cell is a code cell
-  }
+  };
 }
 
 
@@ -225,7 +225,7 @@ const jsLanguageDefinition = {
   evaluator: 'eval',
   keybinding: 'j',
   url: '',
-}
+};
 
 function blankState() {
   const initialState = {
@@ -248,27 +248,27 @@ function blankState() {
     locallySaved: [],
     savedEnvironment: {},
     runningCellID: undefined,
-  }
-  return initialState
+  };
+  return initialState;
 }
 
 function newCellID(cells) {
-  return Math.max(-1, ...cells.map(c => c.id)) + 1
+  return Math.max(-1, ...cells.map(c => c.id)) + 1;
 }
 
 function addNewCellToState(state, cellType = 'code', language = 'js') {
-  const nextCellId = newCellID(state.cells)
-  state.cells.push(newCell(nextCellId, cellType, language))
-  return state
+  const nextCellId = newCellID(state.cells);
+  state.cells.push(newCell(nextCellId, cellType, language));
+  return state;
 }
 
 
 function newNotebook() {
   // initialize a blank notebook and push a blank new cell into it
-  const initialState = addNewCellToState(blankState())
+  const initialState = addNewCellToState(blankState());
   // set the cell that was just pushed to be the selected cell
-  initialState.cells[0].selected = true
-  return Object.assign(initialState)
+  initialState.cells[0].selected = true;
+  return Object.assign(initialState);
 }
 
 export {
@@ -281,4 +281,4 @@ export {
   // enums and schemas
   rowOverflowEnum,
   stateSchema,
-}
+};

--- a/src/store.js
+++ b/src/store.js
@@ -1,39 +1,39 @@
 /* global IODIDE_BUILD_MODE */
-import { applyMiddleware, compose, createStore } from 'redux'
-import thunk from 'redux-thunk'
-import { createLogger } from 'redux-logger'
+import { applyMiddleware, compose, createStore } from 'redux';
+import thunk from 'redux-thunk';
+import { createLogger } from 'redux-logger';
 
-import createValidatedReducer from './reducers/create-validated-reducer'
-import reducer from './reducers/reducer'
-import { initializeNotebook } from './initialize-notebook'
-import { stateSchema } from './state-prototypes'
-import { evaluateAllCells } from './actions/actions'
+import createValidatedReducer from './reducers/create-validated-reducer';
+import reducer from './reducers/reducer';
+import { initializeNotebook } from './initialize-notebook';
+import { stateSchema } from './state-prototypes';
+import { evaluateAllCells } from './actions/actions';
 
-let enhancer
-let finalReducer
+let enhancer;
+let finalReducer;
 
 if (IODIDE_BUILD_MODE === 'dev' || IODIDE_BUILD_MODE === 'devperf') {
-  finalReducer = createValidatedReducer(reducer, stateSchema)
+  finalReducer = createValidatedReducer(reducer, stateSchema);
   enhancer = compose(
     applyMiddleware(thunk),
     applyMiddleware(createLogger({
       predicate: (getState, action) => action.type !== 'UPDATE_INPUT_CONTENT',
     })),
-  )
+  );
 } else if (IODIDE_BUILD_MODE === 'test') {
-  finalReducer = createValidatedReducer(reducer, stateSchema)
-  enhancer = applyMiddleware(thunk)
+  finalReducer = createValidatedReducer(reducer, stateSchema);
+  enhancer = applyMiddleware(thunk);
 } else {
-  finalReducer = reducer
-  enhancer = applyMiddleware(thunk)
+  finalReducer = reducer;
+  enhancer = applyMiddleware(thunk);
 }
 
-const initialState = initializeNotebook()
+const initialState = initializeNotebook();
 
-const store = createStore(finalReducer, initialState, enhancer)
+const store = createStore(finalReducer, initialState, enhancer);
 
-if (initialState.viewMode === 'presentation') { store.dispatch(evaluateAllCells(store.getState().cells, store)) }
+if (initialState.viewMode === 'presentation') { store.dispatch(evaluateAllCells(store.getState().cells, store)); }
 
-const { dispatch } = store
+const { dispatch } = store;
 
-export { store, dispatch }
+export { store, dispatch };

--- a/src/tools/__tests__/jsmd-tools_parse.test.js
+++ b/src/tools/__tests__/jsmd-tools_parse.test.js
@@ -4,11 +4,11 @@ import {
   stateFromJsmd,
   jsmdValidCellTypes,
   jsmdToCellTypeMap,
-} from '../jsmd-tools'
+} from '../jsmd-tools';
 import {
   newNotebook,
   cellTypeEnum,
-} from '../../state-prototypes'
+} from '../../state-prototypes';
 
 let jsmdTestCase = `%% meta
 {"title": "What a web notebook looks like",
@@ -51,38 +51,38 @@ https://cdnjs.cloudflare.com/ajax/libs/three.js/88/three.min.js
 
 %% js
 // above this is a DOM cell, which we can also target
-spinCubeInTarget("#dom-cell-2")`
+spinCubeInTarget("#dom-cell-2")`;
 
 describe('jsmd parser Ex 1', () => {
-  const { parseWarnings } = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
+  const { parseWarnings } = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
   // const { parseWarnings } = jsmdParsed
 
   it('new cells should start with "\n%%" or "%%" at the start of the file. drop empty cells.', () => {
-    expect(cells.length).toEqual(7)
-  })
+    expect(cells.length).toEqual(7);
+  });
   it('should have correct cell types', () => {
     expect(cells.map(c => c.cellType)).toEqual([
       'markdown', 'code', 'raw', 'markdown', 'external dependencies', 'css', 'code',
-    ])
-  })
+    ]);
+  });
   it('should have zero parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('cell 2 should have settings (1 of 2) "rowSettings.REPORT.input": "SCROLL"', () => {
-    expect(cells[1].rowSettings.REPORT.input).toEqual('SCROLL')
-  })
+    expect(cells[1].rowSettings.REPORT.input).toEqual('SCROLL');
+  });
   it('cell 2 should have settings (2 of 2) "rowSettings.REPORT.output": "VISIBLE"', () => {
-    expect(cells[1].rowSettings.REPORT.output).toEqual('VISIBLE')
-  })
+    expect(cells[1].rowSettings.REPORT.output).toEqual('VISIBLE');
+  });
   it('should have correct meta settings: title', () => {
-    expect(state.title).toEqual('What a web notebook looks like')
-  })
+    expect(state.title).toEqual('What a web notebook looks like');
+  });
   it('should have correct meta settings: viewMode', () => {
-    expect(state.viewMode).toEqual('editor')
-  })
-})
+    expect(state.viewMode).toEqual('editor');
+  });
+});
 
 
 jsmdTestCase = `
@@ -98,52 +98,52 @@ foo
 
 foo
 
-`
+`;
 
 describe('jsmd parser test case 3', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
 
   it('should have 4 cells and not trip up on caps or whitespace', () => {
-    expect(cells.length).toEqual(4)
-  })
+    expect(cells.length).toEqual(4);
+  });
   it('should have zero parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('parseWarnings should be an empty array', () => {
-    expect(parseWarnings).toEqual([])
-  })
+    expect(parseWarnings).toEqual([]);
+  });
   it('all cells should have cellType==js', () => {
-    expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(['code']))
-  })
+    expect(cells.map(c => c.cellType)).toEqual(expect.arrayContaining(['code']));
+  });
   it('all cells should have content=="foo"', () => {
-    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['foo']))
-  })
-})
+    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['foo']));
+  });
+});
 
 
 // this case is for an observed bug
 jsmdTestCase = `
 %% js
-`
+`;
 describe('jsmd parser test case 4', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
 
   it('should have 1 cell', () => {
-    expect(cells.length).toEqual(1)
-  })
+    expect(cells.length).toEqual(1);
+  });
   it('should have zero parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('cell 0 should have no content', () => {
-    expect(cells[0].content).toEqual('')
-  })
-})
+    expect(cells[0].content).toEqual('');
+  });
+});
 
 
 // test error parsing and bad cell type conversion
@@ -154,52 +154,52 @@ foo
 foo
 %% badcelltype {"rowSettings.REPORT.input":"SCROLL_carrots"}
 foo
-`
+`;
 describe('jsmd parser test case 5, error parsing and bad cell type conversion', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
   it('should have 3 parse warnings', () => {
-    expect(parseWarnings.length).toEqual(3)
-  })
+    expect(parseWarnings.length).toEqual(3);
+  });
   it('all cells should have cellType==js (bad cellTypes should convert to js)', () => {
-    expect(cells.map(c => c.cellType)).toEqual(['code', 'code', 'code'])
-  })
+    expect(cells.map(c => c.cellType)).toEqual(['code', 'code', 'code']);
+  });
   it('cell 1 should have "rowSettings.REPORT.output":"VISIBLE"', () => {
-    expect(cells[1].rowSettings.REPORT.output).toEqual('VISIBLE')
-  })
+    expect(cells[1].rowSettings.REPORT.output).toEqual('VISIBLE');
+  });
   it('cell 2 should have "rowSettings.REPORT.output"=="SCROLL"', () => {
-    expect(cells[2].rowSettings.REPORT.input).toEqual('SCROLL_carrots')
-  })
+    expect(cells[2].rowSettings.REPORT.input).toEqual('SCROLL_carrots');
+  });
   it('all cells should have content=="foo"', () => {
-    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['foo']))
-  })
-})
+    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['foo']));
+  });
+});
 
 
 jsmdTestCase = `
 %% meta
 invalid_json_content for meta setings
-`
+`;
 describe('jsmd parser test case 6, bad meta parsing and creation of default JS cell', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
   it('should have 1 cells (%% meta is not converted to a cell)', () => {
-    expect(cells.length).toEqual(1)
-  })
+    expect(cells.length).toEqual(1);
+  });
   it('should have 1 parse warning1', () => {
-    expect(parseWarnings.length).toEqual(1)
-  })
+    expect(parseWarnings.length).toEqual(1);
+  });
   it('the cells should have cellType==js (bad cellTypes should convert to code)', () => {
-    expect(cells.map(c => c.cellType)).toEqual(['code'])
-  })
+    expect(cells.map(c => c.cellType)).toEqual(['code']);
+  });
   it('state should be a default notebook with no additions', () => {
-    expect(state).toEqual(newNotebook())
-  })
-})
+    expect(state).toEqual(newNotebook());
+  });
+});
 
 // test multiple cell settings
 jsmdTestCase = `
@@ -207,31 +207,31 @@ jsmdTestCase = `
 test cell
 %% js {"rowSettings.REPORT.input": "VALUE_1","skipInRunAll":true}
 test cell
-`
+`;
 describe('jsmd parser test case 7, cell settings', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
   it('should have 2 cells', () => {
-    expect(cells.length).toEqual(2)
-  })
+    expect(cells.length).toEqual(2);
+  });
   it('should have 0 parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('cell 0 should have "rowSettings.REPORT.input":"VALUE_1"', () => {
-    expect(cells[0].rowSettings.REPORT.input).toEqual('VALUE_1')
-  })
+    expect(cells[0].rowSettings.REPORT.input).toEqual('VALUE_1');
+  });
   it('cell 0 should have "rowSettings.REPORT.output"=="VALUE_2"', () => {
-    expect(cells[0].rowSettings.REPORT.output).toEqual('VALUE_2')
-  })
+    expect(cells[0].rowSettings.REPORT.output).toEqual('VALUE_2');
+  });
   it('cell 1 should have "skipInRunAll"===true', () => {
-    expect(cells[1].skipInRunAll).toEqual(true)
-  })
+    expect(cells[1].skipInRunAll).toEqual(true);
+  });
   it('all cells should have content=="test cell"', () => {
-    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['test cell']))
-  })
-})
+    expect(cells.map(c => c.content)).toEqual(expect.arrayContaining(['test cell']));
+  });
+});
 
 
 jsmdTestCase = `
@@ -253,18 +253,18 @@ foo
 
 
 
-`
+`;
 describe('jsmd parser test case 7, multi line cell content should parse ok', () => {
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
   it('should have 1 cells', () => {
-    expect(cells.length).toEqual(1)
-  })
+    expect(cells.length).toEqual(1);
+  });
   it('should have 0 parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('multi line cell content should parse ok', () => {
     expect(cells[0].content).toEqual(`foo
 foo
@@ -276,59 +276,59 @@ foo
 
 
 
-foo`)
-  })
-})
+foo`);
+  });
+});
 
 
 describe('jsmd parser test case 7, non-js code cells should parse ok', () => {
   jsmdTestCase = `
 %% code {"language":"python"}
-foo`
-  const jsmdParsed = parseJsmd(jsmdTestCase)
-  const state = stateFromJsmd(jsmdTestCase)
-  const { cells } = state
-  const { parseWarnings } = jsmdParsed
+foo`;
+  const jsmdParsed = parseJsmd(jsmdTestCase);
+  const state = stateFromJsmd(jsmdTestCase);
+  const { cells } = state;
+  const { parseWarnings } = jsmdParsed;
   it('should have 1 cells', () => {
-    expect(cells.length).toEqual(1)
-  })
+    expect(cells.length).toEqual(1);
+  });
   it('should have 0 parse warnings', () => {
-    expect(parseWarnings.length).toEqual(0)
-  })
+    expect(parseWarnings.length).toEqual(0);
+  });
   it('cell content should parse ok', () => {
-    expect(cells[0].content).toEqual('foo')
-  })
+    expect(cells[0].content).toEqual('foo');
+  });
   it('cell type parse ok', () => {
-    expect(cells[0].cellType).toEqual('code')
-  })
+    expect(cells[0].cellType).toEqual('code');
+  });
   it('cell language parse ok', () => {
-    expect(cells[0].language).toEqual('python')
-  })
-})
+    expect(cells[0].language).toEqual('python');
+  });
+});
 
 describe('all jsmdValidCellTypes (including legacy cell types) should convert to a state-prototypes cell type', () => {
   jsmdValidCellTypes.forEach((cellTypeStr) => {
     jsmdTestCase = `
 %% ${cellTypeStr}
-foo`
-    const jsmdParsed = parseJsmd(jsmdTestCase)
-    const state = stateFromJsmd(jsmdTestCase)
-    const { cells } = state
-    const { parseWarnings } = jsmdParsed
+foo`;
+    const jsmdParsed = parseJsmd(jsmdTestCase);
+    const state = stateFromJsmd(jsmdTestCase);
+    const { cells } = state;
+    const { parseWarnings } = jsmdParsed;
     it(`should have 1 cell (cell type: ${cellTypeStr})`, () => {
-      expect(cells.length).toEqual(1)
-    })
+      expect(cells.length).toEqual(1);
+    });
     it(`should have 0 parse warnings (cell type: ${cellTypeStr})`, () => {
-      expect(parseWarnings.length).toEqual(0)
-    })
+      expect(parseWarnings.length).toEqual(0);
+    });
     it(`cell content should parse ok (cell type: ${cellTypeStr})`, () => {
-      expect(cells[0].content).toEqual('foo')
-    })
+      expect(cells[0].content).toEqual('foo');
+    });
     it(`jsmd cell type parse to expected cell type (cell type: ${cellTypeStr})`, () => {
-      expect(cells[0].cellType).toEqual(jsmdToCellTypeMap.get(cellTypeStr))
-    })
+      expect(cells[0].cellType).toEqual(jsmdToCellTypeMap.get(cellTypeStr));
+    });
     it(`jsmd cell type parse to a state-prototypes cell type (cell type: ${cellTypeStr})`, () => {
-      expect(cellTypeEnum.values()).toContain(cells[0].cellType)
-    })
-  })
-})
+      expect(cellTypeEnum.values()).toContain(cells[0].cellType);
+    });
+  });
+});

--- a/src/tools/__tests__/jsmd-tools_serialize.test.js
+++ b/src/tools/__tests__/jsmd-tools_serialize.test.js
@@ -1,35 +1,35 @@
 /* global it describe expect */
-import _ from 'lodash'
+import _ from 'lodash';
 
-import { stringifyStateToJsmd, jsmdValidNotebookSettings } from '../jsmd-tools'
-import { newNotebook, addNewCellToState } from '../../state-prototypes'
+import { stringifyStateToJsmd, jsmdValidNotebookSettings } from '../jsmd-tools';
+import { newNotebook, addNewCellToState } from '../../state-prototypes';
 
 
 // this can be defined once for all test cases
-const lastExport = new Date().toISOString()
+const lastExport = new Date().toISOString();
 
 describe('jsmd stringifier test case 1', () => {
-  const state = newNotebook()
-  state.cells[0].content = 'foo'
-  const jsmd = stringifyStateToJsmd(state, lastExport)
+  const state = newNotebook();
+  state.cells[0].content = 'foo';
+  const jsmd = stringifyStateToJsmd(state, lastExport);
   const jsmdExpected = `%% meta
 {
   "lastExport": "${lastExport}"
 }
 
 %% js
-foo`
+foo`;
   it('simple state with default global setting should serialize to jsmd correctly', () => {
-    expect(jsmd).toEqual(jsmdExpected)
-  })
-})
+    expect(jsmd).toEqual(jsmdExpected);
+  });
+});
 
 
 describe('jsmd stringifier test case 2', () => {
-  const state = newNotebook()
-  state.cells[0].content = 'foo'
-  state.title = 'foo notebook'
-  const jsmd = stringifyStateToJsmd(state, lastExport)
+  const state = newNotebook();
+  state.cells[0].content = 'foo';
+  state.title = 'foo notebook';
+  const jsmd = stringifyStateToJsmd(state, lastExport);
   const jsmdExpected = `%% meta
 {
   "title": "foo notebook",
@@ -37,25 +37,25 @@ describe('jsmd stringifier test case 2', () => {
 }
 
 %% js
-foo`
+foo`;
   it('simple state should serialize to jsmd correctly', () => {
-    expect(jsmd).toEqual(jsmdExpected)
-  })
-})
+    expect(jsmd).toEqual(jsmdExpected);
+  });
+});
 
 
 describe('jsmd stringifier test case 3, non-default cell settings 1', () => {
-  let state = newNotebook()
-  state.title = 'foo notebook'
-  state.viewMode = 'presentation'
+  let state = newNotebook();
+  state.title = 'foo notebook';
+  state.viewMode = 'presentation';
 
-  state.cells[0].content = 'foo'
-  _.set(state, 'cells[0].rowSettings.REPORT.input', 'SCROLL')
+  state.cells[0].content = 'foo';
+  _.set(state, 'cells[0].rowSettings.REPORT.input', 'SCROLL');
 
-  state = addNewCellToState(state, 'markdown')
-  state.cells[1].content = 'foo'
+  state = addNewCellToState(state, 'markdown');
+  state.cells[1].content = 'foo';
 
-  const jsmd = stringifyStateToJsmd(state, lastExport)
+  const jsmd = stringifyStateToJsmd(state, lastExport);
   const jsmdExpected = `%% meta
 {
   "title": "foo notebook",
@@ -67,28 +67,28 @@ describe('jsmd stringifier test case 3, non-default cell settings 1', () => {
 foo
 
 %% md
-foo`
+foo`;
   it('cell settings should serialize to jsmd correctly', () => {
-    expect(jsmd).toEqual(jsmdExpected)
-  })
-})
+    expect(jsmd).toEqual(jsmdExpected);
+  });
+});
 
 
 describe('jsmd stringifier test case 4, non-default cell settings 2', () => {
-  let state = newNotebook()
-  state.title = 'foo notebook'
+  let state = newNotebook();
+  state.title = 'foo notebook';
 
-  state.cells[0].content = 'foo'
-  _.set(state, 'cells[0].rowSettings.REPORT.output', 'VISIBLE')
-  _.set(state, 'cells[0].skipInRunAll', true)
+  state.cells[0].content = 'foo';
+  _.set(state, 'cells[0].rowSettings.REPORT.output', 'VISIBLE');
+  _.set(state, 'cells[0].skipInRunAll', true);
 
-  const cellTypes = ['markdown', 'external dependencies', 'raw']
+  const cellTypes = ['markdown', 'external dependencies', 'raw'];
   cellTypes.forEach((cellType, i) => {
-    state = addNewCellToState(state, cellType)
-    state.cells[i + 1].content = 'foo'
-  })
+    state = addNewCellToState(state, cellType);
+    state.cells[i + 1].content = 'foo';
+  });
 
-  const jsmd = stringifyStateToJsmd(state, lastExport)
+  const jsmd = stringifyStateToJsmd(state, lastExport);
   const jsmdExpected = `%% meta
 {
   "title": "foo notebook",
@@ -105,25 +105,25 @@ foo
 foo
 
 %% raw
-foo`
+foo`;
   it('all cell types should serialize to jsmd correctly', () => {
-    expect(jsmd).toEqual(jsmdExpected)
-  })
-})
+    expect(jsmd).toEqual(jsmdExpected);
+  });
+});
 
 
 describe('jsmd stringifier test case 5, non-default languages', () => {
-  let state = newNotebook()
+  let state = newNotebook();
   beforeEach(() => {
-    state = newNotebook()
-    state.title = 'foo notebook'
-  })
+    state = newNotebook();
+    state.title = 'foo notebook';
+  });
 
   it('non-js code cells should serialize to jsmd correctly', () => {
-    _.set(state, 'cells[0].language', 'python')
-    _.set(state, 'cells[0].content', 'foo')
+    _.set(state, 'cells[0].language', 'python');
+    _.set(state, 'cells[0].content', 'foo');
 
-    const jsmd = stringifyStateToJsmd(state, lastExport)
+    const jsmd = stringifyStateToJsmd(state, lastExport);
     const jsmdExpected = `%% meta
 {
   "title": "foo notebook",
@@ -131,9 +131,9 @@ describe('jsmd stringifier test case 5, non-default languages', () => {
 }
 
 %% code {"language":"python"}
-foo`
-    expect(jsmd).toEqual(jsmdExpected)
-  })
+foo`;
+    expect(jsmd).toEqual(jsmdExpected);
+  });
 //   it('non-js code cells should serialize to jsmd correctly', () => {
 //     _.set(state, 'cells[0].content', 'foo')
 
@@ -148,29 +148,29 @@ foo`
 // foo`
 //     expect(jsmd).toEqual(jsmdExpected)
 //   })
-})
+});
 
 
 describe('jsmd stringifier: non-default meta setting jsmdValidNotebookSettings must serialize correctly', () => {
-  const state = newNotebook()
-  let metaToJsonify = {}
-  const nonDefaultVal = '___this weird string is not default___'
-  metaToJsonify = {}
+  const state = newNotebook();
+  let metaToJsonify = {};
+  const nonDefaultVal = '___this weird string is not default___';
+  metaToJsonify = {};
   jsmdValidNotebookSettings.forEach((k) => {
-    state[k] = nonDefaultVal
-    metaToJsonify[k] = nonDefaultVal
-  })
-  state.lastExport = lastExport
-  metaToJsonify.lastExport = lastExport
+    state[k] = nonDefaultVal;
+    metaToJsonify[k] = nonDefaultVal;
+  });
+  state.lastExport = lastExport;
+  metaToJsonify.lastExport = lastExport;
 
   it('all non-default meta setting must serialize correctly', () => {
-    const expectedJson = JSON.stringify(metaToJsonify, undefined, 2)
+    const expectedJson = JSON.stringify(metaToJsonify, undefined, 2);
 
-    const jsmd = stringifyStateToJsmd(state, lastExport)
+    const jsmd = stringifyStateToJsmd(state, lastExport);
     const jsmdExpected = `%% meta
 ${expectedJson}
 
-%% js`
-    expect(jsmd).toEqual(jsmdExpected)
-  })
-})
+%% js`;
+    expect(jsmd).toEqual(jsmdExpected);
+  });
+});

--- a/src/tools/__tests__/nb.test.js
+++ b/src/tools/__tests__/nb.test.js
@@ -1,97 +1,97 @@
-import nb from '../nb'
+import nb from '../nb';
 
 describe('nb.isRowDf', () => {
   it('accepts the following values', () => {
-    expect(nb.isRowDf(undefined)).toBe(false)
-    expect(nb.isRowDf([])).toBe(false)
-    expect(nb.isRowDf(['x', 'y'])).toBe(false)
-    expect(nb.isRowDf([[1, 2, 3, 4], [1, 2, 3, 4]])).toBe(false)
-    expect(nb.isRowDf({})).toBe(false)
+    expect(nb.isRowDf(undefined)).toBe(false);
+    expect(nb.isRowDf([])).toBe(false);
+    expect(nb.isRowDf(['x', 'y'])).toBe(false);
+    expect(nb.isRowDf([[1, 2, 3, 4], [1, 2, 3, 4]])).toBe(false);
+    expect(nb.isRowDf({})).toBe(false);
 
-    expect(nb.isRowDf([{ a: 10, b: 20 }])).toBe(true)
-    expect(nb.isRowDf([{ a: 10 }, { a: 20 }])).toBe(true)
-    expect(nb.isRowDf([{}])).toBe(true)
-  })
+    expect(nb.isRowDf([{ a: 10, b: 20 }])).toBe(true);
+    expect(nb.isRowDf([{ a: 10 }, { a: 20 }])).toBe(true);
+    expect(nb.isRowDf([{}])).toBe(true);
+  });
   it('rejects the following values', () => {
-    expect(nb.isRowDf(undefined)).toBe(false)
-    expect(nb.isRowDf(null)).toBe(false)
-    expect(nb.isRowDf([undefined])).toBe(false)
-    expect(nb.isRowDf(['test'])).toBe(false)
-    expect(nb.isRowDf([new Date()])).toBe(false)
-    expect(nb.isRowDf({})).toBe(false)
-    expect(nb.isRowDf([])).toBe(false)
-    expect(nb.isRowDf([1, 2, 3, 4])).toBe(false)
-  })
-})
+    expect(nb.isRowDf(undefined)).toBe(false);
+    expect(nb.isRowDf(null)).toBe(false);
+    expect(nb.isRowDf([undefined])).toBe(false);
+    expect(nb.isRowDf(['test'])).toBe(false);
+    expect(nb.isRowDf([new Date()])).toBe(false);
+    expect(nb.isRowDf({})).toBe(false);
+    expect(nb.isRowDf([])).toBe(false);
+    expect(nb.isRowDf([1, 2, 3, 4])).toBe(false);
+  });
+});
 
 describe('nb.isColumnDf', () => {
-  expect(nb.isColumnDf(undefined)).toBe(false)
-  expect(nb.isColumnDf({})).toBe(false)
-  expect(nb.isColumnDf([])).toBe(false)
-  expect(nb.isColumnDf({ something: [1, 2, 3, 4, 5], somethingElse: [4, 5, 6, 7, 8] })).toBe(true)
-  expect(nb.isColumnDf({ something: [], somethingElse: [] })).toBe(true)
-  expect(nb.isColumnDf({ something: 'ok', somethingElse: [] })).toBe(false)
-  expect(nb.isColumnDf({ something: [1, 2], somethingElse: 'ok' })).toBe(false)
-})
+  expect(nb.isColumnDf(undefined)).toBe(false);
+  expect(nb.isColumnDf({})).toBe(false);
+  expect(nb.isColumnDf([])).toBe(false);
+  expect(nb.isColumnDf({ something: [1, 2, 3, 4, 5], somethingElse: [4, 5, 6, 7, 8] })).toBe(true);
+  expect(nb.isColumnDf({ something: [], somethingElse: [] })).toBe(true);
+  expect(nb.isColumnDf({ something: 'ok', somethingElse: [] })).toBe(false);
+  expect(nb.isColumnDf({ something: [1, 2], somethingElse: 'ok' })).toBe(false);
+});
 
 describe('nb.shape', () => {
-  expect(nb.shape([1, 2, 3, 4])).toEqual([undefined, undefined])
-  expect(nb.shape('hello')).toEqual([undefined, undefined])
-  expect(nb.shape([[1], [1]])).toEqual([2, 1])
-  expect(nb.shape([[1, 1]])).toEqual([1, 2])
-  expect(nb.shape([[1, 1, 1, 1, 1, 1]])).toEqual([1, 6])
-  expect(nb.shape([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])).toEqual([2, 6])
-  expect(nb.shape({ col1: [1, 2, 3, 4, 5], col2: [1, 2, 3, 4, 5] })).toEqual([5, 2])
-  expect(nb.shape({})).toEqual([undefined, undefined])
+  expect(nb.shape([1, 2, 3, 4])).toEqual([undefined, undefined]);
+  expect(nb.shape('hello')).toEqual([undefined, undefined]);
+  expect(nb.shape([[1], [1]])).toEqual([2, 1]);
+  expect(nb.shape([[1, 1]])).toEqual([1, 2]);
+  expect(nb.shape([[1, 1, 1, 1, 1, 1]])).toEqual([1, 6]);
+  expect(nb.shape([[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 1, 1]])).toEqual([2, 6]);
+  expect(nb.shape({ col1: [1, 2, 3, 4, 5], col2: [1, 2, 3, 4, 5] })).toEqual([5, 2]);
+  expect(nb.shape({})).toEqual([undefined, undefined]);
   expect(nb.shape([
     { a: 10, b: 20 }, { a: 20, b: 30 }, { a: 20, b: 30 },
-  ])).toEqual([3, 2])
-  expect(nb.shape([{}])).toEqual([1, 0])
-  expect(nb.shape([{}, { a: 10, b: 20 }])).toEqual([undefined, undefined]) // is this right??
-})
+  ])).toEqual([3, 2]);
+  expect(nb.shape([{}])).toEqual([1, 0]);
+  expect(nb.shape([{}, { a: 10, b: 20 }])).toEqual([undefined, undefined]); // is this right??
+});
 
 describe('nb.isMatrix', () => {
   it('accepts the following values', () => {
-    expect(nb.isMatrix([[1, 2, 3], [4, 5, 6]])).toBe(true)
-    expect(nb.isMatrix([[1, 2, 3], [4, 6]])).toBe(true)
-    expect(nb.isMatrix([[1, 2, 3], []])).toBe(true)
-    expect(nb.isMatrix([[], []])).toBe(true)
-    expect(nb.isMatrix([[[[]]]])).toBe(true)
-  })
+    expect(nb.isMatrix([[1, 2, 3], [4, 5, 6]])).toBe(true);
+    expect(nb.isMatrix([[1, 2, 3], [4, 6]])).toBe(true);
+    expect(nb.isMatrix([[1, 2, 3], []])).toBe(true);
+    expect(nb.isMatrix([[], []])).toBe(true);
+    expect(nb.isMatrix([[[[]]]])).toBe(true);
+  });
   it('rejects the following values', () => {
-    expect(nb.isMatrix({})).toBe(false)
-    expect(nb.isMatrix(undefined)).toBe(false)
-    expect(nb.isMatrix([{ a: 10 }, { b: 20 }])).toBe(false)
-  })
-})
+    expect(nb.isMatrix({})).toBe(false);
+    expect(nb.isMatrix(undefined)).toBe(false);
+    expect(nb.isMatrix([{ a: 10 }, { b: 20 }])).toBe(false);
+  });
+});
 
 describe('nb.prettyFormatNumber', () => {
-  const dt = new Date()
+  const dt = new Date();
   // passthroughs
-  expect(nb.prettyFormatNumber('test')).toBe('test')
-  expect(nb.prettyFormatNumber({})).toEqual({})
-  expect(nb.prettyFormatNumber(dt)).toEqual(dt)
+  expect(nb.prettyFormatNumber('test')).toBe('test');
+  expect(nb.prettyFormatNumber({})).toEqual({});
+  expect(nb.prettyFormatNumber(dt)).toEqual(dt);
   // numerical conversions
-  expect(nb.prettyFormatNumber(1e11)).toBe('1.0000e+11')
-  expect(nb.prettyFormatNumber(1e1)).toBe('10')
-  expect(nb.prettyFormatNumber(1e2)).toBe('100')
-  expect(nb.prettyFormatNumber(1e3)).toBe('1000')
-  expect(nb.prettyFormatNumber(1e4)).toBe('10000')
-  expect(nb.prettyFormatNumber(1e5)).toBe('100000')
-  expect(nb.prettyFormatNumber(1e9)).toBe('1.0000e+9')
-  expect(nb.prettyFormatNumber(1e11)).toBe('1.0000e+11')
-  const num = 123456789.123456789
-  expect(nb.prettyFormatNumber(num)).toBe('1.2346e+8')
-  expect(nb.prettyFormatNumber(-num)).toBe('-1.2346e+8')
-  expect(nb.prettyFormatNumber(num / 1e1)).toBe('1.2346e+7')
-  expect(nb.prettyFormatNumber(num / 1e2)).toBe('1234568')
-  expect(nb.prettyFormatNumber(num / 1e8)).toBe('1.23457')
-  expect(nb.prettyFormatNumber(num / 1e9)).toBe('0.123457')
-  expect(nb.prettyFormatNumber(num / 1e12)).toBe('0.000123')
-  expect(nb.prettyFormatNumber(num / 1e15)).toBe('0.00000') // does this seem right?
-  expect(nb.prettyFormatNumber(-num / 1e12)).toBe('-0.000123')
-})
+  expect(nb.prettyFormatNumber(1e11)).toBe('1.0000e+11');
+  expect(nb.prettyFormatNumber(1e1)).toBe('10');
+  expect(nb.prettyFormatNumber(1e2)).toBe('100');
+  expect(nb.prettyFormatNumber(1e3)).toBe('1000');
+  expect(nb.prettyFormatNumber(1e4)).toBe('10000');
+  expect(nb.prettyFormatNumber(1e5)).toBe('100000');
+  expect(nb.prettyFormatNumber(1e9)).toBe('1.0000e+9');
+  expect(nb.prettyFormatNumber(1e11)).toBe('1.0000e+11');
+  const num = 123456789.123456789;
+  expect(nb.prettyFormatNumber(num)).toBe('1.2346e+8');
+  expect(nb.prettyFormatNumber(-num)).toBe('-1.2346e+8');
+  expect(nb.prettyFormatNumber(num / 1e1)).toBe('1.2346e+7');
+  expect(nb.prettyFormatNumber(num / 1e2)).toBe('1234568');
+  expect(nb.prettyFormatNumber(num / 1e8)).toBe('1.23457');
+  expect(nb.prettyFormatNumber(num / 1e9)).toBe('0.123457');
+  expect(nb.prettyFormatNumber(num / 1e12)).toBe('0.000123');
+  expect(nb.prettyFormatNumber(num / 1e15)).toBe('0.00000'); // does this seem right?
+  expect(nb.prettyFormatNumber(-num / 1e12)).toBe('-0.000123');
+});
 
 describe('nb.shape', () => {
 
-})
+});

--- a/src/tools/handle-url-query.js
+++ b/src/tools/handle-url-query.js
@@ -1,24 +1,24 @@
-import queryString from 'query-string'
+import queryString from 'query-string';
 
-import { stateFromJsmd } from './jsmd-tools'
-import { store } from '../store'
-import { importFromURL, evaluateAllCells } from '../actions/actions'
-import { importIpynb } from './ipynb-import'
+import { stateFromJsmd } from './jsmd-tools';
+import { store } from '../store';
+import { importFromURL, evaluateAllCells } from '../actions/actions';
+import { importIpynb } from './ipynb-import';
 
 function loadJsmd(jsmd) {
   store.dispatch(importFromURL(stateFromJsmd(jsmd))).then(() => {
-    if (store.getState().viewMode === 'presentation') { store.dispatch(evaluateAllCells(store.getState().cells, store)) }
-  })
+    if (store.getState().viewMode === 'presentation') { store.dispatch(evaluateAllCells(store.getState().cells, store)); }
+  });
 }
 
 async function loadJsmdFromNotebookUrl(url) {
   try {
     const response = await fetch(url);
-    const notebookString = await response.text()
-    const parser = new DOMParser()
+    const notebookString = await response.text();
+    const parser = new DOMParser();
     const doc = parser.parseFromString(notebookString, 'text/html');
-    const jsmd = doc.querySelector('#jsmd').innerHTML
-    loadJsmd(jsmd)
+    const jsmd = doc.querySelector('#jsmd').innerHTML;
+    loadJsmd(jsmd);
   } catch (err) {
     console.error('failed to load notebook url', err);
   }
@@ -26,34 +26,34 @@ async function loadJsmdFromNotebookUrl(url) {
 
 async function loadIpynbFromUrl(url) {
   try {
-    const response = await fetch(url)
-    const ipynbJson = await response.json()
-    const jsmd = importIpynb(url, ipynbJson)
-    loadJsmd(jsmd)
+    const response = await fetch(url);
+    const ipynbJson = await response.json();
+    const jsmd = importIpynb(url, ipynbJson);
+    loadJsmd(jsmd);
   } catch (err) {
-    console.error('failed to load ipynb url', err)
+    console.error('failed to load ipynb url', err);
   }
 }
 
 function loadFromUrlString(urlString) {
   try {
-    loadJsmd(urlString)
+    loadJsmd(urlString);
   } catch (err) {
-    console.error('failed to load notebook from urlString', err)
+    console.error('failed to load notebook from urlString', err);
   }
 }
 
 function handleUrlQuery() {
   const queryParams = queryString.parse(window.location.search);
   if ({}.hasOwnProperty.call(queryParams, 'url')) {
-    loadJsmdFromNotebookUrl(queryParams.url)
+    loadJsmdFromNotebookUrl(queryParams.url);
   } else if ({}.hasOwnProperty.call(queryParams, 'gist')) {
-    loadJsmdFromNotebookUrl(`https://gist.githubusercontent.com/${queryParams.gist}/raw/`)
+    loadJsmdFromNotebookUrl(`https://gist.githubusercontent.com/${queryParams.gist}/raw/`);
   } else if ({}.hasOwnProperty.call(queryParams, 'ipynb')) {
     loadIpynbFromUrl(queryParams.ipynb);
   } else if ({}.hasOwnProperty.call(queryParams, 'jsmd')) {
-    loadFromUrlString(queryParams.jsmd)
+    loadFromUrlString(queryParams.jsmd);
   }
 }
 
-export default handleUrlQuery
+export default handleUrlQuery;

--- a/src/tools/ipynb-import.js
+++ b/src/tools/ipynb-import.js
@@ -1,14 +1,14 @@
 function importIpynb(url, json) {
   if (json.nbformat !== 4) {
-    throw new Error('Iodide can only import version 4 of the .ipynb format')
+    throw new Error('Iodide can only import version 4 of the .ipynb format');
   }
 
-  const title = url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'))
+  const title = url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'));
 
   const { metadata, cells } = json;
   const languageInfo = metadata.language_info;
   if (languageInfo.name !== 'python') {
-    throw new Error(`Iodide can only import Python .ipynb notebooks at this time.  Found ${languageInfo.name}.`)
+    throw new Error(`Iodide can only import Python .ipynb notebooks at this time.  Found ${languageInfo.name}.`);
   }
 
   let jsmd = `
@@ -66,22 +66,22 @@ pyodide.loadPackage('matplotlib')
 
   cells.forEach((cell) => {
     if (cell.cell_type === 'markdown') {
-      jsmd += '\n%% md\n\n'
+      jsmd += '\n%% md\n\n';
     } else if (cell.cell_type === 'code') {
-      jsmd += '\n%% code {"language":"py"}\n\n'
+      jsmd += '\n%% code {"language":"py"}\n\n';
     }
     cell.source.forEach((line) => {
-      jsmd += line
-    })
-  })
+      jsmd += line;
+    });
+  });
 
   // Set the base URL of the page to the url of the source document, so links to
   // image content in markdown will work.
-  const base = document.createElement('base')
-  base.href = url
-  document.body.appendChild(base)
+  const base = document.createElement('base');
+  base.href = url;
+  document.body.appendChild(base);
 
-  return jsmd
+  return jsmd;
 }
 
 export { importIpynb };

--- a/src/tools/jsmd-tools.js
+++ b/src/tools/jsmd-tools.js
@@ -1,11 +1,11 @@
 /* global IODIDE_JS_PATH IODIDE_CSS_PATH IODIDE_VERSION */
-import deepEqual from 'deep-equal'
-import _ from 'lodash'
+import deepEqual from 'deep-equal';
+import _ from 'lodash';
 
-import { newNotebook, blankState, newCell } from '../state-prototypes'
-import htmlTemplate from '../html-template'
+import { newNotebook, blankState, newCell } from '../state-prototypes';
+import htmlTemplate from '../html-template';
 
-const jsmdValidCellTypes = ['md', 'js', 'code', 'raw', 'resource', 'css', 'plugin']
+const jsmdValidCellTypes = ['md', 'js', 'code', 'raw', 'resource', 'css', 'plugin'];
 
 
 const jsmdToCellTypeMap = new Map([
@@ -18,7 +18,7 @@ const jsmdToCellTypeMap = new Map([
   ['resource', 'external dependencies'],
   ['raw', 'raw'],
   ['css', 'css'],
-])
+]);
 
 const cellTypeToJsmdMap = new Map([
   ['plugin', 'plugin'],
@@ -27,7 +27,7 @@ const cellTypeToJsmdMap = new Map([
   ['external dependencies', 'resource'],
   ['raw', 'raw'],
   ['css', 'css'],
-])
+]);
 
 const jsmdValidNotebookSettings = [
   'title',
@@ -35,220 +35,220 @@ const jsmdValidNotebookSettings = [
   'lastSaved',
   'languages',
   'savedEnvironment',
-]
+];
 const jsmdValidCellSettingPaths = [
   'language',
   'rowSettings.REPORT.input',
   'rowSettings.REPORT.output',
   'skipInRunAll',
-]
+];
 
 function getNonDefaultValuesForPaths(paths, target, template) {
-  const out = {}
+  const out = {};
   paths.forEach((p) => {
     if (_.get(target, p) !== _.get(template, p)) {
-      out[p] = _.get(target, p)
+      out[p] = _.get(target, p);
     }
-  })
-  return out
+  });
+  return out;
 }
 
 function parseMetaChunk(content, parseWarnings) {
-  let metaSettings
+  let metaSettings;
   try {
-    metaSettings = JSON.parse(content)
+    metaSettings = JSON.parse(content);
   } catch (e) {
     parseWarnings.push({
       parseError: 'Failed to parse notebook settings from meta cell. Using default settings.',
       details: content,
       jsError: `${e.name}: ${e.message}`,
-    })
-    metaSettings = {} // set content back to empty object
+    });
+    metaSettings = {}; // set content back to empty object
   }
-  return { chunkType: 'meta', iodideSettings: metaSettings }
+  return { chunkType: 'meta', iodideSettings: metaSettings };
 }
 
 function parseCellChunk(chunkType, content, settings, str, chunkNum, parseWarnings) {
-  let cellType = jsmdToCellTypeMap.get(chunkType)
+  let cellType = jsmdToCellTypeMap.get(chunkType);
   // if the cell type is not valid, set it to js
   if (jsmdValidCellTypes.indexOf(chunkType) === -1) {
     parseWarnings.push({
       parseError: 'invalid cell type, converted to js cell',
       details: `chunkType: ${chunkType} chunkNum:${chunkNum} raw string: ${str}`,
-    })
-    cellType = 'code'
+    });
+    cellType = 'code';
   }
 
-  const cell = newCell(chunkNum, cellType)
-  cell.content = content
+  const cell = newCell(chunkNum, cellType);
+  cell.content = content;
   // make sure that only valid cell settings are kept
   Object.keys(settings).forEach((path) => {
     if (_.includes(jsmdValidCellSettingPaths, path)) {
-      _.set(cell, path, settings[path])
+      _.set(cell, path, settings[path]);
     } else {
       parseWarnings.push({
         parseError: 'invalid cell setting path',
         details: path,
-      })
+      });
     }
-  })
+  });
 
-  return { chunkType: 'cell', cell }
+  return { chunkType: 'cell', cell };
 }
 
 function parseJsmdChunk(str, i, parseWarnings) {
   // note: this is not a pure function, it mutates parseWarnings
-  let chunkType
-  let settings = {}
-  let content
-  let firstLine
-  const firstLineBreak = str.indexOf('\n')
+  let chunkType;
+  let settings = {};
+  let content;
+  let firstLine;
+  const firstLineBreak = str.indexOf('\n');
   if (firstLineBreak === -1) {
     // a cell with only 1 line, and hence no content
-    firstLine = str
-    content = ''
+    firstLine = str;
+    content = '';
   } else {
-    firstLine = str.substring(0, firstLineBreak).trim()
-    content = str.substring(firstLineBreak + 1).trim()
+    firstLine = str.substring(0, firstLineBreak).trim();
+    content = str.substring(firstLineBreak + 1).trim();
   }
   // let firstLine = str.substring(0,firstLineBreak).trim()
-  const firstLineFirstSpace = firstLine.indexOf(' ')
+  const firstLineFirstSpace = firstLine.indexOf(' ');
 
 
   if (firstLineFirstSpace === -1) {
     // if there is NO space on the first line (after trimming), there are no cell settings
-    chunkType = firstLine.toLowerCase()
+    chunkType = firstLine.toLowerCase();
   } else {
     // if there is a space on the first line (after trimming), there must be cell settings
-    chunkType = firstLine.substring(0, firstLineFirstSpace).toLowerCase()
+    chunkType = firstLine.substring(0, firstLineFirstSpace).toLowerCase();
     // make sure the cell settings parse as JSON
     try {
-      settings = JSON.parse(firstLine.substring(firstLineFirstSpace + 1))
+      settings = JSON.parse(firstLine.substring(firstLineFirstSpace + 1));
     } catch (e) {
       parseWarnings.push({
         parseError: 'failed to parse cell settings, using defaults',
         details: firstLine,
         jsError: `${e.name}: ${e.message}`,
-      })
+      });
     }
   }
-  let chunkObject
+  let chunkObject;
   if (chunkType === 'meta') {
-    chunkObject = parseMetaChunk(content, parseWarnings)
+    chunkObject = parseMetaChunk(content, parseWarnings);
   } else {
-    chunkObject = parseCellChunk(chunkType, content, settings, str, i, parseWarnings)
+    chunkObject = parseCellChunk(chunkType, content, settings, str, i, parseWarnings);
   }
 
-  return chunkObject
+  return chunkObject;
 }
 
 function parseJsmd(jsmd) {
-  const parseWarnings = []
+  const parseWarnings = [];
   const chunkObjects = jsmd
     .split('\n%%')
     .map((str, chunkNum) => {
       // if this is the first chunk, and it starts with "%%", drop those chars
-      let sstr
+      let sstr;
       if (chunkNum === 0 && str.substring(0, 2) === '%%') {
-        sstr = str.substring(2)
+        sstr = str.substring(2);
       } else {
-        sstr = str
+        sstr = str;
       }
-      return sstr
+      return sstr;
     })
     .map(str => str.trim())
     .filter(str => str !== '')
-    .map((str, i) => parseJsmdChunk(str, i, parseWarnings))
-  return { chunkObjects, parseWarnings }
+    .map((str, i) => parseJsmdChunk(str, i, parseWarnings));
+  return { chunkObjects, parseWarnings };
 }
 
 function stateFromJsmd(jsmdString) {
-  const parsed = parseJsmd(jsmdString)
-  const { chunkObjects } = parsed
-  const { parseWarnings } = parsed
+  const parsed = parseJsmd(jsmdString);
+  const { chunkObjects } = parsed;
+  const { parseWarnings } = parsed;
   if (parseWarnings.length > 0) {
-    console.warn('JSMD parse errors', parseWarnings)
+    console.warn('JSMD parse errors', parseWarnings);
   }
   // initialize a blank notebook
-  const initialState = blankState()
+  const initialState = blankState();
   // add top-level meta settings if any exist
-  const meta = chunkObjects.filter(c => c.chunkType === 'meta')[0]
+  const meta = chunkObjects.filter(c => c.chunkType === 'meta')[0];
   if (meta) {
-    Object.assign(initialState, meta.iodideSettings)
+    Object.assign(initialState, meta.iodideSettings);
   }
 
   chunkObjects
     .filter(c => c.chunkType !== 'meta')
     .forEach((c) => {
-      initialState.cells.push(c.cell)
-    })
+      initialState.cells.push(c.cell);
+    });
   // if only a meta cell exists, return a default JS cell
   if (initialState.cells.length === 0) {
-    initialState.cells.push(newCell(0, 'code'))
+    initialState.cells.push(newCell(0, 'code'));
   }
   // set cell 0  to be the selected cell
-  initialState.cells[0].selected = true
-  return initialState
+  initialState.cells[0].selected = true;
+  return initialState;
 }
 
 
 function stringifyStateToJsmd(state, exportDatetimeString) {
   // we pass in exportDatetimeString as a string to keep this function
   // **functional** -- makes testing easier
-  const defaultState = newNotebook()
+  const defaultState = newNotebook();
   // let defaultCellPrototype = defaultState.cells[0]
   // serialize cells. most of the work here is seeing if cell properties
   // are in the jsmd valid list, and seeing if they are not default
   // values for this cell type
   const cellsStr = state.cells.map((cell) => {
-    const defaultCell = newCell(0, cell.cellType)
+    const defaultCell = newCell(0, cell.cellType);
     const cellSettings = getNonDefaultValuesForPaths(
       jsmdValidCellSettingPaths,
       cell,
       defaultCell,
-    )
-    let cellSettingsStr = JSON.stringify(cellSettings)
-    let jsmdCellType = cellTypeToJsmdMap.get(cell.cellType)
+    );
+    let cellSettingsStr = JSON.stringify(cellSettings);
+    let jsmdCellType = cellTypeToJsmdMap.get(cell.cellType);
     // note: js is the DEFAULT language, so if the lang of this cell is JS,
     // cellSettings.language will be undefined since it matches that default
-    jsmdCellType = jsmdCellType === 'code' && cellSettings.language === undefined ? 'js' : jsmdCellType
-    cellSettingsStr = cellSettingsStr === '{}' ? '' : ` ${cellSettingsStr}`
+    jsmdCellType = jsmdCellType === 'code' && cellSettings.language === undefined ? 'js' : jsmdCellType;
+    cellSettingsStr = cellSettingsStr === '{}' ? '' : ` ${cellSettingsStr}`;
     return `\n%% ${jsmdCellType}${cellSettingsStr}
-${cell.content}`
-  }).join('\n').trim()
+${cell.content}`;
+  }).join('\n').trim();
 
   // serialize global settings. as above, check if state properties
   // are in the jsmd valid list, and check if they are non-default
-  const metaSettings = {}
+  const metaSettings = {};
   for (const setting of jsmdValidNotebookSettings) {
     if (Object.prototype.hasOwnProperty.call(state, setting)
       && !deepEqual(state[setting], defaultState[setting])) {
-      metaSettings[setting] = state[setting]
+      metaSettings[setting] = state[setting];
     }
   }
-  metaSettings.lastExport = exportDatetimeString
-  let metaSettingsStr = JSON.stringify(metaSettings, undefined, 2)
-  metaSettingsStr = metaSettingsStr === '{}' ? '' : `%% meta\n${metaSettingsStr}\n\n`
-  return metaSettingsStr + cellsStr
+  metaSettings.lastExport = exportDatetimeString;
+  let metaSettingsStr = JSON.stringify(metaSettings, undefined, 2);
+  metaSettingsStr = metaSettingsStr === '{}' ? '' : `%% meta\n${metaSettingsStr}\n\n`;
+  return metaSettingsStr + cellsStr;
 }
 
 function exportJsmdBundle(state) {
-  const htmlTemplateCompiler = _.template(htmlTemplate)
+  const htmlTemplateCompiler = _.template(htmlTemplate);
   return htmlTemplateCompiler({
     NOTEBOOK_TITLE: state.title,
     APP_PATH_STRING: IODIDE_JS_PATH,
     CSS_PATH_STRING: IODIDE_CSS_PATH,
     APP_VERSION_STRING: IODIDE_VERSION,
     JSMD: stringifyStateToJsmd(state, new Date().toISOString()),
-  })
+  });
 }
 
 function exportJsmdToString(state) {
-  return stringifyStateToJsmd(state, new Date().toISOString())
+  return stringifyStateToJsmd(state, new Date().toISOString());
 }
 
 function titleToHtmlFilename(title) {
-  return `${title.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.html`
+  return `${title.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.html`;
 }
 
 export {
@@ -262,4 +262,4 @@ export {
   exportJsmdBundle,
   exportJsmdToString,
   titleToHtmlFilename,
-}
+};

--- a/src/tools/notebook-utils.js
+++ b/src/tools/notebook-utils.js
@@ -1,59 +1,59 @@
-import { store } from '../store'
+import { store } from '../store';
 
 function viewModeIsEditor() {
-  return store.getState().viewMode === 'editor'
+  return store.getState().viewMode === 'editor';
 }
 
 function isCommandMode() {
-  return store.getState().mode === 'command' && viewModeIsEditor()
+  return store.getState().mode === 'command' && viewModeIsEditor();
 }
 
 function viewModeIsPresentation() {
-  return store.getState().viewMode === 'presentation'
+  return store.getState().viewMode === 'presentation';
 }
 
 function getCells() {
-  return store.getState().cells
+  return store.getState().cells;
 }
 
 function getCellBelowSelectedId() {
-  const { cells } = store.getState()
-  const index = cells.findIndex(c => c.selected)
+  const { cells } = store.getState();
+  const index = cells.findIndex(c => c.selected);
   if (index === cells.length - 1) {
     // if there is no cell below, return null
-    return null
+    return null;
   } else if (index >= 0 && index < (cells.length - 1)) {
-    return cells[index + 1].id
+    return cells[index + 1].id;
   }
-  throw new Error('no cell currently selected')
+  throw new Error('no cell currently selected');
 }
 
 function getCellAboveSelectedId() {
-  const { cells } = store.getState()
-  const index = cells.findIndex(c => c.selected)
+  const { cells } = store.getState();
+  const index = cells.findIndex(c => c.selected);
   if (index === 0) {
     // if there is no cell above, return null
-    return null
+    return null;
   } else if (index > 0 && index <= (cells.length - 1)) {
-    return cells[index - 1].id
+    return cells[index - 1].id;
   }
-  throw new Error('no cell currently selected')
+  throw new Error('no cell currently selected');
 }
 
 function getCellById(cells, cellID) {
   // returns a reference to the cell.
-  const thisCellIndex = cells.findIndex(c => c.id === cellID)
-  const thisCell = cells[thisCellIndex]
-  return thisCell
+  const thisCellIndex = cells.findIndex(c => c.id === cellID);
+  const thisCell = cells[thisCellIndex];
+  return thisCell;
 }
 
 function prettyDate(time) {
-  const date = new Date(time)
-  const diff = (((new Date()).getTime() - date.getTime()) / 1000)
-  const dayDiff = Math.floor(diff / 86400)
+  const date = new Date(time);
+  const diff = (((new Date()).getTime() - date.getTime()) / 1000);
+  const dayDiff = Math.floor(diff / 86400);
   // return date for anything greater than a day
   if (Number.isNaN(dayDiff) || dayDiff < 0 || dayDiff > 0) {
-    return `${date.getDate()} ${date.toDateString().split(' ')[1]}`
+    return `${date.getDate()} ${date.toDateString().split(' ')[1]}`;
   }
 
   return (
@@ -67,12 +67,12 @@ function prettyDate(time) {
     (dayDiff === 1 && 'Yesterday') ||
     (dayDiff < 7 && `${dayDiff} days ago`) ||
     (dayDiff < 31 && `${Math.ceil(dayDiff / 7)} weeks ago`)
-  )
+  );
 }
 
 function formatDateString(d) {
-  const newd = new Date(d)
-  return newd.toUTCString()
+  const newd = new Date(d);
+  return newd.toUTCString();
 }
 
 export {
@@ -83,4 +83,4 @@ export {
   getCellBelowSelectedId, getCellAboveSelectedId,
   isCommandMode,
   viewModeIsEditor, viewModeIsPresentation,
-}
+};

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -1,4 +1,4 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-Enzyme.configure({ adapter: new Adapter() })
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
There is no "right" answer to the question of whether semi-colons
are good or bad in modern-day js, but historically Mozilla's
web tools (and in particular our data tools) have used and enforced
a style where semicolons are always used to terminate the end of a line
or expression.

Redash, test-tube, metricsgraphics, missioncontrol for example all
use this rule. Furthermore, it's a default part of the airbnb
style guide which is recommended by Mozilla's frontend infrastructure
working group (https://github.com/mozilla-frontend-infra).

To avoid confusing people who have to move between these projects on a
frequent basis, I propose that we just adopt the rule and move on.
This commit adds the rule (really deleting an exception) and updates
the source code accordingly (done automatically via eslint's --fix
option)

<!---
@huboard:{"milestone_order":172.93622138458113}
-->
