### PR TITLE
Add keybindings for resizing frames

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -422,6 +422,18 @@ export function toggleEditorLink() {
   }
 }
 
+export function increaseEditorWidth() {
+  return {
+    type: 'INCREASE_EDITOR_WIDTH',
+  }
+}
+
+export function decreaseEditorWidth() {
+  return {
+    type: 'DECREASE_EDITOR_WIDTH',
+  }
+}
+
 export function changeSidePaneMode(mode) {
   return {
     type: 'CHANGE_SIDE_PANE_MODE',

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -407,6 +407,20 @@ tasks.setViewModeToPresentation = new UserTask({
 //   callback() { dispatcher.toggleEvalFrameVisibility() },
 // })
 
+tasks.increaseEditorWidth = new UserTask({
+  title: 'Set Editor Size',
+  keybindings: ['ctrl+right'],
+  keybindingPrecondition: isCommandMode,
+  callback() { dispatcher.increaseEditorWidth() },
+})
+
+tasks.decreaseEditorWidth = new UserTask({
+  title: 'Set Editor Size',
+  keybindings: ['ctrl+left'],
+  keybindingPrecondition: isCommandMode,
+  callback() { dispatcher.decreaseEditorWidth() },
+})
+
 tasks.fileAnIssue = new ExternalLinkTask({
   title: 'File an Issue',
   menuTitle: 'File an Issue ...',

--- a/src/components/editor-pane-container.jsx
+++ b/src/components/editor-pane-container.jsx
@@ -17,6 +17,7 @@ class EditorPaneContainer extends React.Component {
     cellResizerDisplayStyle: PropTypes.string.isRequired,
     cellResizerWidth: PropTypes.number.isRequired,
     cellIds: PropTypes.array.isRequired,
+    paneMinWidth: PropTypes.number.isRequired,
     // showFrame: PropTypes.bool.isRequired,
   }
   constructor(props) {
@@ -54,7 +55,7 @@ class EditorPaneContainer extends React.Component {
           }}
           handleClasses={{ right: 'resizer' }}
           bounds="window"
-          minWidth={0}
+          minWidth={this.props.paneMinWidth}
           onResizeStop={this.onResizeStopHandler}
           size={{ width: this.props.cellResizerWidth }}
           style={{
@@ -62,7 +63,7 @@ class EditorPaneContainer extends React.Component {
             flexDirection: 'column',
           }}
         >
-          <div style={this.props.cellsClass} id="cells">
+          <div style={this.props.cellsStyle} id="cells">
 
             {cellInputComponents}
           </div>
@@ -73,16 +74,17 @@ class EditorPaneContainer extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const cellsClass = { padding: '15px 15px 20px 15px' }
+  const cellsStyle = { padding: '15px 15px 20px 15px' }
   if (state.editorWidth < 30) {
-    cellsClass.padding = '15px 0 20px 0'
+    cellsStyle.padding = '15px 0 20px 0'
   }
   return {
     cellIds: state.cells.map(c => c.id),
     cellResizerWidth: state.editorWidth,
     cellResizerDisplayStyle: state.viewMode === 'REPORT_VIEW' ? 'none' : 'flex',
     // showFrame: state.showFrame,
-    cellsClass,
+    cellsStyle,
+    paneMinWidth: state.editorWidth ? 300 : 0,
   }
 }
 

--- a/src/components/editor-pane-container.jsx
+++ b/src/components/editor-pane-container.jsx
@@ -54,7 +54,7 @@ class EditorPaneContainer extends React.Component {
           }}
           handleClasses={{ right: 'resizer' }}
           bounds="window"
-          minWidth={300}
+          minWidth={0}
           onResizeStop={this.onResizeStopHandler}
           size={{ width: this.props.cellResizerWidth }}
           style={{
@@ -62,7 +62,7 @@ class EditorPaneContainer extends React.Component {
             flexDirection: 'column',
           }}
         >
-          <div id="cells">
+          <div style={this.props.cellsClass} id="cells">
 
             {cellInputComponents}
           </div>
@@ -73,11 +73,16 @@ class EditorPaneContainer extends React.Component {
 }
 
 function mapStateToProps(state) {
+  const cellsClass = { padding: '15px 15px 20px 15px' }
+  if (state.editorWidth < 30) {
+    cellsClass.padding = '15px 0 20px 0'
+  }
   return {
     cellIds: state.cells.map(c => c.id),
     cellResizerWidth: state.editorWidth,
     cellResizerDisplayStyle: state.viewMode === 'REPORT_VIEW' ? 'none' : 'flex',
     // showFrame: state.showFrame,
+    cellsClass,
   }
 }
 

--- a/src/components/panes/side-pane.jsx
+++ b/src/components/panes/side-pane.jsx
@@ -52,7 +52,7 @@ export class SidePaneUnconnected extends React.Component {
               }}
               handleClasses={{ left: 'resizer' }}
               maxWidth={800}
-              minWidth={300}
+              minWidth={100}
               size={{
                 width: this.props.sidePaneMode === this.props.openOnMode ?
                        this.props.sidePaneWidth :

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -5,11 +5,14 @@
 
 // for editorWidth calc. We're using this
 // because re-resizable doesn't intelligently deal w/ calc(100% - 20px) or whatever.
-const DEFAULT_EDITOR_WIDTH = Math.round(document.documentElement.clientWidth / 2)
+const SCREEN_WIDTH = document.documentElement.clientWidth
+const DEFAULT_EDITOR_WIDTH = Math.round(SCREEN_WIDTH / 2)
 // Math.max(
 //   document.documentElement.clientWidth - 600,
 //   (window.innerWidth - 600) || 0,
 // )
+
+export const paneSizes = [0, 0.33, 0.5, 0.66, 1].map(x => Math.round(x * SCREEN_WIDTH))
 
 const StringEnum = class {
   constructor(...vals) {

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -5,14 +5,13 @@
 
 // for editorWidth calc. We're using this
 // because re-resizable doesn't intelligently deal w/ calc(100% - 20px) or whatever.
-const SCREEN_WIDTH = document.documentElement.clientWidth
-const DEFAULT_EDITOR_WIDTH = Math.round(SCREEN_WIDTH / 2)
+const DEFAULT_EDITOR_WIDTH = Math.round(document.documentElement.clientWidth / 2)
 // Math.max(
 //   document.documentElement.clientWidth - 600,
 //   (window.innerWidth - 600) || 0,
 // )
 
-export const paneSizes = [0, 0.33, 0.5, 0.66, 1].map(x => Math.round(x * SCREEN_WIDTH))
+export const paneRatios = [0, 0.33, 0.5, 0.66, 1]
 
 const StringEnum = class {
   constructor(...vals) {

--- a/src/eval-frame/actions/eval-frame-tasks.js
+++ b/src/eval-frame/actions/eval-frame-tasks.js
@@ -45,6 +45,20 @@ tasks.closePanes = new UserTask({
   },
 })
 
+tasks.increaseEditorWidth = new UserTask({
+  title: 'Set Editor Size',
+  keybindings: ['ctrl+right'],
+  preventDefaultKeybinding: true,
+  callback() { postKeypressToEditor(this.keybindings[0]) },
+})
+
+tasks.decreaseEditorWidth = new UserTask({
+  title: 'Set Editor Size',
+  keybindings: ['ctrl+left'],
+  preventDefaultKeybinding: true,
+  callback() { postKeypressToEditor(this.keybindings[0]) },
+})
+
 tasks.toggleDeclaredVariablesPane = new UserTask({
   title: 'Toggle the Declared Variables Pane',
   menuTitle: 'Declared Variables',

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -29,6 +29,8 @@ const approvedKeys = [
   'ctrl+d',
   'ctrl+h',
   'ctrl+i',
+  'ctrl+left',
+  'ctrl+right',
 ]
 
 function receiveMessage(event) {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,5 +1,5 @@
 import copy from 'copy-to-clipboard';
-import { newNotebook, newCell, newCellID } from '../editor-state-prototypes'
+import { newNotebook, newCell, newCellID, paneSizes } from '../editor-state-prototypes'
 import {
   exportJsmdBundle,
   exportJsmdToString,
@@ -204,6 +204,29 @@ const notebookReducer = (state = newNotebook(), action) => {
       const width = state.editorWidth + action.widthShift
       return Object.assign({}, state, { editorWidth: width })
     }
+
+    /* eslint-disable prefer-destructuring */
+
+    case 'INCREASE_EDITOR_WIDTH': {
+      let width = state.editorWidth
+      if (width < paneSizes[1]) width = paneSizes[1]
+      else if (width < paneSizes[2]) width = paneSizes[2]
+      else if (width < paneSizes[3]) width = paneSizes[3]
+      else width = paneSizes[4]
+      return Object.assign({}, state, { editorWidth: width })
+    }
+
+    case 'DECREASE_EDITOR_WIDTH': {
+      let width = state.editorWidth
+      if (width > paneSizes[3]) width = paneSizes[3]
+      else if (width > paneSizes[2]) width = paneSizes[2]
+      else if (width > paneSizes[1]) width = paneSizes[1]
+      else width = paneSizes[0]
+      console.log(width, document.documentElement.clientWidth)
+      return Object.assign({}, state, { editorWidth: width })
+    }
+
+    /* eslint-enable prefer-destructuring */
 
     case 'INCREMENT_EXECUTION_NUMBER': {
       let { executionNumber } = state

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,5 +1,5 @@
 import copy from 'copy-to-clipboard';
-import { newNotebook, newCell, newCellID, paneSizes } from '../editor-state-prototypes'
+import { newNotebook, newCell, newCellID, paneRatios } from '../editor-state-prototypes'
 import {
   exportJsmdBundle,
   exportJsmdToString,
@@ -208,6 +208,8 @@ const notebookReducer = (state = newNotebook(), action) => {
     /* eslint-disable prefer-destructuring */
 
     case 'INCREASE_EDITOR_WIDTH': {
+      const SCREEN_WIDTH = document.documentElement.clientWidth
+      const paneSizes = paneRatios.map(x => Math.round(x * SCREEN_WIDTH))
       let width = state.editorWidth
       if (width < paneSizes[1]) width = paneSizes[1]
       else if (width < paneSizes[2]) width = paneSizes[2]
@@ -217,12 +219,13 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case 'DECREASE_EDITOR_WIDTH': {
+      const SCREEN_WIDTH = document.documentElement.clientWidth
+      const paneSizes = paneRatios.map(x => Math.round(x * SCREEN_WIDTH))
       let width = state.editorWidth
       if (width > paneSizes[3]) width = paneSizes[3]
       else if (width > paneSizes[2]) width = paneSizes[2]
       else if (width > paneSizes[1]) width = paneSizes[1]
       else width = paneSizes[0]
-      console.log(width, document.documentElement.clientWidth)
       return Object.assign({}, state, { editorWidth: width })
     }
 

--- a/src/style/top-level-container-styles.css
+++ b/src/style/top-level-container-styles.css
@@ -30,7 +30,7 @@ div#panes-container {
 
 div#editor-react-root{
   /* this prevents the resizer from getting too wide and covering the eval frame*/
-  max-width: calc(100% - 300px);
+  max-width: calc(100%);
 }
 
 div#cells-resizer {
@@ -44,10 +44,6 @@ div#cells {
   box-sizing: border-box;
   /*height: 100%;*/
   overflow-y: auto;
-  padding-top: 15px;
-  padding-left: 15px;
-  padding-right: 15px;
-  padding-bottom: 20px;
   border-right: 2px solid lightgray;
 }
 


### PR DESCRIPTION
This implements `Ctrl+left` and `Ctrl+right` keybindings which help you resize the two frames in steps of 0%, 33%, 50%, 66% and 100% .

Closes Issue #726 

<!---
@huboard:{"order":754.0,"milestone_order":725.8911181472779,"custom_state":""}
-->
