### PR TITLE
Use DevExtreme React Grid rather than React Table for dataframe rep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     ]
   },
   "dependencies": {
+    "@devexpress/dx-react-core": "^1.7.0",
+    "@devexpress/dx-react-grid": "^1.7.0",
+    "@devexpress/dx-react-grid-material-ui": "^1.7.0",
     "@material-ui/core": "^1.4.0",
     "@material-ui/icons": "^1.1.0",
     "@skidding/react-codemirror": "^1.0.0",
@@ -55,7 +58,6 @@
     "react-helmet": "^5.2.0",
     "react-inspector": "^2.3.0",
     "react-redux": "^5.0.7",
-    "react-table": "^6.8.2",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",

--- a/src/components/reps/dataframe-handler.jsx
+++ b/src/components/reps/dataframe-handler.jsx
@@ -1,33 +1,62 @@
 import React from 'react'
-import ReactTable from 'react-table'
+import { Grid, VirtualTable, TableHeaderRow, Table } from '@devexpress/dx-react-grid-material-ui'
+import { DataTypeProvider, IntegratedSorting, SortingState } from '@devexpress/dx-react-grid'
 
 import { renderValue } from './value-renderer'
 import nb from '../../tools/nb'
+
+const ValueFormatter = ({ value }) => (
+  <div className="rep-base">
+    {renderValue(value, true)}
+  </div>
+)
+
+const ValueRendererProvider = props => (
+  <DataTypeProvider
+    formatterComponent={ValueFormatter}
+    {...props}
+  />
+)
+
+// Force heights to be based on contents, not the extremely spacious default
+const TableRow = props => (
+  <Table.Row
+    {... props}
+    style={{ height: 'auto' }}
+  />
+)
 
 export default {
   shouldHandle: (value, inContainer) => !inContainer && nb.isRowDf(value),
 
   render: (value) => {
     const columns = Object.keys(value[0])
-      .map(k => ({
-        Header: k,
-        accessor: k,
-        Cell: cell => renderValue(cell.value, true),
-      }))
+      .map(k => ({ name: k, title: k }))
     const dataSetInfo = `array of objects: ${value.length} rows, ${columns.length} columns`
-    const pageSize = value.length > 10 ? 10 : value.length
     return (
       <div className="dataframe-rep">
         <div className="data-set-info">{dataSetInfo}</div>
-        <ReactTable
-          data={value}
-          columns={columns}
-          showPaginationTop
-          showPaginationBottom={false}
-          pageSizeOptions={[5, 10, 25, 50, 100]}
-          minRows={0}
-          defaultPageSize={pageSize}
-        />
+        <Grid rows={value} columns={columns}>
+          <ValueRendererProvider
+            for={Object.keys(value[0])}
+          />
+          <SortingState
+            defaultSorting={[{
+              columnName: Object.keys(value[0])[0],
+              direction: 'asc',
+            }]}
+          />
+          <IntegratedSorting />
+          <VirtualTable
+            height={120}
+            estimatedRowHeight={24}
+            rowComponent={TableRow}
+          />
+          <TableHeaderRow
+            rowComponent={TableRow}
+            showSortingControls
+          />
+        </Grid>
       </div>
     )
   },

--- a/src/eval-frame/index.jsx
+++ b/src/eval-frame/index.jsx
@@ -5,7 +5,6 @@ import { render } from 'react-dom'
 // external styles
 import 'font-awesome/css/font-awesome.css'
 import 'opensans-npm-webfont/style.css'
-import 'react-table/react-table.css'
 import '../../node_modules/katex/dist/katex.min.css'
 
 // iodide styles

--- a/src/eval-frame/style/eval-container.css
+++ b/src/eval-frame/style/eval-container.css
@@ -50,6 +50,13 @@ color: #a41c1c;
 overflow-x: auto;
 }
 
+.rep-base {
+  word-break: break-all;
+  line-height: 14px;
+  font-family: Menlo, monospace;
+  font-size: 11px;
+}
+
 .string-rep {
     word-break: break-word;
     color: #c41a16;


### PR DESCRIPTION
(This is a follow-on for #812, and includes/requires its rep improvements).

This uses [DevExtreme React Grid](https://devexpress.github.io/devextreme-reactive/react/grid/) instead of [React Table](https://react-table.js.org/#/story/readme).

The main improvement is the use of "virtual scrolling" rather than pagination.  Having two levels of scrolling (one for the table and one for the console) is a little annoying, but it feels better than having pagination.  I suspect that comes down a matter of personal preference, however.  Note that React Grid [also supports pagination](https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/paging/) so we could provide either as a user preference, potentially.

Anyway, hopefully this PR serves as a proof-of-concept.  It's hopefully at feature parity to what we had before.

<!---
@huboard:{"milestone_order":65.0585234054608}
-->
