### PR TITLE
Fix #766: Export should point to resources on exporting server

### DIFF
--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -68,5 +68,9 @@ def new_notebook_view(request):
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),
         'notebook_info': {'user_can_save': True},
-        'jsmd': ''
+        'jsmd': '',
+        'iframe_src': '{}/iodide.eval-frame.{}.html'.format(
+            EVAL_FRAME_ORIGIN,
+            APP_VERSION_STRING,
+            )
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,14 +38,12 @@ module.exports = (env) => {
     plugins.push(new UglifyJSPlugin())
   }
 
-  if (env.includes('client-only')) {
-    APP_PATH_STRING = `${EDITOR_ORIGIN}/`
-    CSS_PATH_STRING = `${EDITOR_ORIGIN}/`
-  } else {
+  APP_PATH_STRING = `${EDITOR_ORIGIN}/`
+  CSS_PATH_STRING = `${EDITOR_ORIGIN}/`
+
+  if (!env.includes('client-only')) {
     // default case: heroku or local python server using docker-compose
     EDITOR_ORIGIN = process.env.SERVER_URI || `http://localhost:${DEV_SERVER_PORT}`
-    APP_PATH_STRING = ''
-    CSS_PATH_STRING = ''
   }
 
   EVAL_FRAME_ORIGIN = EVAL_FRAME_ORIGIN || EDITOR_ORIGIN


### PR DESCRIPTION
When exporting a notebook, is was exporting a relative path to the .js and .css.  This fixes it to point back to the code from the server doing the exporting.

Fixes #766 and is a necessary first step for #896.

Also fixes `/new` not having an iframe which was broken by #871.