### PR TITLE
Make notebook code built with `npm run start` have server features

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "webpack --watch --env=dev",
     "build": "webpack",
     "build-production": "webpack --env=production",
-    "build-ghpages": "webpack --env=ghpages",
+    "build-ghpages": "webpack --env=ghpages-client-only",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix"
   },
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ const plugins = []
 
 // const config
 module.exports = (env) => {
-  if (env === 'ghpages') {
+  if (env.startsWith('ghpages')) {
     BUILD_DIR = path.resolve(__dirname, 'prod/')
     const gitRev = require('git-rev-sync')
     if (gitRev.isTagDirty()) {
@@ -161,7 +161,7 @@ module.exports = (env) => {
         IODIDE_JS_PATH: JSON.stringify(APP_PATH_STRING),
         IODIDE_CSS_PATH: JSON.stringify(CSS_PATH_STRING),
         IODIDE_BUILD_MODE: JSON.stringify((env && env.startsWith('dev')) ? 'dev' : 'production'),
-        IODIDE_BUILD_TYPE: JSON.stringify(env ? 'standalone' : 'server'),
+        IODIDE_BUILD_TYPE: JSON.stringify((env && env.includes('client-only')) ? 'standalone' : 'server'),
         IODIDE_REDUX_LOG_MODE: JSON.stringify(reduxLogMode),
       }),
       new ExtractTextPlugin(`[name].${APP_VERSION_STRING}.css`),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ const plugins = []
 
 // const config
 module.exports = (env) => {
-  if (env.startsWith('ghpages')) {
+  if (env && env.startsWith('ghpages')) {
     BUILD_DIR = path.resolve(__dirname, 'prod/')
     const gitRev = require('git-rev-sync')
     if (gitRev.isTagDirty()) {


### PR DESCRIPTION
For example, the user panel / authentication. This will allow testing
of the "full stack" (both server and client features) with the
recommended workflow described in README.md.