### PR TITLE
Notebook revision fixes

### DIFF
--- a/server/notebooks/serializers.py
+++ b/server/notebooks/serializers.py
@@ -6,8 +6,7 @@ from server.base.models import User
 
 class NotebookLatestRevisionField(serializers.RelatedField):
     def get_attribute(self, obj):
-        return NotebookRevision.objects.filter(notebook_id=obj.id).order_by(
-            '-created').first()
+        return NotebookRevision.objects.filter(notebook_id=obj.id).last()
 
     def to_representation(self, value):
         if value:

--- a/server/notebooks/tests/test_notebook_api.py
+++ b/server/notebooks/tests/test_notebook_api.py
@@ -38,12 +38,31 @@ def test_notebook_detail(client, test_notebook):
     assert resp.json() == {
         "id": test_notebook.id,
         "owner": "testuser1",
-        "title": test_notebook.title,
+        "title": "First revision",
         "latest_revision": {
             "content": "*fake notebook content*",
             "created": "2018-07-01T13:00:00Z",
             "id": 1,
             "title": "First revision"
+        }
+    }
+
+    # add another revision, make sure all return values are updated
+    # appropriately
+    NotebookRevision.objects.create(notebook=test_notebook,
+                                    title="Second revision",
+                                    content="*updated fake notebook content*")
+    resp = client.get(reverse('notebooks-detail', kwargs={'pk': test_notebook.id}))
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "id": test_notebook.id,
+        "owner": "testuser1",
+        "title": "Second revision",
+        "latest_revision": {
+            "content": "*updated fake notebook content*",
+            "created": "2018-07-01T13:00:00Z",
+            "id": 2,
+            "title": "Second revision"
         }
     }
 

--- a/server/notebooks/tests/test_notebook_revision_api.py
+++ b/server/notebooks/tests/test_notebook_revision_api.py
@@ -95,3 +95,7 @@ def test_create_notebook_revision(fake_user, test_notebook, client):
     notebook_revision = NotebookRevision.objects.first()
     assert notebook_revision.title == post_blob['title']
     assert notebook_revision.content == post_blob['content']
+
+    # make sure that the title gets updated too
+    test_notebook.refresh_from_db()
+    assert test_notebook.title == post_blob['title']

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -11,7 +11,7 @@ from .models import Notebook
 def notebook_view(request, pk):
     template = loader.get_template('notebook.html')
     notebook = get_object_or_404(Notebook, pk=pk)
-    latest_revision = notebook.revisions.first()
+    latest_revision = notebook.revisions.last()
     if request.user.is_authenticated:
         user_info = json.dumps(get_user_info_dict(request.user))
     else:


### PR DESCRIPTION
Be sure that the title property of a notebook gets updated when a new
revision is sent, and that we always associate the latest revision
with the notebook when requesting the notebook by itself.