### PR TITLE
consolidate our webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8964,9 +8964,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mississippi": {
@@ -9021,6 +9021,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mousetrap": {
@@ -9607,10 +9615,16 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "license": "MPL-2.0",
   "scripts": {
     "test": "jest --no-cache",
-    "start": "webpack-dev-server --watch --env dev",
-    "build": "webpack --env production",
+    "start-and-serve": "webpack-dev-server --watch --env=dev-client-only",
+    "start": "webpack --watch --env=dev",
+    "build": "webpack --env=production",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix",
-    "build-server": "webpack --env server"
+    "build-server": "webpack --env=server"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
@@ -87,6 +88,7 @@
     "jest": "^21.2.1",
     "jest-cli": "^22.4.3",
     "jest-localstorage-mock": "^2.2.0",
+    "minimist": "^1.2.0",
     "neutrino": "^8.2.3",
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^15.6.1",

--- a/readme.md
+++ b/readme.md
@@ -43,16 +43,17 @@ Run `npm install` after cloning this repository.
 
 ## Running/Building
 
-### Development mode
+### Client-only mode
 
-Use `npm run start` to write development versions of the Iodide app resources to `dev/` and to serve the files in that folder at `http://localhost:8888`. You can open
-`http://localhost:8888/iodide.dev.html` in your browser to get started with a blank notebook, or open `http://localhost:8888` to see the list of files saved in `dev/` (in case you have saved other test notebooks in that folder)
+If you're only working on client code and don't need to use/test any of the server functionality described below. You can use `npm run start-and-serve` to write development versions of the Iodide client-side app resources to `dev/` and to serve the files in that folder at `http://localhost:8000`. You can open `http://localhost:8000/iodide.dev.html` in your browser to get started with a blank notebook, or open `http://localhost:8000` to see the list of files saved in `dev/` (in case you have exported other test notebooks in that folder)
 
-The command `npm run start` runs in watch mode, so changes to files will be detected and bundled into `dev/` automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
+The command `npm run start-and-serve` runs in watch mode, so changes to files will be detected and bundled into `dev/` automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
 
-#### Exporting from dev mode
+If you require verbose Redux logging, you can use the command `npm run start-and-serve -- reduxVerbose`
 
-In dev mode, resource paths are set to be relative to the `dev/` directory. Thus, you export a bundled notebook from a dev notebook, you need to be sure save the exported HTML file in the `dev/` folder for the relative paths to correctly resolve the required js/css/font files (and if you want to share a notebook that you created in a dev environment, you'll need to update the paths to point to the web-accessible resources at iodide.io).
+#### Exporting from client-only dev mode
+
+In this mode, resource paths are set to be relative to the `dev/` directory. Thus, if you export a bundled notebook from a dev notebook, you need to be sure save the exported HTML file in the `dev/` folder for the relative paths to correctly resolve the required js, css, and font files (and if you want to share a notebook that you created in a dev environment, you'll need to update the paths to point to the web-accessible resources at `iodide.io` and `iodide.app`).
 
 
 ### Server mode
@@ -66,6 +67,10 @@ it supports are login/identity (via the github API). To test/run it locally, fol
 * Make sure you have [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) installed and working correctly
 * Run `make build && make up`
 * You should now be able to navigate to a test server instance at http://localhost:8000
+
+On subsequent runs, you only need to run `make up`.
+
+Additionally, if you are working on client code, you can run `npm run start` in a separate terminal to run webpack in watch mode (which will make your client code changes visible on page reload). If you require verbose Redux logging, you can use the command `npm run start -- reduxVerbose`
 
 ## Testing
 

--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -7,5 +7,5 @@
 <script>
   window.userData = {{ user_info|safe }}
 </script>
-<script src="/iodide.iodide-server.js"></script>
+<script src="/iodide.dev.js"></script>
 {% endblock %}

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
-<link rel="stylesheet" type="text/css" href="/iodide.iodide-server.css">
+<link rel="stylesheet" type="text/css" href="/iodide.dev.css">
 <body>
   {% block content %}{% endblock %}
 </body>

--- a/src/eval-frame/store.js
+++ b/src/eval-frame/store.js
@@ -1,4 +1,4 @@
-/* global IODIDE_BUILD_MODE */
+/* global IODIDE_BUILD_MODE IODIDE_REDUX_LOG_MODE */
 import { applyMiddleware, compose, createStore } from 'redux'
 import thunk from 'redux-thunk'
 import { createLogger } from 'redux-logger'
@@ -10,7 +10,13 @@ import { stateSchema, newNotebook } from './eval-frame-state-prototypes'
 let enhancer
 let finalReducer
 
-if (IODIDE_BUILD_MODE === 'dev' || IODIDE_BUILD_MODE === 'devperf') {
+if (IODIDE_BUILD_MODE === 'production') {
+  finalReducer = reducer
+  enhancer = applyMiddleware(thunk)
+} else if (IODIDE_BUILD_MODE === 'test' || IODIDE_REDUX_LOG_MODE === 'SILENT') {
+  finalReducer = createValidatedReducer(reducer, stateSchema)
+  enhancer = applyMiddleware(thunk)
+} else {
   finalReducer = createValidatedReducer(reducer, stateSchema)
   enhancer = compose(
     applyMiddleware(thunk),
@@ -19,12 +25,6 @@ if (IODIDE_BUILD_MODE === 'dev' || IODIDE_BUILD_MODE === 'devperf') {
       colors: { title: () => '#27ae60' },
     })),
   )
-} else if (IODIDE_BUILD_MODE === 'test') {
-  finalReducer = createValidatedReducer(reducer, stateSchema)
-  enhancer = applyMiddleware(thunk)
-} else {
-  finalReducer = reducer
-  enhancer = applyMiddleware(thunk)
 }
 
 const initialState = newNotebook()


### PR DESCRIPTION
@wlach -- with @mdboom having completed #748, can you jump in to get this over the line?

i think you should be able to build off this PR, which a bunch of changes to consolidate our webpack config and get things working and streamlined since most of our testing will be done using the django server going forward.

things to note:
- since we're not yet really versioning our resources, i don't think we need to have e.g. `iodide.X.js` for X = {master, stable, dev, iodide-server} all floating around. so this config just uses the 'dev' label everywhere other than tags (since really all this stuff is "dev" until we decide to get serious about versioning).

- we'll probably need to move some of the stuff about which origin a given instance is being served from to the `.env` file (which will need to be configured per origin anyway since we'll need different GH secrets etc). this way, the `.env` file can pass the correct origin into the python and webpack templates.

i think other changes will be needed, but this should be a start.