### PR TITLE
Remove unused export-to-gist functionality

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -4,7 +4,6 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import (get_object_or_404,
                               redirect,
                               render)
-from social_django.models import UserSocialAuth
 
 from .notebooks.models import Notebook, NotebookRevision
 from .base.models import User
@@ -12,12 +11,9 @@ from .base.models import User
 
 def get_user_info_dict(user):
     if user.is_authenticated:
-        user_social_auth = UserSocialAuth.objects.get(user=user)
-        social_auth_extra_data = user_social_auth.extra_data
         return {
-            'name': social_auth_extra_data['login'],
+            'name': user.username,
             'avatar': user.avatar,
-            'accessToken': user.social_auth_extra_data['access_token']
         }
     return {}
 

--- a/src/actions/__tests__/verify-action-store-consistency.test.js
+++ b/src/actions/__tests__/verify-action-store-consistency.test.js
@@ -14,7 +14,6 @@ import { jsLanguageDefinition } from '../../state-schemas/mirrored-state-schema'
 // arbitrary props with arbitrary values into cells
 
 const mockUserData = {
-  accessToken: 'accessToken',
   name: 'name',
   avatar: 'avatar',
 }

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -98,11 +98,6 @@ tasks.logoutGithub = new UserTask({
   callback() { dispatcher.logout() },
 })
 
-tasks.exportGist = new UserTask({
-  title: 'Export Gist',
-  callback() { dispatcher.exportGist() },
-})
-
 tasks.selectUp = new UserTask({
   title: 'Select Cell Above',
   displayKeybinding: 'Up', // \u2191',

--- a/src/components/menu/view-controls.jsx
+++ b/src/components/menu/view-controls.jsx
@@ -51,7 +51,7 @@ export class ViewControlsUnconnected extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  const isAuthenticated = Boolean(state.userData.accessToken)
+  const isAuthenticated = Boolean(state.userData.name)
   return {
     isAuthenticated,
     name: state.userData.name,


### PR DESCRIPTION
This allows us to stop passing down the github access token to the
client, which is/was a bit of a security no-no. If we ever choose
to reimplement export-to-gist, we should do that on the server only.