### PR TITLE
717 console eval area

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -126,6 +126,8 @@ export function evalConsoleInput(languageId) {
     const state = getState()
     let output
     const code = state.consoleText
+    // exit if there is no code in the console to  eval
+    if (!code) { return undefined }
     const evalLanguageId = languageId === undefined ? state.languageLastUsed : languageId
     const languageModule = state.languages[evalLanguageId].module
     const { evaluator } = state.languages[evalLanguageId]
@@ -385,14 +387,20 @@ function evaluateLanguagePluginCell(cell) {
 
 export function evaluateCell(cellId) {
   return (dispatch, getState) => {
-    dispatch(incrementExecutionNumber())
-    let evaluation
     let cell
     if (cellId === undefined) {
       cell = getSelectedCell(getState())
     } else {
       cell = getCellById(getState().cells, cellId)
     }
+
+    if (!cell.content) {
+      // if the cell has no content, evaluation is a no-op
+      return undefined
+    }
+
+    let evaluation
+    dispatch(incrementExecutionNumber())
     // here is where we should mark a cell as PENDING.
     if (cell.cellType === 'code') {
       evaluationQueue = evaluationQueue

--- a/src/eval-frame/actions/eval-frame-tasks.js
+++ b/src/eval-frame/actions/eval-frame-tasks.js
@@ -1,6 +1,7 @@
 import UserTask from '../../actions/user-task'
 import { postKeypressToEditor, postActionToEditor } from '../port-to-editor'
-// import { store } from '../store'
+import { store } from '../store'
+import { evalConsoleInput } from './actions'
 
 
 const tasks = {}
@@ -24,13 +25,6 @@ tasks.exportNotebook = new UserTask({
   keybindings: ['ctrl+shift+e', 'meta+shift+e'],
   callback() { postKeypressToEditor(this.keybindings[0]) },
 })
-
-// tasks.changePaneHeight = new UserTask({
-//   title: 'Change Width of Side Pane',
-//   callback(heightShift) {
-//     store.dispatch(changePaneHeight(heightShift))
-//   },
-// })
 
 tasks.closePanes = new UserTask({
   title: 'Close the eval context info panes',
@@ -69,58 +63,23 @@ tasks.toggleAppInfoPane = new UserTask({
   callback() { postKeypressToEditor(this.keybindings[0]) },
 })
 
-// tasks.changeReportPaneSort = new UserTask({
-//   title: 'Change Report Pane Sort',
-//   callback() {
-//     postActionToEditor({
-//       type: 'CHANGE_REPORT_PANE_SORT',
-//       sortType: store.getState().reportPaneSort === 'EVAL_ORDER' ? 'CELL_ORDER' : 'EVAL_ORDER',
-//     })
-//   },
-// })
-
-// tasks.changeConsolePaneSort = new UserTask({
-//   title: 'Change Console Pane Sort',
-//   callback() {
-//     postActionToEditor({
-//       type: 'CHANGE_CONSOLE_PANE_SORT',
-//       sortType: store.getState().consolePaneSort === 'EVAL_ORDER' ? 'CELL_ORDER' : 'EVAL_ORDER',
-//     })
-//   },
-// })
-
-// const nextFilter = {
-//   OUTPUT_ROWS_ONLY: 'REPORT_ROWS_ONLY',
-//   REPORT_ROWS_ONLY: 'SHOW_ALL_ROWS',
-//   SHOW_ALL_ROWS: 'OUTPUT_ROWS_ONLY',
-// }
-
-// tasks.changeReportPaneFilter = new UserTask({
-//   title: 'Change Report Pane Filter',
-//   callback() {
-//     postActionToEditor({
-//       type: 'CHANGE_REPORT_PANE_FILTER',
-//       reportPaneOutputFilter: nextFilter[store.getState().reportPaneOutputFilter],
-//     })
-//   },
-// })
-
-// tasks.changeConsolePaneFilter = new UserTask({
-//   title: 'Change Console Pane Filter',
-//   callback() {
-//     postActionToEditor({
-//       type: 'CHANGE_CONSOLE_PANE_FILTER',
-//       consolePaneOutputFilter: nextFilter[store.getState().consolePaneOutputFilter],
-//     })
-//   },
-// })
-
 tasks.toggleEditorLink = new UserTask({
   title: 'Link Editor',
   callback() {
     postActionToEditor({
       type: 'TOGGLE_EDITOR_LINK',
     })
+  },
+})
+
+// the following task operates only in the eval frame
+tasks.evalConsoleInput = new UserTask({
+  title: 'Evaluate code in the console input area',
+  menuTitle: 'Evaluate console',
+  keybindings: ['mod+enter', 'shift+enter'],
+  preventDefaultKeybinding: true,
+  callback() {
+    store.dispatch(evalConsoleInput())
   },
 })
 

--- a/src/eval-frame/components/panes/__tests__/history-pane.test.js
+++ b/src/eval-frame/components/panes/__tests__/history-pane.test.js
@@ -86,7 +86,7 @@ describe('HistoryPane mapStateToProps', () => {
           lastRan: 1533078293981,
           content: 'var a = 3',
         }],
-        paneDisplay: 'block',
+        paneDisplay: 'flex',
       })
   })
 

--- a/src/eval-frame/components/panes/console-input.js
+++ b/src/eval-frame/components/panes/console-input.js
@@ -1,0 +1,70 @@
+import React from 'react'
+// import PropTypes from 'prop-types'
+// import { connect } from 'react-redux'
+// import deepEqual from 'deep-equal'
+import DoubleChevronIcon from './double-chevron-icon'
+
+
+export default class ConsoleInput extends React.Component {
+  // static propTypes = {
+  //   history: PropTypes.array,
+  // }
+
+  constructor(props) {
+    super(props);
+    this.textAreaRef = React.createRef()
+    this.containerRef = React.createRef()
+    this.inputHeightAdjustFn = this.inputHeightAdjustFn.bind(this)
+  }
+
+  inputHeightAdjustFn() {
+    // snippet adapted from:
+    // https://stackoverflow.com/questions/2803880/is-there-a-way-to-get-a-textarea-to-stretch-to-fit-its-content-without-using-php
+    this.textAreaRef.current.style.height = '';
+    this.containerRef.current.style['min-height'] = `${this.textAreaRef.current.scrollHeight + 4}px`
+    this.textAreaRef.current.style.height = '100%';
+  }
+
+  render() {
+    return (
+      <div
+        ref={this.containerRef}
+        className="console-text-input-container"
+        style={{
+          borderTop: '1px solid #ddd',
+          display: 'flex',
+        }}
+      >
+        <DoubleChevronIcon />
+        <div style={{ flexGrow: 1 }}>
+          <textarea
+            name="text"
+            ref={this.textAreaRef}
+            onInput={this.inputHeightAdjustFn}
+            rows="1"
+            style={{
+              resize: 'none',
+              lineHeight: '20px',
+              padding: '3px 0px 0px 0px',
+              height: '100%',
+              width: '100%',
+              border: 'none',
+              boxSizing: 'border-box',
+              outline: 'none',
+            }}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+// export function mapStateToProps(state) {
+//   return {
+//     sidePaneMode: state.sidePaneMode,
+//     history: state.history,
+//     paneDisplay: state.sidePaneMode === '_CONSOLE' ? 'block' : 'none',
+//   }
+// }
+
+// export default connect(mapStateToProps)(HistoryPaneUnconnected)

--- a/src/eval-frame/components/panes/double-chevron-icon.js
+++ b/src/eval-frame/components/panes/double-chevron-icon.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import SvgIcon from '@material-ui/core/SvgIcon'
+
+export default class DoubleChevronIcon extends React.Component {
+  render() {
+    return (
+      <SvgIcon {...this.props}>
+        <svg
+          style={{
+            width: '24px',
+            height: '24px',
+          }}
+          viewBox="0 0 24 24"
+        >
+          <path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" />
+        </svg>
+      </SvgIcon>
+    )
+  }
+}

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -17,7 +17,9 @@ import { postMessageToEditor } from '../../port-to-editor'
 export class HistoryItemUnconnected extends React.Component {
   static propTypes = {
     content: PropTypes.string.isRequired,
-    cellId: PropTypes.number.isRequired,
+    cellId: PropTypes.number,
+    historyId: PropTypes.number.isRequired,
+    historyType: PropTypes.string.isRequired,
     lastRan: PropTypes.number.isRequired,
   }
   constructor(props) {
@@ -44,27 +46,35 @@ export class HistoryItemUnconnected extends React.Component {
 
   render() {
     // const id = this.props.cell.cellId
-    let cellOutput
+    let output
+    let showCellReturnButton = true
     switch (this.props.historyType) {
       case 'CELL_EVAL_VALUE':
-        cellOutput = (<ValueRenderer
+        output = (<ValueRenderer
           render
           valueToRender={this.props.valueToRender}
         />)
         break
       case 'CELL_EVAL_EXTERNAL_RESOURCE':
-        cellOutput = <ExternalResourceOutputHandler value={this.props.valueToRender} />
+        output = <ExternalResourceOutputHandler value={this.props.valueToRender} />
         break
       case 'CELL_EVAL_INFO':
-        cellOutput = this.props.valueToRender
+        output = this.props.valueToRender
+        break
+      case 'CONSOLE_EVAL':
+        output = (<ValueRenderer
+          render
+          valueToRender={this.props.valueToRender}
+        />)
+        showCellReturnButton = false
         break
       default:
         // TODO: Use better class for inline error
-        cellOutput = <div>Unknown history type {this.props.historyType}</div>
+        output = <div>Unknown history type {this.props.historyType}</div>
         break
     }
 
-    const historyMetadata = (
+    const cellReturnButton = showCellReturnButton ? (
       <div className="history-metadata-positioner">
         <div className="history-metadata">
           <div className="history-show-actual-cell">
@@ -78,15 +88,16 @@ export class HistoryItemUnconnected extends React.Component {
           {/* <div className="history-time-since"> {this.state.timeSince} </div> */}
         </div>
       </div>)
+      : ''
 
     return (
-      <div id={`cell-${this.props.cellId}-history`} className="history-cell">
+      <div id={`history-item-id-${this.props.historyId}`} className="history-cell">
         <div className="history-content editor">
-          {historyMetadata}
+          {cellReturnButton}
           <pre className="history-item-code">{this.props.content}</pre>
         </div>
         <div className="history-item-output">
-          {cellOutput}
+          {output}
         </div>
       </div>
     )
@@ -95,8 +106,9 @@ export class HistoryItemUnconnected extends React.Component {
 
 export function mapStateToProps(state, ownProps) {
   return {
-    cellId: ownProps.historyItem.cellId,
     content: ownProps.historyItem.content,
+    cellId: ownProps.historyItem.cellId,
+    historyId: ownProps.historyItem.historyId,
     historyType: ownProps.historyItem.historyType,
     lastRan: ownProps.historyItem.lastRan,
     valueToRender: ownProps.historyItem.value,

--- a/src/eval-frame/components/panes/history-pane.jsx
+++ b/src/eval-frame/components/panes/history-pane.jsx
@@ -6,6 +6,7 @@ import deepEqual from 'deep-equal'
 // import Pane from './pane-container'
 // import tasks from '../../actions/eval-frame-tasks'
 import HistoryItem from './history-item'
+import ConsoleInput from './console-input'
 import EmptyPaneContents from './empty-pane-contents'
 
 export class HistoryPaneUnconnected extends React.Component {
@@ -49,11 +50,35 @@ export class HistoryPaneUnconnected extends React.Component {
 
     return (
       <div
-        className="pane-content history-cells"
-        style={{ display: this.props.paneDisplay }}
-        ref={this.historyScrollerRef}
+        className="pane-content"
+        style={{
+          display: this.props.paneDisplay,
+          overflow: 'hidden',
+        }}
       >
-        {histContents}
+        <div
+          className="console-pane"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flexGrow: 1,
+            maxWidth: '100%',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            className="history-cells"
+            style={{
+              flexGrow: 1,
+              maxHeight: '100%',
+              overflow: 'auto',
+            }}
+            ref={this.historyScrollerRef}
+          >
+            {histContents}
+          </div>
+          <ConsoleInput />
+        </div>
       </div>
     )
   }
@@ -63,7 +88,7 @@ export function mapStateToProps(state) {
   return {
     sidePaneMode: state.sidePaneMode,
     history: state.history,
-    paneDisplay: state.sidePaneMode === '_CONSOLE' ? 'block' : 'none',
+    paneDisplay: state.sidePaneMode === '_CONSOLE' ? 'flex' : 'none',
   }
 }
 

--- a/src/eval-frame/eval-frame-state-prototypes.js
+++ b/src/eval-frame/eval-frame-state-prototypes.js
@@ -124,6 +124,15 @@ const stateSchema = {
       type: 'array',
       items: cellSchema,
     },
+    consoleText: { type: 'string' },
+    consoleTextCache: {
+      // stores the current entry when keying up/down
+      type: 'string',
+    },
+    consoleScrollbackPosition: {
+      // the position from the END of the history when keying up/down in the console
+      type: 'integer',
+    },
     languages: {
       type: 'object',
       additionalProperties: languageSchema,
@@ -221,6 +230,9 @@ function newNotebook() {
   const initialState = {
     title: 'untitled',
     cells: [newCell(0)],
+    consoleText: '',
+    consoleTextCache: '',
+    consoleScrollbackPosition: 0,
     languages: { js: jsLanguageDefinition },
     languageLastUsed: 'js',
     userDefinedVarNames: [],

--- a/src/eval-frame/reducers/eval-frame-reducer.js
+++ b/src/eval-frame/reducers/eval-frame-reducer.js
@@ -98,6 +98,46 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { history })
     }
 
+    case 'UPDATE_CONSOLE_TEXT': {
+      return Object.assign({}, state, { consoleText: action.consoleText })
+    }
+
+    case 'CLEAR_CONSOLE_TEXT_CACHE': {
+      return Object.assign({}, state, { consoleTextCache: '' })
+    }
+
+    case 'CONSOLE_HISTORY_MOVE': {
+      const historyLength = state.history.length
+      // note that we bound consoleScrollbackPosition between
+      // zero (which represents the cursor being in th) and historyLength
+      const nextScrollback = Math.min(Math.max(
+        0,
+        state.consoleScrollbackPosition + action.consoleCursorDelta,
+      ), historyLength)
+
+
+      let { consoleTextCache } = state
+      if (state.consoleScrollbackPosition === 0) {
+        // if we moved FROM 0, set the consoleTextCache from the current value
+        consoleTextCache = state.consoleText
+      }
+
+      let nextConsoleText
+      if (nextScrollback === 0) {
+        // if we moved TO 0, set the consoleText from the cache
+        nextConsoleText = consoleTextCache
+      } else {
+        // otherwise set the consoleText to the history value
+        nextConsoleText = state.history[historyLength - nextScrollback].content
+      }
+
+      return Object.assign({}, state, {
+        consoleText: nextConsoleText,
+        consoleTextCache,
+        consoleScrollbackPosition: nextScrollback,
+      })
+    }
+
     case 'UPDATE_APP_MESSAGES': {
       nextState = Object.assign({}, state)
       nextState.appMessages = nextState.appMessages.slice()


### PR DESCRIPTION
@wlach or @djbarnwal or @teonbrooks or @mdboom -- this PR implements a code entry area at the bottom of the console. I don't need review from all of you of course, but if one of you could give this a quick QA and pass over the code to see that it looks ok, that would be great.

This is the baseline mvp version of the console feature, just REPL entry and key back/forward through history entries. Still need to do something to enable selecting other language evaluators (which can be filed as a second issue). flag any merge blocker in the PR, and then also of course feel free to file any issues for feature requests on top of this baseline.

thanks!



ps @hamilton: i think this will be merged before you get back, but please take a look over this when you do get back to make sure that nothing here will break around promises. I tried to copy the existing pattern, but i'm still not sure how the eval queue really works