### PR TITLE
Add editor state schema for userData structure (fixes #802)

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -12,8 +12,7 @@ def get_user_info_dict(user):
     if user.is_authenticated:
         return {
             'name': user.username,
-            'avatar': user.avatar,
-            'accessToken': user.social_auth_extra_data['access_token']
+            'avatar': user.avatar
         }
     return {}
 

--- a/src/components/menu/editor-toolbar-menu.jsx
+++ b/src/components/menu/editor-toolbar-menu.jsx
@@ -30,7 +30,7 @@ export class EditorToolbarMenuUnconnected extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  const isAuthenticated = Boolean(state.userData.accessToken)
+  const isAuthenticated = Boolean(state.userData.name)
   return {
     isAuthenticated,
   }

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -69,8 +69,12 @@ export const editorOnlyStateProperties = {
     default: 'untitled',
   },
   userData: {
-    // FIXME userData needs full schema!!
     type: 'object',
+    properties: {
+      name: { type: 'string' },
+      avatar: { type: 'string' },
+    },
+    additionalProperties: false,
     default: {},
   },
   viewMode: {


### PR DESCRIPTION
This PR also cleans up some code which was still sending the access token
down to the client as part of the userData structure.