### PR TITLE
Error rep remove unnecessary frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "codemirror": "^5.37.0",
     "codemirror-no-newlines": "^1.0.2",
     "deep-equal": "^1.0.1",
+    "error-stack-parser": "^2.0.2",
     "font-awesome": "^4.7.0",
     "fuse.js": "^3.2.0",
     "lodash": "^4.17.10",
@@ -57,7 +58,8 @@
     "react-table": "^6.8.2",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "stackframe": "^1.0.4"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/src/components/reps/error-handler.jsx
+++ b/src/components/reps/error-handler.jsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import ErrorStackParser from 'error-stack-parser'
+import StackFrame from 'stackframe'
+
+
+ErrorStackParser.parseV8OrIE = (error) => {
+  const filtered = error.stack.split('\n').filter(
+    line => !!line.match(/^\s*at .*(\S+:\d+|\(native\))/m),
+    ErrorStackParser,
+  );
+
+  return filtered.map(
+    (line) => {
+      const tokens = line.replace(/^\s+/, '').replace(/\(eval code/g, '(').split(/\s+/).slice(1);
+
+      if (line.indexOf('(eval ') > -1) {
+        const regExp = /\), (<[^>]+>:\d+:\d+)\)$/;
+        const evalParts = regExp.exec(line);
+        if (evalParts) {
+          const evalLocationParts = ErrorStackParser.extractLocation(evalParts[1]);
+          return new StackFrame({
+            functionName: tokens[0],
+            fileName: 'cell',
+            lineNumber: evalLocationParts[1],
+            columnNumber: evalLocationParts[2],
+            source: line,
+            isEval: true,
+          });
+        }
+      }
+
+      const locationParts = ErrorStackParser.extractLocation(tokens.pop());
+      const functionName = tokens.join(' ') || undefined;
+      const fileName = ['eval', '<anonymous>'].indexOf(locationParts[0]) > -1 ? undefined : locationParts[0];
+
+      return new StackFrame({
+        functionName,
+        fileName,
+        lineNumber: locationParts[1],
+        columnNumber: locationParts[2],
+        source: line,
+      });
+    },
+    ErrorStackParser,
+  );
+}
+
+ErrorStackParser.parseFFOrSafari = (error) => {
+  const filtered = error.stack.split('\n').filter(
+    line => !line.match(/^(eval@)?(\[native code\])?$/),
+    ErrorStackParser,
+  );
+
+  return filtered.map(
+    (line) => {
+      const functionNameRegex = /((.*".+"[^@]*)?[^@]*)(?:@)/;
+      const matches = line.match(functionNameRegex);
+      const functionName = matches && matches[1] ? matches[1] : undefined;
+
+      if (line.indexOf(' > eval') > -1) {
+        const regExp = / > (eval:\d+:\d+)$/
+        const evalParts = regExp.exec(line)
+        console.log(JSON.stringify(evalParts))
+        if (evalParts) {
+          const evalLocationParts = ErrorStackParser.extractLocation(evalParts[1]);
+          return new StackFrame({
+            functionName: functionName !== undefined ? functionName : 'eval',
+            fileName: 'cell',
+            lineNumber: evalLocationParts[1],
+            columnNumber: evalLocationParts[2],
+            source: line,
+            isEval: true,
+          });
+        }
+      }
+
+      if (line.indexOf('@') === -1 && line.indexOf(':') === -1) {
+        // Safari eval frames only have function names and nothing else
+        return new StackFrame({
+          functionName: line,
+        });
+      }
+
+      const locationParts = ErrorStackParser.extractLocation(line.replace(functionNameRegex, ''));
+
+      return new StackFrame({
+        functionName,
+        fileName: locationParts[0],
+        lineNumber: locationParts[1],
+        columnNumber: locationParts[2],
+        source: line,
+      });
+    },
+    ErrorStackParser,
+  );
+}
+
+export default {
+  shouldHandle: value => value instanceof Error,
+  render: (e) => {
+    const frames = ErrorStackParser.parse(e)
+    const outputFrames = []
+
+    for (const frame of frames) {
+      console.log(`${frame.functionName} ${frame.fileName}`);
+      if ((frame.functionName !== undefined &&
+           frame.functionName.startsWith('evaluateCodeCell')) ||
+          (frame.functionName === undefined &&
+           frame.fileName !== 'cell')) {
+        break
+      }
+      outputFrames.push(frame.toString())
+    }
+
+    const stack = `${e.name}: ${e.message}\n${outputFrames.join('\n')}`
+
+    return (
+      <div className="error-output">
+        <pre>{stack}</pre>
+      </div>
+    )
+  },
+}
+

--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -3,13 +3,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-
-import nullHandler from './null-handler'
-import dataFrameHandler from './dataframe-handler'
-import matrixHandler from './matrix-handler'
 import arrayHandler from './array-handler'
-import promiseHandler from './promise-handler'
+import dataFrameHandler from './dataframe-handler'
 import defaultHandler from './default-handler'
+import errorHandler from './error-handler'
+import matrixHandler from './matrix-handler'
+import nullHandler from './null-handler'
+import promiseHandler from './promise-handler'
 import stringHandler from './string-handler'
 
 export function renderValue(value, inContainer = false) {
@@ -46,31 +46,6 @@ const renderMethodHandler = {
       return <div dangerouslySetInnerHTML={{ __html: output }} /> // eslint-disable-line
     }
     return undefined
-  },
-}
-
-
-const errorHandler = {
-  shouldHandle: value => value instanceof Error,
-  render: (e) => {
-    let { stack } = e
-    if (e.lineNumber) {
-      // this is firefox
-      // prepend the name and message
-      stack = `${e.name}: ${e.message}\n${stack}`
-      // lines after the line beginning with "cellReducer@" can
-      // be discarded, because they refer to app state not notebook state
-      // stack = stack.slice(0, stack.indexOf('cellReducer@'))
-    } else {
-      // not FF;
-      // for now, treat as chrome. it appears that anything after:
-      // '    at cellReducer' is not useful.
-    }
-    return (
-      <div className="error-output">
-        <pre>{stack}</pre>
-      </div>
-    )
   },
 }
 


### PR DESCRIPTION
Fix #805.

This is a follow-on to #794, which should probably be merged before this is reviewed.

This removes the uninteresting part of the traceback (that goes back into Iodide itself).

It also properly displays line numbers for stack frames within the cell itself.

This required some mild monkey-patching of the `error-stack-parser` library to support eval frames.  It only works in Firefox and Chrome.  Opera apparently has a different stack trace format.