### PR TITLE
generalizes the state around modals and the modal handler component,

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -410,9 +410,17 @@ export function deleteCell() {
   }
 }
 
-export function toggleHelpModal() {
+export function setModalState(modalState) {
   return {
-    type: 'TOGGLE_HELP_MODAL',
+    type: 'SET_MODAL_STATE',
+    modalState,
+  }
+}
+
+export function toggleHelpModal() {
+  return (dispatch, getState) => {
+    const modalState = getState().modalState === 'HELP_MODAL' ? 'MODALS_CLOSED' : 'HELP_MODAL'
+    dispatch(setModalState(modalState))
   }
 }
 

--- a/src/components/menu/notebook-header.jsx
+++ b/src/components/menu/notebook-header.jsx
@@ -6,7 +6,7 @@ import EditorModeToolbar from './editor-mode-toolbar'
 
 import AppMessages from '../app-messages/app-messages'
 
-import HelpModal from '../modals/help-modal'
+import IodideModalsRoot from '../modals/iodide-modals-root'
 
 const theme = createMuiTheme({
   palette: {
@@ -24,7 +24,7 @@ export default class NotebookHeader extends React.Component {
         </MuiThemeProvider>
         <PresentationModeToolbar />
         <AppMessages />
-        <HelpModal />
+        <IodideModalsRoot />
       </div>
     )
   }

--- a/src/components/modals/__tests__/keyboard-shortcut-list-test.js
+++ b/src/components/modals/__tests__/keyboard-shortcut-list-test.js
@@ -19,7 +19,6 @@ describe('HelpModalUnconnected React component', () => {
   beforeEach(() => {
     // postMessageToEditorMock = jest.fn()
     props = {
-      helpModalOpen: true,
       tasks: {
         a: new UserTask({
           title: 'task a',

--- a/src/components/modals/__tests__/keyboard-shortcut-list-test.js
+++ b/src/components/modals/__tests__/keyboard-shortcut-list-test.js
@@ -17,7 +17,6 @@ describe('HelpModalUnconnected React component', () => {
   }
 
   beforeEach(() => {
-    // postMessageToEditorMock = jest.fn()
     props = {
       tasks: {
         a: new UserTask({
@@ -55,12 +54,16 @@ describe('HelpModalUnconnected React component', () => {
   })
 
   it('has the right number of global shortcuts', () => {
-    expect(getTestComponent().find('.keyboard-shortcuts-global').children().length)
+    expect(getTestComponent()
+      .find('table.keyboard-shortcuts-global tbody')
+      .children().length)
       .toEqual(3)
   })
 
   it('has the right number of command mode shortcuts', () => {
-    expect(getTestComponent().find('.keyboard-shortcuts-command-mode').children().length)
+    expect(getTestComponent()
+      .find('table.keyboard-shortcuts-command-mode tbody')
+      .children().length)
       .toEqual(2)
   })
 })

--- a/src/components/modals/help-modal.jsx
+++ b/src/components/modals/help-modal.jsx
@@ -2,17 +2,13 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-// import { connect } from 'react-redux'
 
-// import Modal from '@material-ui/core/Modal'
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
-// import Close from '@material-ui/icons/Close'
 
 import KeyboardShortcutList from './keyboard-shortcut-list'
 
-// import { toggleHelpModal } from '../../actions/actions'
 import tasks from '../../actions/task-definitions'
 
 function AboutIodide() {
@@ -84,17 +80,3 @@ export default class HelpModal extends React.Component {
     )
   }
 }
-
-// export function mapStateToProps(state) {
-//   return {
-//     helpModalOpen: state.helpModalOpen,
-//   }
-// }
-
-// export function mapDispatchToProps(dispatch) {
-//   return {
-//     toggleHelpModal: () => dispatch(toggleHelpModal()),
-//   }
-// }
-
-// export default connect(mapStateToProps, mapDispatchToProps)(HelpModalUnconnected)

--- a/src/components/modals/help-modal.jsx
+++ b/src/components/modals/help-modal.jsx
@@ -2,9 +2,9 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
+// import { connect } from 'react-redux'
 
-import Modal from '@material-ui/core/Modal'
+// import Modal from '@material-ui/core/Modal'
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -12,7 +12,7 @@ import Tab from '@material-ui/core/Tab';
 
 import KeyboardShortcutList from './keyboard-shortcut-list'
 
-import { toggleHelpModal } from '../../actions/actions'
+// import { toggleHelpModal } from '../../actions/actions'
 import tasks from '../../actions/task-definitions'
 
 function AboutIodide() {
@@ -33,9 +33,8 @@ function MoreResources() {
   return (<div className="help-modal-contents">Coming soon...</div>);
 }
 
-export class HelpModalUnconnected extends React.Component {
+export default class HelpModal extends React.Component {
   static propTypes = {
-    helpModalOpen: PropTypes.bool,
     tasks: PropTypes.object,
   }
 
@@ -51,57 +50,51 @@ export class HelpModalUnconnected extends React.Component {
     // const { classes } = this.props
     const { value } = this.state
     return (
-      <Modal
-        open={this.props.helpModalOpen}
-        onEscapeKeyDown={this.props.toggleHelpModal}
-        onBackdropClick={this.props.toggleHelpModal}
+      <div
+        className="help-modal"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          height: '80%',
+          width: '60%',
+          background: 'white',
+          boxShadow: '0px 3px 10px 3px rgba(0, 0, 0, 0.7)',
+          flexDirection: 'column',
+          display: 'flex',
+        }}
       >
-        <div
-          className="help-modal"
+        <AppBar
+          position="static"
           style={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            height: '80%',
-            width: '60%',
-            background: 'white',
-            boxShadow: '0px 3px 10px 3px rgba(0, 0, 0, 0.7)',
-            flexDirection: 'column',
-            display: 'flex',
+            background: '#5d5d5d',
           }}
         >
-          <AppBar
-            position="static"
-            style={{
-              background: '#5d5d5d',
-            }}
-          >
-            <Tabs value={value} onChange={this.handleChange}>
-              <Tab label="Keyboard shortcuts" />
-              <Tab label="More resources" />
-              <Tab label="About Iodide" href="#basic-tabs" />
-            </Tabs>
-          </AppBar>
-          {value === 0 && <KeyboardShortcutList tasks={tasks} />}
-          {value === 1 && <MoreResources />}
-          {value === 2 && <AboutIodide />}
-        </div>
-      </Modal>
+          <Tabs value={value} onChange={this.handleChange}>
+            <Tab label="Keyboard shortcuts" />
+            <Tab label="More resources" />
+            <Tab label="About Iodide" href="#basic-tabs" />
+          </Tabs>
+        </AppBar>
+        {value === 0 && <KeyboardShortcutList tasks={tasks} />}
+        {value === 1 && <MoreResources />}
+        {value === 2 && <AboutIodide />}
+      </div>
     )
   }
 }
 
-export function mapStateToProps(state) {
-  return {
-    helpModalOpen: state.helpModalOpen,
-  }
-}
+// export function mapStateToProps(state) {
+//   return {
+//     helpModalOpen: state.helpModalOpen,
+//   }
+// }
 
-export function mapDispatchToProps(dispatch) {
-  return {
-    toggleHelpModal: () => dispatch(toggleHelpModal()),
-  }
-}
+// export function mapDispatchToProps(dispatch) {
+//   return {
+//     toggleHelpModal: () => dispatch(toggleHelpModal()),
+//   }
+// }
 
-export default connect(mapStateToProps, mapDispatchToProps)(HelpModalUnconnected)
+// export default connect(mapStateToProps, mapDispatchToProps)(HelpModalUnconnected)

--- a/src/components/modals/iodide-modals-root.jsx
+++ b/src/components/modals/iodide-modals-root.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import Modal from '@material-ui/core/Modal'
+
+import { setModalState } from '../../actions/actions'
+
+import HelpModal from './help-modal'
+
+export class IodideModalRootUnconnected extends React.Component {
+  static propTypes = {
+    modalState: PropTypes.string.isRequired,
+  }
+
+  render() {
+    const { modalState } = this.props
+    let modalContents
+    switch (modalState) {
+      case 'HELP_MODAL':
+        modalContents = <HelpModal />
+        break
+      default:
+        modalContents = <div>(empty modal placeholder)</div>
+    }
+
+    return (
+      <Modal
+        open={modalState !== 'MODALS_CLOSED'}
+        onEscapeKeyDown={this.props.closeModals}
+        onBackdropClick={this.props.closeModals}
+      >
+        {modalContents}
+      </Modal>
+    )
+  }
+}
+
+export function mapStateToProps(state) {
+  return {
+    modalState: state.modalState,
+  }
+}
+
+export function mapDispatchToProps(dispatch) {
+  return {
+    closeModals: () => dispatch(setModalState('MODALS_CLOSED')),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(IodideModalRootUnconnected)

--- a/src/components/modals/keyboard-shortcut-list.jsx
+++ b/src/components/modals/keyboard-shortcut-list.jsx
@@ -27,10 +27,10 @@ export default class KeyboardShortcutList extends React.Component {
     return (
       <div className="help-modal-contents">
         <h2>Global keys</h2>
-        <table className="keyboard-shortcuts-global">{globalKeys}</table>
+        <table className="keyboard-shortcuts-global"><tbody>{globalKeys}</tbody></table>
         <h2>Command mode keys (press <pre className="key-combo-pill">Esc</pre> to enter command mode)
         </h2>
-        <table className="keyboard-shortcuts-command-mode">{commandModeKeys}</table>
+        <table className="keyboard-shortcuts-command-mode"><tbody>{commandModeKeys}</tbody></table>
       </div>
     )
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,6 +17,7 @@ import './style/header-bar-styles.css'
 import './style/side-panes.css'
 import './style/menu-and-button-and-ui-styles.css'
 import './style/cell-styles.css'
+import './style/help-modal-styles.css'
 
 import NotebookHeader from './components/menu/notebook-header'
 import EditorPaneContainer from './components/editor-pane-container'

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -103,9 +103,8 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { viewMode })
     }
 
-    case 'TOGGLE_HELP_MODAL': {
-      const helpModalOpen = !state.helpModalOpen
-      return Object.assign({}, state, { helpModalOpen })
+    case 'SET_MODAL_STATE': {
+      return Object.assign({}, state, { modalState: action.modalState })
     }
 
     case 'TOGGLE_EDITOR_LINK': {

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -41,9 +41,10 @@ export const editorOnlyStateProperties = {
     type: 'boolean',
     default: false,
   },
-  helpModalOpen: {
-    type: 'boolean',
-    default: false,
+  modalState: {
+    type: 'string',
+    enum: ['HELP_MODAL', 'MODALS_CLOSED'],
+    default: 'MODALS_CLOSED',
   },
   lastSaved: {
     type: 'string',


### PR DESCRIPTION
also fixes #840 and clears a warning

@hamilton please review to make sure the code looks reasonable. @mdboom please review to take a look at this pattern to assess whether you want to use this in what you're working on.

(regarding that latter bit: I wonder if it might make sense to invert control here a little bit? -- maybe replace saveNotebookToServer with a wrapper trySavingNotebookToServer that can detect (a) if a user is logged in, and (b) if a user is looking at their own notebook, inwhich case saveNotebookToServer can be called straight away; but if those things are not true, the user can be prompted to log in and/or make a copy)