### PR TITLE
Fix #818: Support multi-line strings in iodide.output.text

### DIFF
--- a/src/eval-frame/iodide-api/output.js
+++ b/src/eval-frame/iodide-api/output.js
@@ -26,8 +26,10 @@ function sideEffectDiv(sideEffectClass, reportSideEffect) {
 export const output = {
   text: (s, reportSideEffect = false) => {
     // dumbly puts a string in a side effect div
-    const div = sideEffectDiv('side-effect-print', reportSideEffect)
-    div.innerHTML = s.toString()
+    for (const line of s.toString().split('\n')) {
+      const div = sideEffectDiv('side-effect-print', reportSideEffect)
+      div.innerHTML = line
+    }
   },
   element: (nodeType, reportSideEffect = true) => {
     const div = sideEffectDiv('side-effect-element', reportSideEffect)

--- a/src/eval-frame/iodide-api/output.js
+++ b/src/eval-frame/iodide-api/output.js
@@ -28,7 +28,7 @@ export const output = {
     // dumbly puts a string in a side effect div
     for (const line of s.toString().split('\n')) {
       const div = sideEffectDiv('side-effect-print', reportSideEffect)
-      div.innerHTML = line
+      div.innerText = line
     }
   },
   element: (nodeType, reportSideEffect = true) => {


### PR DESCRIPTION
This has been updated to also support XML tag characters so that `output.text('<b>')` displays `<b>`.