### PR TITLE
Add Cell Menu Container Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,13 +1210,13 @@
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       },
       "dependencies": {
         "http-errors": {
@@ -1224,10 +1224,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "iconv-lite": {
@@ -1235,7 +1235,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "mime-db": {
@@ -1248,7 +1248,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "qs": {
@@ -1267,7 +1267,7 @@
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
+            "mime-types": "~2.1.18"
           }
         }
       }
@@ -3984,15 +3984,15 @@
           "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.2",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "1.6.15"
+            "type-is": "~1.6.15"
           }
         },
         "raw-body": {
@@ -10901,10 +10901,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "iconv-lite": {
@@ -10912,7 +10912,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "statuses": {

--- a/src/components/cells/__tests__/__snapshots__/cell-menu-container.test.js.snap
+++ b/src/components/cells/__tests__/__snapshots__/cell-menu-container.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CellMenuContainerUnconnected matches the snapshot if props.skipInRunAll is false 1`] = `
+exports[`CellMenuContainerUnconnected matches the snapshot if props.skipInRunAll is false and anchorElement is null 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
@@ -1266,6 +1266,586 @@ ShallowWrapper {
             },
             "type": [Function],
           },
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`CellMenuContainerUnconnected matches the snapshot if state.anchorElement is not null 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <CellMenuContainerUnconnected
+    cellId={0}
+    label="md"
+    skipInRunAll={false}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <WithStyles(Tooltip)
+          classes={
+            Object {
+              "tooltip": "iodide-tooltip",
+            }
+          }
+          enterDelay={600}
+          placement="bottom"
+          title="Cell Settings"
+        >
+          <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl="not null"
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={true}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns="cell-menu"
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>
+        </WithStyles(Tooltip)>,
+        <div
+          className="cell-status-indicators"
+        >
+          
+        </div>,
+      ],
+      "className": "cell-menu-container",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl="not null"
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={true}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns="cell-menu"
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>,
+          "classes": Object {
+            "tooltip": "iodide-tooltip",
+          },
+          "enterDelay": 600,
+          "placement": "bottom",
+          "title": "Cell Settings",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              <WithStyles(Menu)
+                anchorEl="not null"
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={true}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>,
+              <div
+                aria-haspopup="true"
+                aria-owns="cell-menu"
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "anchorEl": "not null",
+                "anchorOrigin": Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                },
+                "anchorReference": "anchorEl",
+                "children": <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />,
+                "getContentAnchorEl": null,
+                "id": "cell-menu",
+                "onClose": [Function],
+                "open": true,
+                "transformOrigin": Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                },
+                "transitionDuration": 70,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "cellId": 0,
+                  "menuLabel": "md",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "aria-haspopup": "true",
+                "aria-owns": "cell-menu",
+                "children": Array [
+                  "md",
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />,
+                ],
+                "className": "cell-type-label",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": Array [
+                "md",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "style": Object {
+                      "fontSize": 20,
+                    },
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+              ],
+              "type": "div",
+            },
+          ],
+          "type": Symbol(react.fragment),
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "",
+          "className": "cell-status-indicators",
+        },
+        "ref": null,
+        "rendered": "",
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <WithStyles(Tooltip)
+            classes={
+              Object {
+                "tooltip": "iodide-tooltip",
+              }
+            }
+            enterDelay={600}
+            placement="bottom"
+            title="Cell Settings"
+          >
+            <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl="not null"
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={true}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns="cell-menu"
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>
+          </WithStyles(Tooltip)>,
+          <div
+            className="cell-status-indicators"
+          >
+            
+          </div>,
+        ],
+        "className": "cell-menu-container",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl="not null"
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={true}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns="cell-menu"
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>,
+            "classes": Object {
+              "tooltip": "iodide-tooltip",
+            },
+            "enterDelay": 600,
+            "placement": "bottom",
+            "title": "Cell Settings",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <WithStyles(Menu)
+                  anchorEl="not null"
+                  anchorOrigin={
+                    Object {
+                      "horizontal": "right",
+                      "vertical": "top",
+                    }
+                  }
+                  anchorReference="anchorEl"
+                  getContentAnchorEl={null}
+                  id="cell-menu"
+                  onClose={[Function]}
+                  open={true}
+                  transformOrigin={
+                    Object {
+                      "horizontal": "left",
+                      "vertical": "top",
+                    }
+                  }
+                  transitionDuration={70}
+                >
+                  <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />
+                </WithStyles(Menu)>,
+                <div
+                  aria-haspopup="true"
+                  aria-owns="cell-menu"
+                  className="cell-type-label"
+                  onClick={[Function]}
+                >
+                  md
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />
+                </div>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "anchorEl": "not null",
+                  "anchorOrigin": Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  },
+                  "anchorReference": "anchorEl",
+                  "children": <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />,
+                  "getContentAnchorEl": null,
+                  "id": "cell-menu",
+                  "onClose": [Function],
+                  "open": true,
+                  "transformOrigin": Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  },
+                  "transitionDuration": 70,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "cellId": 0,
+                    "menuLabel": "md",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "aria-haspopup": "true",
+                  "aria-owns": "cell-menu",
+                  "children": Array [
+                    "md",
+                    <pure(ArrowDropDown)
+                      style={
+                        Object {
+                          "fontSize": 20,
+                        }
+                      }
+                    />,
+                  ],
+                  "className": "cell-type-label",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": Array [
+                  "md",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "style": Object {
+                        "fontSize": 20,
+                      },
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
+                "type": "div",
+              },
+            ],
+            "type": Symbol(react.fragment),
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "",
+            "className": "cell-status-indicators",
+          },
+          "ref": null,
+          "rendered": "",
           "type": "div",
         },
       ],

--- a/src/components/cells/__tests__/__snapshots__/cell-menu-container.test.js.snap
+++ b/src/components/cells/__tests__/__snapshots__/cell-menu-container.test.js.snap
@@ -1,0 +1,1283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellMenuContainerUnconnected matches the snapshot if props.skipInRunAll is false 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <CellMenuContainerUnconnected
+    cellId={0}
+    label="md"
+    skipInRunAll={false}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <WithStyles(Tooltip)
+          classes={
+            Object {
+              "tooltip": "iodide-tooltip",
+            }
+          }
+          enterDelay={600}
+          placement="bottom"
+          title="Cell Settings"
+        >
+          <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns={null}
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>
+        </WithStyles(Tooltip)>,
+        <div
+          className="cell-status-indicators"
+        >
+          
+        </div>,
+      ],
+      "className": "cell-menu-container",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns={null}
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>,
+          "classes": Object {
+            "tooltip": "iodide-tooltip",
+          },
+          "enterDelay": 600,
+          "placement": "bottom",
+          "title": "Cell Settings",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>,
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "anchorEl": null,
+                "anchorOrigin": Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                },
+                "anchorReference": "anchorEl",
+                "children": <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />,
+                "getContentAnchorEl": null,
+                "id": "cell-menu",
+                "onClose": [Function],
+                "open": false,
+                "transformOrigin": Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                },
+                "transitionDuration": 70,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "cellId": 0,
+                  "menuLabel": "md",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "aria-haspopup": "true",
+                "aria-owns": null,
+                "children": Array [
+                  "md",
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />,
+                ],
+                "className": "cell-type-label",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": Array [
+                "md",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "style": Object {
+                      "fontSize": 20,
+                    },
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+              ],
+              "type": "div",
+            },
+          ],
+          "type": Symbol(react.fragment),
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "",
+          "className": "cell-status-indicators",
+        },
+        "ref": null,
+        "rendered": "",
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <WithStyles(Tooltip)
+            classes={
+              Object {
+                "tooltip": "iodide-tooltip",
+              }
+            }
+            enterDelay={600}
+            placement="bottom"
+            title="Cell Settings"
+          >
+            <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>
+          </WithStyles(Tooltip)>,
+          <div
+            className="cell-status-indicators"
+          >
+            
+          </div>,
+        ],
+        "className": "cell-menu-container",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>,
+            "classes": Object {
+              "tooltip": "iodide-tooltip",
+            },
+            "enterDelay": 600,
+            "placement": "bottom",
+            "title": "Cell Settings",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <WithStyles(Menu)
+                  anchorEl={null}
+                  anchorOrigin={
+                    Object {
+                      "horizontal": "right",
+                      "vertical": "top",
+                    }
+                  }
+                  anchorReference="anchorEl"
+                  getContentAnchorEl={null}
+                  id="cell-menu"
+                  onClose={[Function]}
+                  open={false}
+                  transformOrigin={
+                    Object {
+                      "horizontal": "left",
+                      "vertical": "top",
+                    }
+                  }
+                  transitionDuration={70}
+                >
+                  <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />
+                </WithStyles(Menu)>,
+                <div
+                  aria-haspopup="true"
+                  aria-owns={null}
+                  className="cell-type-label"
+                  onClick={[Function]}
+                >
+                  md
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />
+                </div>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "anchorEl": null,
+                  "anchorOrigin": Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  },
+                  "anchorReference": "anchorEl",
+                  "children": <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />,
+                  "getContentAnchorEl": null,
+                  "id": "cell-menu",
+                  "onClose": [Function],
+                  "open": false,
+                  "transformOrigin": Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  },
+                  "transitionDuration": 70,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "cellId": 0,
+                    "menuLabel": "md",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "aria-haspopup": "true",
+                  "aria-owns": null,
+                  "children": Array [
+                    "md",
+                    <pure(ArrowDropDown)
+                      style={
+                        Object {
+                          "fontSize": 20,
+                        }
+                      }
+                    />,
+                  ],
+                  "className": "cell-type-label",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": Array [
+                  "md",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "style": Object {
+                        "fontSize": 20,
+                      },
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
+                "type": "div",
+              },
+            ],
+            "type": Symbol(react.fragment),
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "",
+            "className": "cell-status-indicators",
+          },
+          "ref": null,
+          "rendered": "",
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`CellMenuContainerUnconnected matches the snapshot if props.skipInRunAll is true 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <CellMenuContainerUnconnected
+    cellId={0}
+    label="md"
+    skipInRunAll={true}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <WithStyles(Tooltip)
+          classes={
+            Object {
+              "tooltip": "iodide-tooltip",
+            }
+          }
+          enterDelay={600}
+          placement="bottom"
+          title="Cell Settings"
+        >
+          <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns={null}
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>
+        </WithStyles(Tooltip)>,
+        <div
+          className="cell-status-indicators"
+        >
+          <WithStyles(Tooltip)
+            classes={
+              Object {
+                "tooltip": "iodide-tooltip",
+              }
+            }
+            enterDelay={600}
+            placement="bottom"
+            title="Cell skipped during run all"
+          >
+            <div
+              className="warning-pill"
+            >
+              skip
+            </div>
+          </WithStyles(Tooltip)>
+        </div>,
+      ],
+      "className": "cell-menu-container",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <UNDEFINED>
+            <WithStyles(Menu)
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                }
+              }
+              anchorReference="anchorEl"
+              getContentAnchorEl={null}
+              id="cell-menu"
+              onClose={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration={70}
+            >
+              <Connect(CellMenuUnconnected)
+                cellId={0}
+                menuLabel="md"
+              />
+            </WithStyles(Menu)>
+            <div
+              aria-haspopup="true"
+              aria-owns={null}
+              className="cell-type-label"
+              onClick={[Function]}
+            >
+              md
+              <pure(ArrowDropDown)
+                style={
+                  Object {
+                    "fontSize": 20,
+                  }
+                }
+              />
+            </div>
+          </UNDEFINED>,
+          "classes": Object {
+            "tooltip": "iodide-tooltip",
+          },
+          "enterDelay": 600,
+          "placement": "bottom",
+          "title": "Cell Settings",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "children": Array [
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>,
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>,
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "anchorEl": null,
+                "anchorOrigin": Object {
+                  "horizontal": "right",
+                  "vertical": "top",
+                },
+                "anchorReference": "anchorEl",
+                "children": <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />,
+                "getContentAnchorEl": null,
+                "id": "cell-menu",
+                "onClose": [Function],
+                "open": false,
+                "transformOrigin": Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                },
+                "transitionDuration": 70,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "cellId": 0,
+                  "menuLabel": "md",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "aria-haspopup": "true",
+                "aria-owns": null,
+                "children": Array [
+                  "md",
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />,
+                ],
+                "className": "cell-type-label",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": Array [
+                "md",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "style": Object {
+                      "fontSize": 20,
+                    },
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+              ],
+              "type": "div",
+            },
+          ],
+          "type": Symbol(react.fragment),
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <WithStyles(Tooltip)
+            classes={
+              Object {
+                "tooltip": "iodide-tooltip",
+              }
+            }
+            enterDelay={600}
+            placement="bottom"
+            title="Cell skipped during run all"
+          >
+            <div
+              className="warning-pill"
+            >
+              skip
+            </div>
+          </WithStyles(Tooltip)>,
+          "className": "cell-status-indicators",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <div
+              className="warning-pill"
+            >
+              skip
+            </div>,
+            "classes": Object {
+              "tooltip": "iodide-tooltip",
+            },
+            "enterDelay": 600,
+            "placement": "bottom",
+            "title": "Cell skipped during run all",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "skip",
+              "className": "warning-pill",
+            },
+            "ref": null,
+            "rendered": "skip",
+            "type": "div",
+          },
+          "type": [Function],
+        },
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <WithStyles(Tooltip)
+            classes={
+              Object {
+                "tooltip": "iodide-tooltip",
+              }
+            }
+            enterDelay={600}
+            placement="bottom"
+            title="Cell Settings"
+          >
+            <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>
+          </WithStyles(Tooltip)>,
+          <div
+            className="cell-status-indicators"
+          >
+            <WithStyles(Tooltip)
+              classes={
+                Object {
+                  "tooltip": "iodide-tooltip",
+                }
+              }
+              enterDelay={600}
+              placement="bottom"
+              title="Cell skipped during run all"
+            >
+              <div
+                className="warning-pill"
+              >
+                skip
+              </div>
+            </WithStyles(Tooltip)>
+          </div>,
+        ],
+        "className": "cell-menu-container",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <UNDEFINED>
+              <WithStyles(Menu)
+                anchorEl={null}
+                anchorOrigin={
+                  Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  }
+                }
+                anchorReference="anchorEl"
+                getContentAnchorEl={null}
+                id="cell-menu"
+                onClose={[Function]}
+                open={false}
+                transformOrigin={
+                  Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  }
+                }
+                transitionDuration={70}
+              >
+                <Connect(CellMenuUnconnected)
+                  cellId={0}
+                  menuLabel="md"
+                />
+              </WithStyles(Menu)>
+              <div
+                aria-haspopup="true"
+                aria-owns={null}
+                className="cell-type-label"
+                onClick={[Function]}
+              >
+                md
+                <pure(ArrowDropDown)
+                  style={
+                    Object {
+                      "fontSize": 20,
+                    }
+                  }
+                />
+              </div>
+            </UNDEFINED>,
+            "classes": Object {
+              "tooltip": "iodide-tooltip",
+            },
+            "enterDelay": 600,
+            "placement": "bottom",
+            "title": "Cell Settings",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "children": Array [
+                <WithStyles(Menu)
+                  anchorEl={null}
+                  anchorOrigin={
+                    Object {
+                      "horizontal": "right",
+                      "vertical": "top",
+                    }
+                  }
+                  anchorReference="anchorEl"
+                  getContentAnchorEl={null}
+                  id="cell-menu"
+                  onClose={[Function]}
+                  open={false}
+                  transformOrigin={
+                    Object {
+                      "horizontal": "left",
+                      "vertical": "top",
+                    }
+                  }
+                  transitionDuration={70}
+                >
+                  <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />
+                </WithStyles(Menu)>,
+                <div
+                  aria-haspopup="true"
+                  aria-owns={null}
+                  className="cell-type-label"
+                  onClick={[Function]}
+                >
+                  md
+                  <pure(ArrowDropDown)
+                    style={
+                      Object {
+                        "fontSize": 20,
+                      }
+                    }
+                  />
+                </div>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "anchorEl": null,
+                  "anchorOrigin": Object {
+                    "horizontal": "right",
+                    "vertical": "top",
+                  },
+                  "anchorReference": "anchorEl",
+                  "children": <Connect(CellMenuUnconnected)
+                    cellId={0}
+                    menuLabel="md"
+                  />,
+                  "getContentAnchorEl": null,
+                  "id": "cell-menu",
+                  "onClose": [Function],
+                  "open": false,
+                  "transformOrigin": Object {
+                    "horizontal": "left",
+                    "vertical": "top",
+                  },
+                  "transitionDuration": 70,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "cellId": 0,
+                    "menuLabel": "md",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "aria-haspopup": "true",
+                  "aria-owns": null,
+                  "children": Array [
+                    "md",
+                    <pure(ArrowDropDown)
+                      style={
+                        Object {
+                          "fontSize": 20,
+                        }
+                      }
+                    />,
+                  ],
+                  "className": "cell-type-label",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": Array [
+                  "md",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "style": Object {
+                        "fontSize": 20,
+                      },
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
+                "type": "div",
+              },
+            ],
+            "type": Symbol(react.fragment),
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <WithStyles(Tooltip)
+              classes={
+                Object {
+                  "tooltip": "iodide-tooltip",
+                }
+              }
+              enterDelay={600}
+              placement="bottom"
+              title="Cell skipped during run all"
+            >
+              <div
+                className="warning-pill"
+              >
+                skip
+              </div>
+            </WithStyles(Tooltip)>,
+            "className": "cell-status-indicators",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": <div
+                className="warning-pill"
+              >
+                skip
+              </div>,
+              "classes": Object {
+                "tooltip": "iodide-tooltip",
+              },
+              "enterDelay": 600,
+              "placement": "bottom",
+              "title": "Cell skipped during run all",
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "skip",
+                "className": "warning-pill",
+              },
+              "ref": null,
+              "rendered": "skip",
+              "type": "div",
+            },
+            "type": [Function],
+          },
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -23,7 +23,7 @@ describe('CellMenuContainerUnconnected', () => {
     expect(mountedMenuContainer.state('anchorElement')).toEqual(null);
   })
 
-  it('matches the snapshot if props.skipInRunAll is false', () => {
+  it('matches the snapshot if props.skipInRunAll is false and anchorElement is null', () => {
     const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
     expect(mountedMenuContainer).toMatchSnapshot();
@@ -37,16 +37,20 @@ describe('CellMenuContainerUnconnected', () => {
   })
 
   it('matches the snapshot if state.anchorElement is not null', () => {
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+    mountedMenuContainer.setState({ anchorElement: 'not null' })
+    mountedMenuContainer.update();
 
-  })
-
-  it('matches the snapshot if state.anchorElement is null', () => {
-
+    expect(mountedMenuContainer).toMatchSnapshot(); 
   })
 
   describe('handleClick', () => {
     it('updates anchorElement in state with the button clicked', () => {
+      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
+      mountedMenuContainer.find('.cell-type-label').simulate('click', { currentTarget: 'a target' });
+
+      expect(mountedMenuContainer.state('anchorElement')).toEqual('a target');
     })
   })
 

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -23,15 +23,17 @@ describe('CellMenuContainerUnconnected', () => {
     expect(mountedMenuContainer.state('anchorElement')).toEqual(null);
   })
 
-  it('matches the snapshot if props.skipInRunAll is true', () => {
-    props.skipInRunAll = true;
+  it('matches the snapshot if props.skipInRunAll is false', () => {
     const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
     expect(mountedMenuContainer).toMatchSnapshot();
   })
 
-  it('matches the snapshot if props.skipInRunAll is false', () => {
+  it('matches the snapshot if props.skipInRunAll is true', () => {
+    props.skipInRunAll = true;
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
+    expect(mountedMenuContainer).toMatchSnapshot();
   })
 
   it('matches the snapshot if state.anchorElement is not null', () => {

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -7,8 +7,20 @@ import {
 } from '../cell-menu-container';
 
 describe('CellMenuContainerUnconnected', () => {
-  it('has default state of anchorElement as null', () => {
+  let props;
 
+  beforeEach(() => {
+    props = {
+      label: 'md',
+      cellId: 0,
+      skipInRunAll: false 
+    } 
+  })
+
+  it('has default state of anchorElement as null', () => {
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+
+    expect(mountedMenuContainer.state('anchorElement')).toEqual(null);
   })
 
   it('matches the snapshot if props.skipInRunAll is true', () => {
@@ -50,6 +62,4 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 })
 
-describe('CellMenuContainerUnconnected mapDispatchToProps', () => {
-  
-})
+

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import {
+  CellMenuContainerUnconnected,
+  mapStateToProps,
+  mapDispatchToProps
+} from '../cell-menu-container';
+
+describe('CellMenuContainerUnconnected', () => {
+
+})
+
+describe('CellMenuContainerUnconnected mapStateToProps', () => {
+
+})
+
+describe('CellMenuContainerUnconnected mapDispatchToProps', () => {
+
+})

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import {
   CellMenuContainerUnconnected,
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 } from '../cell-menu-container';
 
 import * as notebookUtils from '../../../tools/notebook-utils'
@@ -15,40 +15,40 @@ describe('CellMenuContainerUnconnected', () => {
     props = {
       label: 'md',
       cellId: 0,
-      skipInRunAll: false 
-    } 
+      skipInRunAll: false,
+    }
   })
 
   it('has default state of anchorElement as null', () => {
-    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
 
     expect(mountedMenuContainer.state('anchorElement')).toEqual(null);
   })
 
   it('matches the snapshot if props.skipInRunAll is false and anchorElement is null', () => {
-    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
 
     expect(mountedMenuContainer).toMatchSnapshot();
   })
 
   it('matches the snapshot if props.skipInRunAll is true', () => {
     props.skipInRunAll = true;
-    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
 
     expect(mountedMenuContainer).toMatchSnapshot();
   })
 
   it('matches the snapshot if state.anchorElement is not null', () => {
-    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
     mountedMenuContainer.setState({ anchorElement: 'not null' })
     mountedMenuContainer.update();
 
-    expect(mountedMenuContainer).toMatchSnapshot(); 
+    expect(mountedMenuContainer).toMatchSnapshot();
   })
 
   describe('handleClick', () => {
     it('updates anchorElement in state with the currentTarget of the clicked element', () => {
-      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
 
       mountedMenuContainer.find('.cell-type-label').simulate('click', { currentTarget: 'a target' });
 
@@ -58,8 +58,8 @@ describe('CellMenuContainerUnconnected', () => {
 
   describe('handleIconButtonClose', () => {
     it('updates anchorElement in state to null', () => {
-      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
-      
+      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected {...props} />);
+
       mountedMenuContainer.find('#cell-menu').simulate('close');
 
       expect(mountedMenuContainer.state('anchorElement')).toBeNull();
@@ -73,25 +73,25 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
 
   beforeEach(() => {
     state = {
-      cells: [{ 
+      cells: [{
         asyncProcessCount: 0,
-        cellType: "code",
-        content: "",
-        evalStatus: "UNEVALUATED",
-        executionStatus: " ",
+        cellType: 'code',
+        content: '',
+        evalStatus: 'UNEVALUATED',
+        executionStatus: ' ',
         id: 0,
-        language: "js",
+        language: 'js',
         rendered: false,
         selected: true,
         skipInRunAll: false,
-        value: undefined
+        value: undefined,
       }],
-      title: 'untitled'
-    };   
+      title: 'untitled',
+    };
     ownProps = { cellId: 0 };
-    notebookUtils.getCellById = jest.fn().mockImplementation(() => state.cells[0]);    
+    notebookUtils.getCellById = jest.fn().mockImplementation(() => state.cells[0]);
   })
-  
+
   it('calls getCellById with the correct arguments', () => {
     mapStateToProps(state, ownProps);
 
@@ -101,7 +101,7 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "code"', () => {
     const expected = {
       label: 'js',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
@@ -109,10 +109,10 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "markdown"', () => {
-    state.cells[0].cellType = 'markdown'; 
+    state.cells[0].cellType = 'markdown';
     const expected = {
       label: 'md',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
@@ -120,10 +120,10 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "css"', () => {
-    state.cells[0].cellType = 'css'; 
+    state.cells[0].cellType = 'css';
     const expected = {
       label: 'css',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
@@ -131,10 +131,10 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "plugin"', () => {
-    state.cells[0].cellType = 'plugin'; 
+    state.cells[0].cellType = 'plugin';
     const expected = {
       label: 'plugin',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
@@ -142,10 +142,10 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "external dependencies"', () => {
-    state.cells[0].cellType = 'external dependencies'; 
+    state.cells[0].cellType = 'external dependencies';
     const expected = {
       label: 'resource',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
@@ -153,22 +153,20 @@ describe('CellMenuContainerUnconnected mapStateToProps', () => {
   })
 
   it('returns an object with correct label and skipInRunAll key value pairs if cellType is "raw"', () => {
-    state.cells[0].cellType = 'raw'; 
+    state.cells[0].cellType = 'raw';
     const expected = {
       label: 'raw',
-      skipInRunAll: false
+      skipInRunAll: false,
     };
     const result = mapStateToProps(state, ownProps);
 
     expect(result).toEqual(expected);
   })
-
 })
 
 describe('mapDispatchToProps', () => {
   it('returns an object with actions as a property', () => {
     const dispatch = jest.fn();
-    const actions = {};
     const result = mapDispatchToProps(dispatch);
 
     expect(result).toHaveProperty('actions');

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -41,9 +41,15 @@ describe('CellMenuContainerUnconnected', () => {
 })
 
 describe('CellMenuContainerUnconnected mapStateToProps', () => {
+  it('calls getCellById with the correct arguments', () => {
 
+  })
+
+  it('returns an object with label and skipInRunAll key value pairs', () => {
+
+  })
 })
 
 describe('CellMenuContainerUnconnected mapDispatchToProps', () => {
-
+  
 })

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -24,7 +24,10 @@ describe('CellMenuContainerUnconnected', () => {
   })
 
   it('matches the snapshot if props.skipInRunAll is true', () => {
+    props.skipInRunAll = true;
+    const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
+    expect(mountedMenuContainer).toMatchSnapshot();
   })
 
   it('matches the snapshot if props.skipInRunAll is false', () => {

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -45,7 +45,7 @@ describe('CellMenuContainerUnconnected', () => {
   })
 
   describe('handleClick', () => {
-    it('updates anchorElement in state with the button clicked', () => {
+    it('updates anchorElement in state with the currentTarget of the clicked element', () => {
       const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
 
       mountedMenuContainer.find('.cell-type-label').simulate('click', { currentTarget: 'a target' });
@@ -56,7 +56,11 @@ describe('CellMenuContainerUnconnected', () => {
 
   describe('handleIconButtonClose', () => {
     it('updates anchorElement in state to null', () => {
+      const mountedMenuContainer = shallow(<CellMenuContainerUnconnected { ...props } />);
+      
+      mountedMenuContainer.find('#cell-menu').simulate('close');
 
+      expect(mountedMenuContainer.state('anchorElement')).toBeNull();
     })
   })
 })

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -6,6 +6,8 @@ import {
   mapDispatchToProps
 } from '../cell-menu-container';
 
+import * as notebookUtils from '../../../tools/notebook-utils'
+
 describe('CellMenuContainerUnconnected', () => {
   let props;
 
@@ -66,13 +68,109 @@ describe('CellMenuContainerUnconnected', () => {
 })
 
 describe('CellMenuContainerUnconnected mapStateToProps', () => {
+  let state;
+  let ownProps;
+
+  beforeEach(() => {
+    state = {
+      cells: [{ 
+        asyncProcessCount: 0,
+        cellType: "code",
+        content: "",
+        evalStatus: "UNEVALUATED",
+        executionStatus: " ",
+        id: 0,
+        language: "js",
+        rendered: false,
+        selected: true,
+        skipInRunAll: false,
+        value: undefined
+      }],
+      title: 'untitled'
+    };   
+    ownProps = { cellId: 0 };
+    notebookUtils.getCellById = jest.fn().mockImplementation(() => state.cells[0]);    
+  })
+  
   it('calls getCellById with the correct arguments', () => {
+    mapStateToProps(state, ownProps);
 
+    expect(notebookUtils.getCellById).toHaveBeenCalledWith(state.cells, ownProps.cellId);
   })
 
-  it('returns an object with label and skipInRunAll key value pairs', () => {
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "code"', () => {
+    const expected = {
+      label: 'js',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
 
+    expect(result).toEqual(expected);
   })
+
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "markdown"', () => {
+    state.cells[0].cellType = 'markdown'; 
+    const expected = {
+      label: 'md',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
+
+    expect(result).toEqual(expected);
+  })
+
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "css"', () => {
+    state.cells[0].cellType = 'css'; 
+    const expected = {
+      label: 'css',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
+
+    expect(result).toEqual(expected);
+  })
+
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "plugin"', () => {
+    state.cells[0].cellType = 'plugin'; 
+    const expected = {
+      label: 'plugin',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
+
+    expect(result).toEqual(expected);
+  })
+
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "external dependencies"', () => {
+    state.cells[0].cellType = 'external dependencies'; 
+    const expected = {
+      label: 'resource',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
+
+    expect(result).toEqual(expected);
+  })
+
+  it('returns an object with correct label and skipInRunAll key value pairs if cellType is "raw"', () => {
+    state.cells[0].cellType = 'raw'; 
+    const expected = {
+      label: 'raw',
+      skipInRunAll: false
+    };
+    const result = mapStateToProps(state, ownProps);
+
+    expect(result).toEqual(expected);
+  })
+
 })
 
+describe('mapDispatchToProps', () => {
+  it('returns an object with actions as a property', () => {
+    const dispatch = jest.fn();
+    const actions = {};
+    const result = mapDispatchToProps(dispatch);
 
+    expect(result).toHaveProperty('actions');
+  })
+})

--- a/src/components/cells/__tests__/cell-menu-container.test.js
+++ b/src/components/cells/__tests__/cell-menu-container.test.js
@@ -7,7 +7,37 @@ import {
 } from '../cell-menu-container';
 
 describe('CellMenuContainerUnconnected', () => {
+  it('has default state of anchorElement as null', () => {
 
+  })
+
+  it('matches the snapshot if props.skipInRunAll is true', () => {
+
+  })
+
+  it('matches the snapshot if props.skipInRunAll is false', () => {
+
+  })
+
+  it('matches the snapshot if state.anchorElement is not null', () => {
+
+  })
+
+  it('matches the snapshot if state.anchorElement is null', () => {
+
+  })
+
+  describe('handleClick', () => {
+    it('updates anchorElement in state with the button clicked', () => {
+
+    })
+  })
+
+  describe('handleIconButtonClose', () => {
+    it('updates anchorElement in state to null', () => {
+
+    })
+  })
 })
 
 describe('CellMenuContainerUnconnected mapStateToProps', () => {

--- a/src/components/cells/cell-menu-container.js
+++ b/src/components/cells/cell-menu-container.js
@@ -95,7 +95,7 @@ export class CellMenuContainerUnconnected extends React.Component {
 }
 
 
-function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state, ownProps) {
   const { cellId } = ownProps
   const cell = getCellById(state.cells, cellId)
   let label
@@ -118,7 +118,7 @@ function mapStateToProps(state, ownProps) {
   }
 }
 
-function mapDispatchToProps(dispatch) {
+export function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(actions, dispatch),
   }


### PR DESCRIPTION
We noticed [cell-menu-container.js](https://github.com/iodide-project/iodide/blob/master/src/components/cells/cell-menu-container.js) had 0% coverage, so we created the test file and added 14 tests and got this file up to 94% coverage. 

The one line that says it is still not covered (line 112) is tested on line 155 in the cell-menu-container.test.js, so unsure why it says it is not covered. 

![Passing Tests](https://i.imgur.com/vhdcQSn.png)