### PR TITLE
fixes the interstitial appearing with the /new url

### DIFF
--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -60,5 +60,6 @@ def notebook_revisions(request, pk):
 def new_notebook_view(request):
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),
+        'notebook_info': {'user_can_save': True},
         'jsmd': ''
     })

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -433,6 +433,13 @@ export function setModalState(modalState) {
   }
 }
 
+export function updateNotebookInfo(notebookInfo) {
+  return {
+    type: 'UPDATE_NOTEBOOK_INFO',
+    notebookInfo,
+  }
+}
+
 export function toggleHelpModal() {
   return (dispatch, getState) => {
     const modalState = getState().modalState === 'HELP_MODAL' ? 'MODALS_CLOSED' : 'HELP_MODAL'

--- a/src/handle-server-variables.js
+++ b/src/handle-server-variables.js
@@ -1,0 +1,9 @@
+import { getNotebookInfo } from './editor-state-prototypes'
+import { updateNotebookInfo } from './actions/actions'
+
+export default function handleServerVariables(store) {
+  const nbObj = getNotebookInfo()
+  if (Object.keys(nbObj).length > 0) {
+    store.dispatch(updateNotebookInfo(nbObj.notebookInfo))
+  }
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,8 +23,8 @@ import NotebookHeader from './components/menu/notebook-header'
 import EditorPaneContainer from './components/editor-pane-container'
 import { store } from './store'
 import handleInitialJsmd from './handle-initial-jsmd'
+import handleServerVariables from './handle-server-variables'
 import { initializeDefaultKeybindings } from './keybindings'
-
 
 import { listenForEvalFramePortReady } from './port-to-eval-frame'
 
@@ -62,6 +62,7 @@ panesContainerElt.insertBefore(editorElt, iframeElt)
 
 
 handleInitialJsmd(store)
+handleServerVariables(store)
 
 render(
   <Provider store={store}>

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -55,6 +55,9 @@ const notebookReducer = (state = newNotebook(), action) => {
     case 'TOGGLE_WRAP_IN_EDITORS':
       return Object.assign({}, state, { wrapEditors: !state.wrapEditors })
 
+    case 'UPDATE_NOTEBOOK_INFO':
+      return Object.assign({}, state, { notebookInfo: action.notebookInfo })
+
     case 'EVAL_FRAME_READY': {
       state.evalFrameMessageQueue.forEach((actionToPost) => {
         postActionToEvalFrame(actionToPost)


### PR DESCRIPTION
Fixes #917. 

- created a new function in `handle-server-variables.js` which operates similarly to `handleInitialJsmd` - it helps initiate the store with non-store data, particularly using the `getNotebookInfo`
- updated the `new_notebook_view` to pass by default to `user_can_save: true` (since atm login is required to create a new notebook, we'll want to change this later)