### PR TITLE
Fix potential race when running tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,12 @@ matrix:
       script:
         - cp .env-dist .env
         - make build
-        # bring up docker containers and wait for db setup to complete
+        # bring up docker containers and wait for db setup to complete (otherwise
+        # our tests might try to bring up another instance of the db, which is a
+        # race condition)
+        # (FIXME: need some sort of timeout here)
         - docker-compose up -d
+        - docker-compose run server bash -c "while ! echo > /dev/tcp/db/5432 > /dev/null 2>&1; do sleep 1 && echo waiting for db; done"
         # run actual tests
         - make flake8
         - make test


### PR DESCRIPTION
It seems like if docker-compose will attempt to bring up multiple
instances of a container if you run it once with `-d` and then
attempt to run a one-off command before it has brought up the full
environment. Get around this by waiting for our dependent container
to completely start before running our tests.