### PR TITLE
Cell Cut Copy Paste Highlight for Iframe2

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -463,3 +463,37 @@ export function saveEnvironment(updateObj, update) {
     update,
   }
 }
+
+export function highlightCell(cellID, revert = true) {
+  return {
+    type: 'HIGHLIGHT_CELL',
+    id: cellID,
+    revert,
+  }
+}
+export function unHighlightCells() {
+  return {
+    type: 'UNHIGHLIGHT_CELLS',
+  }
+}
+export function multipleCellHighlight(cellID) {
+  return {
+    type: 'MULTIPLE_CELL_HIGHLIGHT',
+    id: cellID,
+  }
+}
+export function cellCopy() {
+  return {
+    type: 'CELL_COPY',
+  }
+}
+export function cellCut() {
+  return {
+    type: 'CELL_CUT',
+  }
+}
+export function cellPaste() {
+  return {
+    type: 'CELL_PASTE',
+  }
+}

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -8,6 +8,7 @@ import {
   getCellBelowSelectedId,
   getCellAboveSelectedId, prettyDate, formatDateString,
 } from '../tools/notebook-utils'
+import { getSelectedCellId } from '../reducers/cell-reducer-utils'
 import { stateFromJsmd } from '../tools/jsmd-tools'
 
 const dispatcher = {}
@@ -69,8 +70,8 @@ tasks.evaluateCellAndSelectBelow = new UserTask({
 
 tasks.moveCellUp = new UserTask({
   title: 'Move Cell Up',
-  displayKeybinding: 'Shift+Up', // '\u21E7 \u2191',
-  keybindings: ['shift+up'],
+  displayKeybinding: `${commandKey()}+Up`,
+  keybindings: ['ctrl+up', 'meta+up'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
@@ -81,12 +82,44 @@ tasks.moveCellUp = new UserTask({
 
 tasks.moveCellDown = new UserTask({
   title: 'Move Cell Down',
-  displayKeybinding: 'Shift+Down', // '\u21E7 \u2193',
-  keybindings: ['shift+down'],
+  displayKeybinding: `${commandKey()}+Down`,
+  keybindings: ['ctrl+down', 'meta+down'],
   keybindingPrecondition: isCommandMode,
   preventDefaultKeybinding: true,
   callback() {
     dispatcher.cellDown()
+  },
+})
+
+tasks.highlightUp = new UserTask({
+  title: 'Select Cell Above',
+  displayKeybinding: 'Shift+Up', // '\u21E7 \u2191',
+  keybindings: ['shift+up'],
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() {
+    const cellAboveId = getCellAboveSelectedId()
+    dispatcher.highlightCell(getSelectedCellId(store.getState()), false)
+    if (cellAboveId !== null) {
+      dispatcher.highlightCell(cellAboveId, false)
+      dispatcher.selectCell(cellAboveId, true)
+    }
+  },
+})
+
+tasks.highlightDown = new UserTask({
+  title: 'Select Cell Down',
+  displayKeybinding: 'Shift+Up', // '\u21E7 \u2193',
+  keybindings: ['shift+down'],
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() {
+    const cellBelowId = getCellBelowSelectedId()
+    dispatcher.highlightCell(getSelectedCellId(store.getState()), false)
+    if (cellBelowId !== null) {
+      dispatcher.highlightCell(cellBelowId, false)
+      dispatcher.selectCell(cellBelowId, true)
+    }
   },
 })
 
@@ -113,7 +146,10 @@ tasks.selectUp = new UserTask({
   preventDefaultKeybinding: true,
   callback() {
     const cellAboveId = getCellAboveSelectedId()
-    if (cellAboveId !== null) { dispatcher.selectCell(cellAboveId, true) }
+    if (cellAboveId !== null) {
+      dispatcher.selectCell(cellAboveId, true)
+      dispatcher.unHighlightCells()
+    }
   },
 })
 
@@ -125,8 +161,38 @@ tasks.selectDown = new UserTask({
   preventDefaultKeybinding: true,
   callback() {
     const cellBelowId = getCellBelowSelectedId()
-    if (cellBelowId !== null) { dispatcher.selectCell(cellBelowId, true) }
+    if (cellBelowId !== null) {
+      dispatcher.selectCell(cellBelowId, true)
+      dispatcher.unHighlightCells()
+    }
   },
+})
+
+tasks.copyCell = new UserTask({
+  title: 'Copy Cell',
+  keybindings: ['ctrl+c', 'command+c'],
+  displayKeybinding: `${commandKey()}+C`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellCopy() },
+})
+
+tasks.cutCell = new UserTask({
+  title: 'Cut Cell',
+  keybindings: ['ctrl+x', 'command+x'],
+  displayKeybinding: `${commandKey()}+X`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellCut() },
+})
+
+tasks.pasteCell = new UserTask({
+  title: 'Paste Cell',
+  keybindings: ['ctrl+v', 'command+v'],
+  displayKeybinding: `${commandKey()}+V`,
+  keybindingPrecondition: isCommandMode,
+  preventDefaultKeybinding: true,
+  callback() { dispatcher.cellPaste() },
 })
 
 tasks.scrollOutputPaneToCell = new UserTask({

--- a/src/components/cells/__tests__/cell-container.test.js
+++ b/src/components/cells/__tests__/cell-container.test.js
@@ -8,6 +8,9 @@ import CellEditor from '../cell-editor'
 describe('CellContainerUnconnected React component', () => {
   let selectCell
   let updateCellProperties
+  let highlightCell
+  let unHighlightCells
+  let multipleCellHighlight
   let props
   let mountedCont
   const node = <span>Hello</span>
@@ -22,9 +25,15 @@ describe('CellContainerUnconnected React component', () => {
   beforeEach(() => {
     selectCell = jest.fn()
     updateCellProperties = jest.fn()
+    highlightCell = jest.fn()
+    unHighlightCells = jest.fn()
+    multipleCellHighlight = jest.fn()
     props = {
       cellId: 1,
-      cellContainerStyle: { outline: 'CONTAINER_OUTLINE_TEST_STRING' },
+      cellContainerStyle: {
+        outline: 'CONTAINER_OUTLINE_TEST_STRING',
+        background: 'CONTAINER_BACKGROUND_TEST_STRING',
+      },
       mainComponentStyle: {
         outline: 'MAIN_COMPONENT_OUTLINE_TEST_STRING',
         display: 'MAIN_COMPONENT_DISPLAY_TEST_STRING',
@@ -35,6 +44,9 @@ describe('CellContainerUnconnected React component', () => {
       // action props
       selectCell,
       updateCellProperties,
+      highlightCell,
+      unHighlightCells,
+      multipleCellHighlight,
     }
     mountedCont = undefined
   })
@@ -63,17 +75,53 @@ describe('CellContainerUnconnected React component', () => {
       .toEqual(cellContainer().instance().handleCellClick)
   })
 
-  it('mousedown on cell container div fires selectCell with cell not selected', () => {
+  it('mouse down on cell container div fires selectCell with correct props', () => {
+    props.viewMode = 'editor'
     props.selected = false
-    cellContainer().simulate('mousedown')
+    cellContainer().simulate('mousedown', {
+      ctrlKey: false,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
     expect(selectCell.mock.calls.length).toBe(1)
     expect(selectCell.mock.calls[0].length).toBe(2)
   })
 
-  it('mousedown on cell container div DOES NOT fires selectCell if cell is selected', () => {
-    props.selected = true
-    cellContainer().simulate('mousedown')
-    expect(selectCell.mock.calls.length).toBe(0)
+  it('mouse down on cell container div fires unHighlightCells with correct props', () => {
+    props.viewMode = 'editor'
+    props.highlighted = true
+    cellContainer().simulate('mousedown', {
+      ctrlKey: false,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
+    expect(unHighlightCells.mock.calls.length).toBe(1)
+    expect(unHighlightCells.mock.calls[0].length).toBe(0)
+  })
+
+  it('mouse down on cell container fires multipleCellHighlight with Shift press', () => {
+    props.viewMode = 'editor'
+    cellContainer().simulate('mousedown', {
+      shiftKey: true,
+      ctrlKey: true,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+      preventDefault: () => {
+      },
+    })
+    expect(multipleCellHighlight.mock.calls.length).toBe(1)
+    expect(multipleCellHighlight.mock.calls[0].length).toBe(1)
+  })
+
+  it('mouse down on cell container fires highlightCell with correct props and Ctrl press', () => {
+    props.viewMode = 'editor'
+    cellContainer().simulate('mousedown', {
+      ctrlKey: true,
+      metaKey: false,
+      target: document.createElement('mockElement'),
+    })
+    expect(highlightCell.mock.calls.length).toBe(1)
+    expect(highlightCell.mock.calls[0].length).toBe(1)
   })
 
   it('always renders one CellMenuContainer inside top div', () => {
@@ -111,31 +159,51 @@ describe('CellContainer mapStateToProps', () => {
   const stateToContainerStylesMappings = [
     {
       state: {
-        cells: [{ id: 5, selected: true, inputFolding: 'VISIBLE' }],
+        cells: [{
+          id: 5,
+          highlighted: false,
+          selected: true,
+          inputFolding: 'VISIBLE',
+        }],
         mode: 'EDIT_MODE',
       },
-      style: { outline: 'solid #bbb 1px' },
+      style: { outline: 'solid #bbb 1px', background: 'none' },
     },
     {
       state: {
-        cells: [{ id: 5, selected: false, inputFolding: 'VISIBLE' }],
+        cells: [{
+          id: 5,
+          highlighted: true,
+          selected: false,
+          inputFolding: 'VISIBLE',
+        }],
         mode: 'EDI_MODE',
       },
-      style: { outline: 'solid #f1f1f1 1px' },
+      style: { outline: 'solid #f1f1f1 1px', background: 'rgba(116, 185, 255, 0.2)' },
     },
     {
       state: {
-        cells: [{ id: 5, selected: true, inputFolding: 'VISIBLE' }],
+        cells: [{
+          id: 5,
+          highlighted: false,
+          selected: true,
+          inputFolding: 'VISIBLE',
+        }],
         mode: 'COMMAND_MODE',
       },
-      style: { outline: 'solid #bbb 2px' },
+      style: { outline: 'solid #bbb 2px', background: 'none' },
     },
     {
       state: {
-        cells: [{ id: 5, selected: false, inputFolding: 'VISIBLE' }],
+        cells: [{
+          id: 5,
+          highlighted: false,
+          selected: false,
+          inputFolding: 'VISIBLE',
+        }],
         mode: 'COMMAND_MODE',
       },
-      style: { outline: 'solid #f1f1f1 1px' },
+      style: { outline: 'solid #f1f1f1 1px', background: 'none' },
     },
   ]
   stateToContainerStylesMappings.forEach((testCase, i) => {

--- a/src/components/cells/cell-container.jsx
+++ b/src/components/cells/cell-container.jsx
@@ -5,7 +5,13 @@ import Tooltip from '@material-ui/core/Tooltip'
 
 import UnfoldLess from '@material-ui/icons/UnfoldLess'
 
-import { selectCell, updateCellProperties } from '../../actions/actions'
+import {
+  selectCell,
+  updateCellProperties,
+  highlightCell,
+  unHighlightCells,
+  multipleCellHighlight,
+} from '../../actions/actions'
 import { getCellById } from '../../tools/notebook-utils'
 
 import CellMenuContainer from './cell-menu-container'
@@ -28,6 +34,9 @@ export class CellContainerUnconnected extends React.Component {
     // action props
     selectCell: PropTypes.func.isRequired,
     updateCellProperties: PropTypes.func.isRequired,
+    highlightCell: PropTypes.func.isRequired,
+    unHighlightCells: PropTypes.func.isRequired,
+    multipleCellHighlight: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -36,10 +45,20 @@ export class CellContainerUnconnected extends React.Component {
     this.editor = React.createRef()
   }
 
-  handleCellClick = () => {
-    const scrollToCell = false
-    if (!this.props.selected) {
-      this.props.selectCell(this.props.cellId, scrollToCell)
+  handleCellClick = (event) => {
+    if (!event.target.classList.contains('CodeMirror-line')) {
+      const scrollToCell = false
+      if (!this.props.selected && !event.shiftKey) {
+        this.props.selectCell(this.props.cellId, scrollToCell)
+      }
+      if (event.shiftKey) {
+        event.preventDefault();
+        this.props.multipleCellHighlight(this.props.cellId)
+      } else if (event.ctrlKey || event.metaKey) {
+        this.props.highlightCell(this.props.cellId)
+      } else {
+        this.props.unHighlightCells()
+      }
     }
   }
 
@@ -96,8 +115,10 @@ export function mapStateToProps(state, ownProps) {
 
   const cellContainerBorderWidth = (cell.selected && !editingCell) ? '2px' : '1px'
   const cellContainerBorderColor = cell.selected ? '#bbb' : '#f1f1f1'
+  const cellContainerBackground = cell.highlighted ? 'rgba(116, 185, 255, 0.2)' : 'none'
   const cellContainerStyle = {
     outline: `solid ${cellContainerBorderColor} ${cellContainerBorderWidth}`,
+    background: cellContainerBackground,
   }
 
   const mainComponentStyle = {
@@ -130,6 +151,15 @@ function mapDispatchToProps(dispatch) {
     },
     updateCellProperties: (cellId, newProps) => {
       dispatch(updateCellProperties(cellId, newProps))
+    },
+    highlightCell: (cellId) => {
+      dispatch(highlightCell(cellId))
+    },
+    unHighlightCells: () => {
+      dispatch(unHighlightCells())
+    },
+    multipleCellHighlight: (cellId) => {
+      dispatch(multipleCellHighlight(cellId))
     },
   }
 }

--- a/src/components/cells/cell-editor.jsx
+++ b/src/components/cells/cell-editor.jsx
@@ -30,6 +30,7 @@ class CellEditor extends React.Component {
       selectCell: PropTypes.func.isRequired,
       changeMode: PropTypes.func.isRequired,
       updateInputContent: PropTypes.func.isRequired,
+      unHighlightCells: PropTypes.func.isRequired,
     }).isRequired,
     containerStyle: PropTypes.object,
     editorOptions: PropTypes.object,
@@ -64,6 +65,7 @@ class CellEditor extends React.Component {
   handleFocusChange(focused) {
     if (focused) {
       if (!this.props.thisCellBeingEdited) {
+        this.props.actions.unHighlightCells()
         this.props.actions.selectCell(this.props.cellId)
         this.props.actions.changeMode('EDIT_MODE')
       }
@@ -190,6 +192,12 @@ function mapStateToProps(state, ownProps) {
     cell.cellType === 'code' ? state.languages[cell.language].codeMirrorMode : cell.cellType
   )
 
+  function getReadOnly() {
+    if (state.viewMode === 'presentation') return true
+    if (cell.highlighted) return 'nocursor'
+    return false
+  }
+
   const editorOptions = {
     mode: codeMirrorModeLoaded ? codeMirrorMode : '',
     lineWrapping: false,
@@ -200,6 +208,7 @@ function mapStateToProps(state, ownProps) {
     lineNumbers: true,
     keyMap: 'sublime',
     comment: codeMirrorMode === 'javascript',
+    readOnly: getReadOnly(),
   }
   switch (cell.cellType) {
     case 'markdown':

--- a/src/components/menu/cell-menu-subsection.jsx
+++ b/src/components/menu/cell-menu-subsection.jsx
@@ -16,6 +16,9 @@ export default class CellMenuSubsection extends React.Component {
         <NotebookMenuItem key={tasks.addCellBelow.title} task={tasks.addCellBelow} />
         <NotebookMenuItem key={tasks.addCellAbove.title} task={tasks.addCellAbove} />
         <NotebookMenuItem key={tasks.deleteCell.title} task={tasks.deleteCell} />
+        <NotebookMenuItem key={tasks.copyCell.title} task={tasks.copyCell} />
+        <NotebookMenuItem key={tasks.cutCell.title} task={tasks.cutCell} />
+        <NotebookMenuItem key={tasks.pasteCell.title} task={tasks.pasteCell} />
         <NotebookMenuDivider />
         <NotebookMenuHeader title="change cell to ..." />
         <NotebookMenuItem

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -60,6 +60,7 @@ const cellSchema = {
     value: {}, // empty schema, `value` can be anything
     rendered: { type: 'boolean' },
     selected: { type: 'boolean' },
+    highlighted: { type: 'boolean' },
     executionStatus: { type: 'string' },
     evalStatus: {
       type: 'string',
@@ -110,6 +111,14 @@ const stateSchema = {
     languages: {
       type: 'object',
       additionalProperties: languageSchema,
+    },
+    copiedCells: {
+      type: 'array',
+      items: cellSchema,
+    },
+    cutCells: {
+      type: 'array',
+      items: cellSchema,
     },
     languageLastUsed: { type: 'string' },
     mode: {
@@ -198,6 +207,7 @@ function newCell(cellId, cellType = 'code', language = 'js') {
     value: undefined,
     rendered: false,
     selected: false,
+    highlighted: false,
     executionStatus: ' ',
     evalStatus: 'UNEVALUATED',
     lastEvalTime: 0,
@@ -236,6 +246,8 @@ function newNotebook() {
     appMessages: [],
     autoSave: undefined,
     locallySaved: [],
+    copiedCells: [],
+    cutCells: [],
     savedEnvironment: {},
     runningCellID: undefined,
     editorWidth: DEFAULT_EDITOR_WIDTH,

--- a/src/eval-frame/eval-frame-state-prototypes.js
+++ b/src/eval-frame/eval-frame-state-prototypes.js
@@ -76,6 +76,7 @@ const cellSchema = {
     value: {}, // empty schema, `value` can be anything
     rendered: { type: 'boolean' },
     selected: { type: 'boolean' },
+    highlighted: { type: 'boolean' },
     executionStatus: { type: 'string' },
     evalStatus: {
       type: 'string',
@@ -127,6 +128,14 @@ const stateSchema = {
     languages: {
       type: 'object',
       additionalProperties: languageSchema,
+    },
+    copiedCells: {
+      type: 'array',
+      items: cellSchema,
+    },
+    cutCells: {
+      type: 'array',
+      items: cellSchema,
     },
     languageLastUsed: { type: 'string' },
     mode: {
@@ -202,6 +211,7 @@ function newCell(cellId, cellType = 'code', language = 'js') {
     value: undefined,
     rendered: false,
     selected: false,
+    highlighted: false,
     executionStatus: ' ',
     evalStatus: 'UNEVALUATED',
     hasSideEffect: false,
@@ -236,6 +246,8 @@ function newNotebook() {
     appMessages: [],
     autoSave: undefined,
     locallySaved: [],
+    copiedCells: [],
+    cutCells: [],
     savedEnvironment: {},
     runningCellID: undefined,
   }

--- a/src/eval-frame/reducers/output-reducer-utils.js
+++ b/src/eval-frame/reducers/output-reducer-utils.js
@@ -119,6 +119,15 @@ function getSelectedCellId(state) {
   return undefined // for now
 }
 
+function getSelectedCellIndex(state) {
+  const { cells } = state
+  const index = cells.findIndex(c => c.selected)
+  if (index > -1) {
+    return index
+  }
+  return undefined // for now
+}
+
 function getCellBelowSelectedId(state) {
   const { cells } = state
   const index = cells.findIndex(c => c.selected)
@@ -138,6 +147,21 @@ function getSelectedCell(state) {
     return cells[index]
   }
   return undefined // for now
+}
+
+function checkForHighlightedCells(state) {
+  const cells = state.cells.slice()
+  return cells.find(c => c.highlighted)
+}
+
+function newStateWithPropsAssignedForHighlightedCells(state, cellPropsToSet) {
+  const cells = state.cells.slice()
+  cells.forEach((cell, i) => {
+    if (cell.highlighted) {
+      cells[i] = Object.assign({}, cell, cellPropsToSet)
+    }
+  })
+  return Object.assign({}, state, { cells })
 }
 
 function newStateWithSelectedCellPropertySet(state, cellPropToSet, newValue) {
@@ -163,8 +187,11 @@ export {
   addExternalDependency,
   getSelectedCell,
   getSelectedCellId,
+  getSelectedCellIndex,
   getCellBelowSelectedId,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 }

--- a/src/eval-frame/reducers/output-reducer.js
+++ b/src/eval-frame/reducers/output-reducer.js
@@ -7,10 +7,14 @@ import { newCell, newCellID, newNotebook } from '../eval-frame-state-prototypes'
 import {
   moveCell,
   alignCellTopTo,
+  getSelectedCell,
   getSelectedCellId,
+  getSelectedCellIndex,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 } from './output-reducer-utils'
 
 const MD = MarkdownIt({ html: true }) // eslint-disable-line
@@ -74,6 +78,124 @@ const cellReducer = (state = newNotebook(), action) => {
         { cells: action.cells },
       )
 
+    case 'HIGHLIGHT_CELL': {
+      const cells = state.cells.slice()
+      const index = cells.findIndex(c => c.id === action.id)
+      const thisCell = cells[index]
+      if (action.revert) thisCell.highlighted = !thisCell.highlighted
+      else thisCell.highlighted = true
+      nextState = Object.assign({}, state, { cells })
+      return nextState
+    }
+
+    case 'UNHIGHLIGHT_CELLS': {
+      const cells = state.cells.slice()
+      cells.forEach((c) => { c.highlighted = false }) // eslint-disable-line
+      return Object.assign({}, state, { cells })
+    }
+
+    case 'MULTIPLE_CELL_HIGHLIGHT': {
+      const cells = state.cells.slice()
+      const index1 = getSelectedCellIndex(state)
+      const index2 = cells.findIndex(c => c.id === action.id)
+      const low = Math.min(index1, index2)
+      const high = Math.max(index1, index2)
+      cells.forEach((c, index) => {
+        if (low <= index && index <= high) {
+          c.highlighted = true // eslint-disable-line
+        } else {
+          c.highlighted = false // eslint-disable-line
+        }
+      })
+      cells[index1].selected = false
+      cells[index2].selected = true
+      return Object.assign({}, state, { cells })
+    }
+
+    case 'CELL_COPY': {
+      const cutCells = []
+      const cells = state.cells.slice()
+      let copiedCells = cells.filter(c => c.highlighted)
+      if (!copiedCells.length) {
+        copiedCells = [getSelectedCell(state)]
+      }
+      return Object.assign({}, state, { copiedCells, cutCells })
+    }
+
+    case 'CELL_CUT': {
+      const copiedCells = []
+      let isNotebookEmpty = false
+      let cutCells
+      let cells = state.cells.slice()
+      cutCells = cells.filter(c => c.highlighted)
+      if (!cutCells.length) {
+        const index = getSelectedCellIndex(state)
+        cutCells = [cells[index]]
+        if (cells[index + 1]) {
+          cells[index + 1].selected = true
+        } else if (cells[index - 1]) {
+          cells[index - 1].selected = true
+        } else {
+          isNotebookEmpty = true
+        }
+        cells.splice(index, 1)
+      } else {
+        const cutIndices = cells.map((c, i) => (c.highlighted ? i : '')).filter(String)
+        const lastHiglighted = cutIndices[cutIndices.length - 1]
+        if (cells[lastHiglighted + 1]) {
+          cells[lastHiglighted + 1].selected = true
+        } else {
+          let lastUnHighlightedCell
+          let cellIndex = lastHiglighted
+          let highlightIndex = cutIndices.length - 1
+          while (highlightIndex >= 0 || cellIndex >= 0) {
+            if (cutIndices[highlightIndex] !== cellIndex) {
+              lastUnHighlightedCell = cellIndex
+              break
+            }
+            cellIndex -= 1
+            highlightIndex -= 1
+          }
+          if (lastUnHighlightedCell) {
+            cells[lastUnHighlightedCell].selected = true
+          } else {
+            isNotebookEmpty = true
+          }
+        }
+        cells = cells.filter(c => !c.highlighted)
+      }
+      if (isNotebookEmpty) {
+        const nextCell = newCell(newCellID(state.cells), 'code')
+        nextCell.selected = true
+        cells = [nextCell]
+      }
+      return Object.assign({}, state, { cells, cutCells, copiedCells })
+    }
+
+    case 'CELL_PASTE': {
+      if (state.copiedCells.length && state.cutCells.length) {
+        return state
+      }
+      const newState = Object.assign({}, state)
+      const cells = newState.cells.slice()
+      let cellsToPaste = newState.copiedCells.length ?
+        newState.copiedCells.slice()
+        :
+        newState.cutCells.slice()
+      const pasteIndex = getSelectedCellIndex(state)
+      const newId = newCellID(cells)
+      cellsToPaste = cellsToPaste.map((cell, i) => Object.assign(
+        {},
+        cell,
+        { highlighted: false, selected: false, id: newId + i },
+      ))
+      cells[pasteIndex].selected = false
+      cellsToPaste[cellsToPaste.length - 1].selected = true
+      cells.splice(pasteIndex + 1, 0, ...cellsToPaste)
+      nextState = Object.assign({}, newState, { cells: [...cells], copiedCells: [], cutCells: [] })
+      return nextState
+    }
+
     case 'CELL_UP':
       return Object.assign(
         {}, state,
@@ -86,8 +208,17 @@ const cellReducer = (state = newNotebook(), action) => {
         { cells: moveCell(state.cells, getSelectedCellId(state), 'down') },
       )
 
-    case 'UPDATE_CELL_PROPERTIES':
+    case 'UPDATE_CELL_PROPERTIES': {
+      const approvedMultipleChanges = new Set(['skipInRunAll'])
+      if (
+        checkForHighlightedCells(state) &&
+        Object.keys(action.updatedProperties).length === 1 &&
+        approvedMultipleChanges.has(Object.keys(action.updatedProperties)[0])
+      ) {
+        return newStateWithPropsAssignedForHighlightedCells(state, action.updatedProperties)
+      }
       return newStateWithPropsAssignedForCell(state, action.cellId, action.updatedProperties)
+    }
 
     case 'UPDATE_INPUT_CONTENT':
       return newStateWithSelectedCellPropertySet(state, 'content', action.content)

--- a/src/eval-frame/style/cell-styles.css
+++ b/src/eval-frame/style/cell-styles.css
@@ -12,7 +12,7 @@ div.cell-container {
   /* put the .cell-menu-container and .cell-row-container in a row */
   display: flex;
   overflow-x: auto;
-  flex-direction: row; 
+  flex-direction: row;
 }
 
 /* These may need to be integrated into the presentation mode style sheets

--- a/src/reducers/cell-reducer-utils.js
+++ b/src/reducers/cell-reducer-utils.js
@@ -100,6 +100,15 @@ function getSelectedCellId(state) {
   return undefined // for now
 }
 
+function getSelectedCellIndex(state) {
+  const { cells } = state
+  const index = cells.findIndex(c => c.selected)
+  if (index > -1) {
+    return index
+  }
+  return undefined // for now
+}
+
 function getCellBelowSelectedId(state) {
   const { cells } = state
   const index = cells.findIndex(c => c.selected)
@@ -119,6 +128,21 @@ function getSelectedCell(state) {
     return cells[index]
   }
   return undefined // for now
+}
+
+function checkForHighlightedCells(state) {
+  const cells = state.cells.slice()
+  return cells.find(c => c.highlighted)
+}
+
+function newStateWithPropsAssignedForHighlightedCells(state, cellPropsToSet) {
+  const cells = state.cells.slice()
+  cells.forEach((cell, i) => {
+    if (cell.highlighted) {
+      cells[i] = Object.assign({}, cell, cellPropsToSet)
+    }
+  })
+  return Object.assign({}, state, { cells })
 }
 
 function newStateWithSelectedCellPropertySet(state, cellPropToSet, newValue) {
@@ -143,9 +167,12 @@ export {
   moveCell,
   addExternalDependency,
   getSelectedCell,
+  getSelectedCellIndex,
   getSelectedCellId,
   getCellBelowSelectedId,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 }

--- a/src/reducers/cell-reducer.js
+++ b/src/reducers/cell-reducer.js
@@ -2,10 +2,14 @@ import { newCell, newCellID, newNotebook, rowOverflowEnum } from '../editor-stat
 
 import {
   moveCell,
+  getSelectedCell,
   getSelectedCellId,
+  getSelectedCellIndex,
   newStateWithSelectedCellPropertySet,
   newStateWithSelectedCellPropsAssigned,
   newStateWithPropsAssignedForCell,
+  checkForHighlightedCells,
+  newStateWithPropsAssignedForHighlightedCells,
 } from './cell-reducer-utils'
 
 const cellReducer = (state = newNotebook(), action) => {
@@ -48,6 +52,124 @@ const cellReducer = (state = newNotebook(), action) => {
       return nextState
     }
 
+    case 'HIGHLIGHT_CELL': {
+      const cells = state.cells.slice()
+      const index = cells.findIndex(c => c.id === action.id)
+      const thisCell = cells[index]
+      if (action.revert) thisCell.highlighted = !thisCell.highlighted
+      else thisCell.highlighted = true
+      nextState = Object.assign({}, state, { cells })
+      return nextState
+    }
+
+    case 'UNHIGHLIGHT_CELLS': {
+      const cells = state.cells.slice()
+      cells.forEach((c) => { c.highlighted = false }) // eslint-disable-line
+      return Object.assign({}, state, { cells })
+    }
+
+    case 'MULTIPLE_CELL_HIGHLIGHT': {
+      const cells = state.cells.slice()
+      const index1 = getSelectedCellIndex(state)
+      const index2 = cells.findIndex(c => c.id === action.id)
+      const low = Math.min(index1, index2)
+      const high = Math.max(index1, index2)
+      cells.forEach((c, index) => {
+        if (low <= index && index <= high) {
+          c.highlighted = true // eslint-disable-line
+        } else {
+          c.highlighted = false // eslint-disable-line
+        }
+      })
+      cells[index1].selected = false
+      cells[index2].selected = true
+      return Object.assign({}, state, { cells })
+    }
+
+    case 'CELL_COPY': {
+      const cutCells = []
+      const cells = state.cells.slice()
+      let copiedCells = cells.filter(c => c.highlighted)
+      if (!copiedCells.length) {
+        copiedCells = [getSelectedCell(state)]
+      }
+      return Object.assign({}, state, { copiedCells, cutCells })
+    }
+
+    case 'CELL_CUT': {
+      const copiedCells = []
+      let isNotebookEmpty = false
+      let cutCells
+      let cells = state.cells.slice()
+      cutCells = cells.filter(c => c.highlighted)
+      if (!cutCells.length) {
+        const index = getSelectedCellIndex(state)
+        cutCells = [cells[index]]
+        if (cells[index + 1]) {
+          cells[index + 1].selected = true
+        } else if (cells[index - 1]) {
+          cells[index - 1].selected = true
+        } else {
+          isNotebookEmpty = true
+        }
+        cells.splice(index, 1)
+      } else {
+        const cutIndices = cells.map((c, i) => (c.highlighted ? i : '')).filter(String)
+        const lastHiglighted = cutIndices[cutIndices.length - 1]
+        if (cells[lastHiglighted + 1]) {
+          cells[lastHiglighted + 1].selected = true
+        } else {
+          let lastUnHighlightedCell
+          let cellIndex = lastHiglighted
+          let highlightIndex = cutIndices.length - 1
+          while (highlightIndex >= 0 || cellIndex >= 0) {
+            if (cutIndices[highlightIndex] !== cellIndex) {
+              lastUnHighlightedCell = cellIndex
+              break
+            }
+            cellIndex -= 1
+            highlightIndex -= 1
+          }
+          if (lastUnHighlightedCell) {
+            cells[lastUnHighlightedCell].selected = true
+          } else {
+            isNotebookEmpty = true
+          }
+        }
+        cells = cells.filter(c => !c.highlighted)
+      }
+      if (isNotebookEmpty) {
+        const nextCell = newCell(newCellID(state.cells), 'code')
+        nextCell.selected = true
+        cells = [nextCell]
+      }
+      return Object.assign({}, state, { cells, cutCells, copiedCells })
+    }
+
+    case 'CELL_PASTE': {
+      if (state.copiedCells.length && state.cutCells.length) {
+        return state
+      }
+      const newState = Object.assign({}, state)
+      const cells = newState.cells.slice()
+      let cellsToPaste = newState.copiedCells.length ?
+        newState.copiedCells.slice()
+        :
+        newState.cutCells.slice()
+      const pasteIndex = getSelectedCellIndex(state)
+      const newId = newCellID(cells)
+      cellsToPaste = cellsToPaste.map((cell, i) => Object.assign(
+        {},
+        cell,
+        { highlighted: false, selected: false, id: newId + i },
+      ))
+      cells[pasteIndex].selected = false
+      cellsToPaste[cellsToPaste.length - 1].selected = true
+      cells.splice(pasteIndex + 1, 0, ...cellsToPaste)
+      nextState = Object.assign({}, newState, { cells: [...cells], copiedCells: [], cutCells: [] })
+      return nextState
+    }
+
     case 'CELL_UP':
       return Object.assign(
         {}, state,
@@ -60,8 +182,17 @@ const cellReducer = (state = newNotebook(), action) => {
         { cells: moveCell(state.cells, getSelectedCellId(state), 'down') },
       )
 
-    case 'UPDATE_CELL_PROPERTIES':
+    case 'UPDATE_CELL_PROPERTIES': {
+      const approvedMultipleChanges = new Set(['skipInRunAll'])
+      if (
+        checkForHighlightedCells(state) &&
+        Object.keys(action.updatedProperties).length === 1 &&
+        approvedMultipleChanges.has(Object.keys(action.updatedProperties)[0])
+      ) {
+        return newStateWithPropsAssignedForHighlightedCells(state, action.updatedProperties)
+      }
       return newStateWithPropsAssignedForCell(state, action.cellId, action.updatedProperties)
+    }
 
     case 'UPDATE_INPUT_CONTENT':
       return newStateWithSelectedCellPropertySet(state, 'content', action.content)

--- a/src/reducers/eval-frame-action-forwarder.js
+++ b/src/reducers/eval-frame-action-forwarder.js
@@ -27,6 +27,12 @@ const evalFrameActionForwarder = (state, action) => {
     case 'UPDATE_CELL_PROPERTIES':
     case 'CHANGE_CELL_TYPE':
     case 'MARK_CELL_NOT_RENDERED':
+    case 'HIGHLIGHT_CELL':
+    case 'UNHIGHLIGHT_CELLS':
+    case 'MULTIPLE_CELL_HIGHLIGHT':
+    case 'CELL_COPY':
+    case 'CELL_CUT':
+    case 'CELL_PASTE':
     case 'CELL_UP':
     case 'CELL_DOWN':
     case 'SELECT_CELL':


### PR DESCRIPTION
Ports features of PR #629 into Iframe 2
Implements cut, copy, paste, highlight, unhighlight, actions using multiple-highlight (for ex. skip in Run all at once for multiple cells)

<!---
@huboard:{"custom_state":"","order":740.0,"milestone_order":172.9368968955862}
-->
