### PR TITLE
Fix #851: Add interstitial about saving to own account

### DIFF
--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -8,5 +8,6 @@
 </script>
 <div id="page"></div>
 {{ user_info|json_script:"userData" }}
+{{ notebook_info|json_script:"notebookInfo" }}
 <script src="/iodide.dev.js"></script>
 {% endblock %}

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -20,7 +20,7 @@ def notebook_view(request, pk):
     else:
         notebook_content = notebook.revisions.last()
     notebook_info = {
-        'user_can_save': notebook.owner_id == request.user
+        'user_can_save': notebook.owner_id == request.user.id
     }
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -19,8 +19,12 @@ def notebook_view(request, pk):
         notebook_content = get_object_or_404(NotebookRevision, pk=int(request.GET['revision']))
     else:
         notebook_content = notebook.revisions.last()
+    notebook_info = {
+        'user_can_save': notebook.owner_id == request.user
+    }
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),
+        'notebook_info': notebook_info,
         'jsmd': notebook_content.content
     })
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -255,43 +255,70 @@ export function logout() {
   }
 }
 
+function getNotebookSaveRequestOptions(state) {
+  const data = {
+    title: state.title,
+    content: exportJsmdToString(state),
+  }
+
+  // Get CSRF Cookie for Django CSRF Middleware
+  function getCookie(name) {
+    if (!document.cookie) {
+      return null
+    }
+    const token = document.cookie.split(';')
+      .map(c => c.trim())
+      .filter(c => c.startsWith(`${name}=`))
+
+    if (token.length === 0) {
+      return null;
+    }
+    return decodeURIComponent(token[0].split('=')[1])
+  }
+
+  const csrftoken = getCookie('csrftoken')
+
+  const postRequestOptions = {
+    body: JSON.stringify(data),
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': csrftoken,
+    },
+  }
+
+  return postRequestOptions
+}
+
+export function createNewNotebookOnServer() {
+  return (dispatch, getState) => {
+    const state = getState()
+
+    const postRequestOptions = getNotebookSaveRequestOptions(state)
+    // Create a New Notebook in Database
+    fetch('/api/v1/notebooks/', postRequestOptions)
+      .then(response => response.json())
+      .then((json) => {
+        const message = 'Notebook saved to server'
+        dispatch(updateAppMessages({
+          message,
+          details: `${message} <br />Notebook saved`,
+        }))
+        dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
+        window.history.pushState('', {}, `/notebooks/${json.id}`)
+      })
+    dispatch({ type: 'NOTEBOOK_SAVED' })
+  }
+}
+
 export function saveNotebookToServer() {
   return (dispatch, getState) => {
     const state = getState()
 
     const notebookInServer = Boolean(state.notebookId)
-    const data = {
-      title: state.title,
-      content: exportJsmdToString(state),
-    }
-
-    // Get CSRF Cookie for Django CSRF Middleware
-    function getCookie(name) {
-      if (!document.cookie) {
-        return null
-      }
-      const token = document.cookie.split(';')
-        .map(c => c.trim())
-        .filter(c => c.startsWith(`${name}=`))
-
-      if (token.length === 0) {
-        return null;
-      }
-      return decodeURIComponent(token[0].split('=')[1])
-    }
-
-    const csrftoken = getCookie('csrftoken')
-
-    const postRequestOptions = {
-      body: JSON.stringify(data),
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': csrftoken,
-      },
-    }
 
     if (notebookInServer) {
+      const postRequestOptions = getNotebookSaveRequestOptions(state)
       // Update Exisiting Notebook
       fetch(`/api/v1/notebooks/${state.notebookId}/revisions/`, postRequestOptions)
         .then(response => response.json())
@@ -302,21 +329,10 @@ export function saveNotebookToServer() {
             details: `${message} <br />Notebook saved`,
           }))
         })
+      dispatch({ type: 'NOTEBOOK_SAVED' })
     } else {
-      // Create a New Notebook in Database
-      fetch('/api/v1/notebooks/', postRequestOptions)
-        .then(response => response.json())
-        .then((json) => {
-          const message = 'Notebook saved to server'
-          dispatch(updateAppMessages({
-            message,
-            details: `${message} <br />Notebook saved`,
-          }))
-          dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
-          window.history.pushState('', {}, `/notebooks/${json.id}`)
-        })
+      createNewNotebookOnServer()(dispatch, getState)
     }
-    dispatch({ type: 'NOTEBOOK_SAVED' })
   }
 }
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -306,8 +306,8 @@ export function createNewNotebookOnServer() {
         }))
         dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
         window.history.pushState('', {}, `/notebooks/${json.id}`)
+        dispatch({ type: 'NOTEBOOK_SAVED' })
       })
-    dispatch({ type: 'NOTEBOOK_SAVED' })
   }
 }
 

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -1,0 +1,45 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import { HeaderMessagesUnconnected, mapStateToProps } from '../header-messages'
+
+describe('HeaderMessagesUnconnected React component', () => {
+ 
+})
+
+
+describe('CellContainer mapStateToProps', () => {
+  let state
+  let ownProps
+
+  beforeEach(() => {
+    state = {
+      viewMode: 'EXPLORE_VIEW',
+      userData: {
+        name: 'user'
+      },
+      notebookInfo: {
+        user_can_save: true
+      },
+    }
+    ownProps = { }
+  })
+
+  it('displays login message', () => {
+    state.userData.name = undefined
+    state.notebookInfo.user_can_save = false
+    expect(mapStateToProps(state, ownProps).message)
+      .toEqual('NEED_TO_LOGIN')
+  })
+
+  it('displays make a copy message', () => {
+    state.notebookInfo.user_can_save = false
+    expect(mapStateToProps(state, ownProps).message)
+      .toEqual('NEED_TO_MAKE_COPY')
+  })
+
+  it('displays nothing', () => {
+    expect(mapStateToProps(state, ownProps).message)
+      .toEqual(undefined)
+  })
+})

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -1,12 +1,14 @@
-import { shallow } from 'enzyme'
-import React from 'react'
+// import { shallow } from 'enzyme'
+// import React from 'react'
 
-import { HeaderMessagesUnconnected, mapStateToProps } from '../header-messages'
+import {
+  // HeaderMessagesUnconnected,
+  mapStateToProps,
+} from '../header-messages'
 
-describe('HeaderMessagesUnconnected React component', () => {
- 
-})
-
+// describe('HeaderMessagesUnconnected React component', () => {
+//
+// })
 
 describe('CellContainer mapStateToProps', () => {
   let state
@@ -16,10 +18,10 @@ describe('CellContainer mapStateToProps', () => {
     state = {
       viewMode: 'EXPLORE_VIEW',
       userData: {
-        name: 'user'
+        name: 'user',
       },
       notebookInfo: {
-        user_can_save: true
+        user_can_save: true,
       },
     }
     ownProps = { }

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import Button from '@material-ui/core/Button'
+
 import { createNewNotebookOnServer, login } from '../../actions/actions'
 
 export class HeaderMessagesUnconnected extends React.Component {
@@ -18,7 +20,7 @@ export class HeaderMessagesUnconnected extends React.Component {
       case 'NEED_TO_LOGIN':
         content = (
           <span>
-            To save to this server, you need to <a onClick={this.props.login}>login</a>.
+            To save to this server, you need to <Button onClick={this.props.login}>login</Button>
           </span>
         )
         break
@@ -26,7 +28,7 @@ export class HeaderMessagesUnconnected extends React.Component {
         content = (
           <span>
             This notebook is owned by another user.
-            <a onClick={this.props.makeCopy}>Make a copy to your account</a>.
+            <Button onClick={this.props.makeCopy}>Make a copy to your account</Button>
           </span>
         )
         break

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -37,7 +37,6 @@ export class HeaderMessagesUnconnected extends React.Component {
     return (
       <div
         className="notebook-header-messages-container"
-        style={{ display: this.props.message ? 'block' : 'none' }}
       >
         {content}
       </div>

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -2,8 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import Button from '@material-ui/core/Button'
-
 import { createNewNotebookOnServer, login } from '../../actions/actions'
 
 export class HeaderMessagesUnconnected extends React.Component {
@@ -20,7 +18,7 @@ export class HeaderMessagesUnconnected extends React.Component {
       case 'NEED_TO_LOGIN':
         content = (
           <span>
-            To save to this server, you need to <Button onClick={this.props.login}>login</Button>
+            To save to this server, you need to <a onClick={this.props.login}>login</a>.
           </span>
         )
         break
@@ -28,7 +26,7 @@ export class HeaderMessagesUnconnected extends React.Component {
         content = (
           <span>
             This notebook is owned by another user.
-            <Button onClick={this.props.makeCopy}>Make a copy to your account</Button>
+            <a onClick={this.props.makeCopy}>Make a copy to your account</a>.
           </span>
         )
         break

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -25,7 +25,7 @@ export class HeaderMessagesUnconnected extends React.Component {
       case 'NEED_TO_MAKE_COPY':
         content = (
           <span>
-            This notebook is owned by another user.
+            This notebook is owned by another user. {}
             <a onClick={this.props.makeCopy}>Make a copy to your account</a>.
           </span>
         )

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -6,7 +6,7 @@ import { createNewNotebookOnServer, login } from '../../actions/actions'
 
 export class HeaderMessagesUnconnected extends React.Component {
   static propTypes = {
-    message: PropTypes.oneOf(['LOGIN', 'MAKE_COPY']),
+    message: PropTypes.oneOf(['NEED_TO_LOGIN', 'NEED_TO_MAKE_COPY']),
     login: PropTypes.func.isRequired,
     makeCopy: PropTypes.func.isRequired,
   }

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -70,5 +70,4 @@ function mapDispatchToProps(dispatch) {
   }
 }
 
-const HeaderMessages = connect(mapStateToProps, mapDispatchToProps)(HeaderMessagesUnconnected)
-export default HeaderMessages
+export default connect(mapStateToProps, mapDispatchToProps)(HeaderMessagesUnconnected)

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import { createNewNotebookOnServer, login } from '../../actions/actions'
+
+export class HeaderMessagesUnconnected extends React.Component {
+  static propTypes = {
+    message: PropTypes.oneOf(['LOGIN', 'MAKE_COPY']),
+    login: PropTypes.func.isRequired,
+    makeCopy: PropTypes.func.isRequired,
+  }
+
+  render() {
+    let content;
+
+    switch (this.props.message) {
+      case 'NEED_TO_LOGIN':
+        content = (
+          <span>
+            To save to this server, you need to <a onClick={this.props.login}>login</a>.
+          </span>
+        )
+        break
+      case 'NEED_TO_MAKE_COPY':
+        content = (
+          <span>
+            This notebook is owned by another user.
+            <a onClick={this.props.makeCopy}>Make a copy to your account</a>.
+          </span>
+        )
+        break
+      default:
+        return null
+    }
+
+    return (
+      <div
+        className="notebook-header-messages-container"
+        style={{ display: this.props.message ? 'block' : 'none' }}
+      >
+        {content}
+      </div>
+    )
+  }
+}
+
+export function mapStateToProps(state) {
+  if (state.viewMode === 'EXPLORE_VIEW') {
+    if (state.userData.name === undefined) {
+      return { message: 'NEED_TO_LOGIN' }
+    } else if (!state.notebookInfo.user_can_save) {
+      return { message: 'NEED_TO_MAKE_COPY' }
+    }
+  }
+
+  return {}
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    login: () => {
+      dispatch(login())
+    },
+    makeCopy: () => {
+      dispatch(createNewNotebookOnServer())
+    },
+  }
+}
+
+const HeaderMessages = connect(mapStateToProps, mapDispatchToProps)(HeaderMessagesUnconnected)
+export default HeaderMessages

--- a/src/components/menu/notebook-header.jsx
+++ b/src/components/menu/notebook-header.jsx
@@ -4,6 +4,8 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import PresentationModeToolbar from './presentation-mode-toolbar'
 import EditorModeToolbar from './editor-mode-toolbar'
 
+import HeaderMessages from './header-messages'
+
 import AppMessages from '../app-messages/app-messages'
 
 import IodideModalsRoot from '../modals/iodide-modals-root'
@@ -22,6 +24,7 @@ export default class NotebookHeader extends React.Component {
         <MuiThemeProvider theme={theme}>
           <EditorModeToolbar />
         </MuiThemeProvider>
+        <HeaderMessages />
         <PresentationModeToolbar />
         <AppMessages />
         <IodideModalsRoot />

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -34,8 +34,17 @@ function getUserData() {
   return {}
 }
 
+function getNotebookInfo() {
+  const notebookInfo = document.getElementById('notebookInfo')
+  if (notebookInfo) {
+    return { notebookInfo: JSON.parse(notebookInfo.textContent) }
+  }
+  return {}
+}
+
 export {
   getUserData,
+  getNotebookInfo,
   newCell,
   newCellID,
   newNotebook,

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -88,7 +88,10 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case 'NOTEBOOK_SAVED': {
-      return Object.assign({}, state, { lastSaved: new Date().toISOString() })
+      return Object.assign({}, state, {
+        lastSaved: new Date().toISOString(),
+        notebookInfo: Object.assign({}, state.notebookInfo, { user_can_save: true }),
+      })
     }
 
     case 'ADD_NOTEBOOK_ID': {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,5 +1,5 @@
 /* global IODIDE_BUILD_TYPE */
-import { newNotebook, getUserData, newCell, newCellID, paneRatios } from '../editor-state-prototypes'
+import { newNotebook, getUserData, getNotebookInfo, newCell, newCellID, paneRatios } from '../editor-state-prototypes'
 import {
   exportJsmdBundle,
   titleToHtmlFilename,
@@ -83,7 +83,7 @@ const notebookReducer = (state = newNotebook(), action) => {
 
       return Object.assign(
         newNotebook(), nextState, { cells, notebookId },
-        getUserData(),
+        getUserData(), getNotebookInfo(),
       )
     }
 

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -73,6 +73,15 @@ export const editorOnlyStateProperties = {
     type: 'object',
     default: {},
   },
+  notebookInfo: {
+    type: 'object',
+    properties: {
+      user_can_save: { type: 'boolean' },
+    },
+    default: {
+      user_can_save: false,
+    },
+  },
   viewMode: {
     type: 'string',
     enum: ['EXPLORE_VIEW', 'REPORT_VIEW'],

--- a/src/style/header-bar-styles.css
+++ b/src/style/header-bar-styles.css
@@ -6,7 +6,7 @@
 
 .notebook-header-messages-container {
   background-color: lightyellow;
-  padding: 10px;
+  padding: 5px;
   border-bottom: darkgrey solid 1px;
 }
 

--- a/src/style/header-bar-styles.css
+++ b/src/style/header-bar-styles.css
@@ -4,6 +4,17 @@
   height: 50px
 }
 
+.notebook-header-messages-container {
+  background-color: lightyellow;
+  padding: 10px;
+  border-bottom: darkgrey solid 1px;
+}
+
+.notebook-header-messages-container a {
+  font-weight: bold;
+  cursor: pointer;
+}
+
 .notebook-toolbar {
   height:50px;
   display: flex;


### PR DESCRIPTION
**Requires #908 to be merged first**

Sorry this is sort of combining two things:

1. This adds a bar right below the toolbar to display notifications that require some sort of action. The state uses a list of these notifications, so there could be more than one.
2. Displaying a message that the user can't save because they aren't logged in, or that they need to save a copy to their own account if this notebook isn't theirs.  (This is really just a proof-of-concept of #1).

Still getting my sealegs with react.  I have some inline comments below.

![image](https://user-images.githubusercontent.com/38294/45571997-167f8200-b836-11e8-9791-99f4635b94ea.png)
