### PR TITLE
Fix #791, #851: Save a copy of notebook to user's account

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -289,18 +289,7 @@ export function saveNotebookToServer() {
       },
     }
 
-    if (notebookInServer) {
-      // Update Exisiting Notebook
-      fetch(`/api/v1/notebooks/${state.notebookId}/revisions/`, postRequestOptions)
-        .then(response => response.json())
-        .then(() => {
-          const message = 'Updated Notebook'
-          dispatch(updateAppMessages({
-            message,
-            details: `${message} <br />Notebook saved`,
-          }))
-        })
-    } else {
+    const createNewNotebook = () => {
       // Create a New Notebook in Database
       fetch('/api/v1/notebooks/', postRequestOptions)
         .then(response => response.json())
@@ -313,6 +302,25 @@ export function saveNotebookToServer() {
           dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
           window.history.pushState('', {}, `/notebooks/${json.id}`)
         })
+    }
+
+    if (notebookInServer) {
+      // Update Exisiting Notebook
+      fetch(`/api/v1/notebooks/${state.notebookId}/revisions/`, postRequestOptions)
+        .then(response => [response.ok, response.json()])
+        .then(([ok]) => {
+          if (ok) {
+            const message = 'Updated Notebook'
+            dispatch(updateAppMessages({
+              message,
+              details: `${message} <br />Notebook saved`,
+            }))
+          } else if (window.confirm('Save a copy to your account?')) { // eslint-disable-line no-alert
+            createNewNotebook()
+          }
+        })
+    } else {
+      createNewNotebook()
     }
     dispatch({ type: 'NOTEBOOK_SAVED' })
   }


### PR DESCRIPTION
Strictly speaking, this closes the issues, but I'm not proud of using `window.confirm` :)

Looked into ways of presenting modal dialogs with material-ui and they all seem to either require persistent DOM content, are incomplete examples or only work with material-ui 0.x.  Maybe you all have a better idea?