### PR TITLE
Updated expected orderedmultidict hashes

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -106,7 +106,8 @@
         },
         "orderedmultidict": {
             "hashes": [
-                "sha256:b89895ba6438038d0bdf88020ceff876cf3eae0d5c66a69b526fab31125db2c5"
+                "sha256:b89895ba6438038d0bdf88020ceff876cf3eae0d5c66a69b526fab31125db2c5",
+                "sha256:24e3b730cf84e4a6a68be5cc760864905cf66abc89851e724bd5b4e849eaa96b"
             ],
             "version": "==1.0"
         },


### PR DESCRIPTION
orderedmultidict now has a wheel distribution (gruns/orderedmultidict#17),
which means we need to update the hashes.