### PR TITLE
Unstyled notebook list on front page

### DIFF
--- a/server/templates/home.html
+++ b/server/templates/home.html
@@ -2,7 +2,8 @@
 {% block content %}
 <div id="page"></div>
 <script>
-  window.userData = {{ user_info|safe }}
+  window.userData = {{ user_info|safe }};
+  window.notebookList = {{ notebook_list|safe }};
 </script>
 <script src="/server.home.dev.js"></script>
 {% endblock %}

--- a/server/views.py
+++ b/server/views.py
@@ -6,6 +6,8 @@ from django.shortcuts import redirect
 from django.template import loader
 from social_django.models import UserSocialAuth
 
+from .notebooks.models import Notebook
+
 
 def get_user_info_dict(user):
     if user.is_authenticated:
@@ -21,8 +23,13 @@ def get_user_info_dict(user):
 
 def index(request):
     template = loader.get_template('home.html')
+    # this is horrible and will not scale
     return HttpResponse(template.render({
-        'user_info': json.dumps(get_user_info_dict(request.user))
+        'user_info': json.dumps(get_user_info_dict(request.user)),
+        'notebook_list': json.dumps(
+            [{'id': v[0], 'title': v[1], 'owner': v[2]} for v in
+             Notebook.objects.values_list('id', 'title', 'owner__username')
+             ])
     }, request))
 
 

--- a/src/server/components/notebook-list.jsx
+++ b/src/server/components/notebook-list.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+
+export default class NotebookList extends React.Component {
+  render() {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>Notebook</th><th>Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            this.props.notebookList.map(notebook => (
+              <tr key={notebook.id}>
+                <td>
+                  <a href={`/notebooks/${notebook.id}/`}>{notebook.title}</a>
+                </td>
+                <td>
+                  {notebook.owner}
+                </td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
+    )
+  }
+}

--- a/src/server/index.jsx
+++ b/src/server/index.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import Header from './components/header';
+import NotebookList from './components/notebook-list';
 
-const userInfo = window.userData;
+const { userInfo, notebookList } = window;
 
 render(
-  <div><Header userInfo={userInfo} /></div>,
+  <div>
+    <Header userInfo={userInfo} />
+    <NotebookList notebookList={notebookList} />
+  </div>,
   document.getElementById('page'),
 )


### PR DESCRIPTION
This expands the placeholder front page to include a primitive set of
links to all the notebooks on the server. It's super ugly and obviously
not scalable, but serves to illustrate the concept of rendering to
a react-based template from django.