### PR TITLE
Fixed submenu switching

### DIFF
--- a/src/components/menu/notebook-menu-subsection.jsx
+++ b/src/components/menu/notebook-menu-subsection.jsx
@@ -22,9 +22,6 @@ export default class NotebookMenuSubsection extends React.Component {
 
   handleClose() {
     this.setState({ anchorElement: null })
-    document.querySelectorAll('div[class^="MuiBackdrop-"]').forEach((backdrop) => {
-      backdrop.click();
-    })
   }
   render() {
     const { anchorElement } = this.state


### PR DESCRIPTION
Related to material_ui problem than submenu cannot easly be closed, there are a solution that @janhoeck provided. https://github.com/mui-org/material-ui/issues/11723

In his demo in subsection menu there is no iterated clicking. 

So i removed and checked. That's worked as expected.

<!---
@huboard:{"milestone_order":172.9221716202434}
-->
