### PR TITLE
Remove npm package method-override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9019,17 +9019,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "method-override": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.10.tgz",
-      "integrity": "sha1-49r41d7hDdLc59SuiNYrvud0drQ=",
-      "requires": {
-        "debug": "2.6.9",
-        "methods": "1.1.2",
-        "parseurl": "1.3.2",
-        "vary": "1.1.2"
-      }
-    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "markdown-it": "^8.4.1",
     "markdown-it-anchor": "^4.0.0",
     "markdown-it-katex": "^2.0.3",
-    "method-override": "^2.3.10",
     "mousetrap": "^1.6.1",
     "opensans-npm-webfont": "^1.0.0",
     "prop-types": "^15.6.1",


### PR DESCRIPTION
This was overlooked when we switched away from the node-based backend server.