### PR TITLE
Make error rep more consistent

### DIFF
--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -67,9 +67,7 @@ const errorHandler = {
       // '    at cellReducer' is not useful.
     }
     return (
-      <div className="error-output">
-        <pre>{stack}</pre>
-      </div>
+      <pre className="error-output">{stack}</pre>
     )
   },
 }

--- a/src/eval-frame/style/eval-container.css
+++ b/src/eval-frame/style/eval-container.css
@@ -43,11 +43,12 @@ div.cells-list {
   padding-bottom: 4px;
 }
 
-div.error-output {
-background: #fff1f4;
-padding: 5px;
-color: #a41c1c;
-overflow-x: auto;
+.error-output {
+  background: #fff1f4;
+  padding: 5px;
+  color: #a41c1c;
+  overflow-x: auto;
+  font-size: 90%;
 }
 
 .string-rep {

--- a/src/eval-frame/style/eval-container.css
+++ b/src/eval-frame/style/eval-container.css
@@ -48,7 +48,7 @@ div.cells-list {
   padding: 5px;
   color: #a41c1c;
   overflow-x: auto;
-  font-size: 90%;
+  font-size: 11px;
 }
 
 .string-rep {


### PR DESCRIPTION
This makes the font slightly smaller to be more in line with the react-inspector reps, and removes the extra vertical space before and after.

This is a follow-on to #794.  Probably should hold off reviewing until #794 is merged.