### PR TITLE
Add https redirect for production deploys

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -93,6 +93,13 @@ TEMPLATES = [
     },
 ]
 
+# When DEBUG is True, allow HTTP traffic, otherwise, never allow HTTP traffic.
+SECURE_SSL_REDIRECT = env.bool('SECURE_SSL_REDIRECT', default=not DEBUG)
+SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', default='31536000')
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', default=False)
+SECURE_BROWSER_XSS_FILTER = env.bool('SECURE_BROWSER_XSS_FILTER', default=True)
+SECURE_CONTENT_TYPE_NOSNIFF = env.bool('SECURE_CONTENT_TYPE_NOSNIFF', default=True)
+
 LOGIN_URL = 'login'
 LOGOUT_URL = 'logout'
 LOGIN_REDIRECT_URL = 'login_success'


### PR DESCRIPTION
The new iframe branch of iodide expects an https url when running in
production.

Automatically redirect by default to https version of server when running in
non-debug mode, or when set by configuration variable (SECURE_SSL_REDIRECT)