### PR TITLE
WIP: Make strings expand when clicking on them

### DIFF
--- a/src/components/reps/array-handler.jsx
+++ b/src/components/reps/array-handler.jsx
@@ -32,7 +32,7 @@ export default {
       if (len > MAX_ELTS) {
         arrayElements.push((
           <span key="array_elts_omitted" className="elements-omitted-info-rep">
-            {` ... ${len - MAX_ELTS} elements omitted ...`}
+            {` … ${len - MAX_ELTS} elements omitted …`}
           </span>))
         arrayElements = arrayElements
           .concat(_.range(len - HALF_MAX_ELTS, len - 1)

--- a/src/components/reps/string-handler.jsx
+++ b/src/components/reps/string-handler.jsx
@@ -5,34 +5,42 @@ const MAX_CHARS = 1000
 export default {
   shouldHandle: value => typeof (value) === 'string',
   render: (value, inCollection) => {
-    const maxChars = inCollection ? 10 : MAX_CHARS
-    if (value.length <= maxChars) {
-      return (
-        <React.Fragment>
-          <span className="string-rep string-rep-before-quote string-rep-after-quote">{value}</span>
-        </React.Fragment>
-      )
+    let extraClasses = ''
+    if (inCollection) {
+      extraClasses = 'string-rep-truncated'
     }
 
-    // In a collection, just truncate and add "…".
-    // Outside a collection, insert the "X characters ommitted..." chunk in the middle
-    if (inCollection) {
+    const toggle = (e) => {
+      const { classList } = e.currentTarget
+      if (classList.contains('string-rep-truncated')) {
+        classList.replace('string-rep-truncated', 'string-rep-expanded')
+      } else if (classList.contains('string-rep-expanded')) {
+        classList.replace('string-rep-expanded', 'string-rep-truncated')
+      }
+    }
+
+    if (value.length <= MAX_CHARS) {
       return (
         <React.Fragment>
-          <span className="string-rep string-rep-before-quote">{value.slice(0, maxChars)}</span>
-          <span className="string-rep-ellipsis string-rep-after-quote">…</span>
+          <span onClick={toggle} className={`string-rep string-rep-before-quote string-rep-after-quote ${extraClasses}`}>
+            {value}
+          </span>
         </React.Fragment>
       )
     }
 
     return (
       <React.Fragment>
-        <span className="string-rep string-rep-before-quote">{value.slice(0, maxChars / 2)}</span>
-        <span className="elements-omitted-info-rep">
-          {`… ${value.length - maxChars} chars …`}
-        </span>
-        <span className="string-rep string-rep-after-quote">
-          {value.slice(value.length - Math.round(maxChars / 2))}
+        <span className={extraClasses} onClick={e => toggle(e)}>
+          <span className="string-rep string-rep-before-quote">
+            {value.slice(0, MAX_CHARS / 2)}
+          </span>
+          <span className="elements-omitted-info-rep">
+            {`… ${value.length - MAX_CHARS} chars …`}
+          </span>
+          <span className="string-rep string-rep-after-quote">
+            {value.slice(value.length - Math.round(MAX_CHARS / 2))}
+          </span>
         </span>
       </React.Fragment>
     )

--- a/src/eval-frame/style/eval-container.css
+++ b/src/eval-frame/style/eval-container.css
@@ -62,6 +62,19 @@ overflow-x: auto;
     content: '"';
     color: #555;
 }
+.string-rep-truncated {
+    max-width: 60px;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: "…";
+    display: inline-block;
+    vertical-align: bottom;
+}
+.string-rep-expanded {
+    white-space: nowrap;
+    display: inline-block;
+    vertical-align: bottom;
+}
 
 .string-rep-ellipsis {
     color: #555;

--- a/src/eval-frame/style/eval-container.css
+++ b/src/eval-frame/style/eval-container.css
@@ -66,7 +66,7 @@ overflow-x: auto;
     max-width: 60px;
     white-space: nowrap;
     overflow-x: hidden;
-    text-overflow: "…";
+    text-overflow: ellipsis;
     display: inline-block;
     vertical-align: bottom;
 }


### PR DESCRIPTION
This allows clicking on a truncated string to display the entire string.

There's probably a lot of unworking edge cases here, and I'm not sure this is the best way to do this, but I think it might be a good place to begin the discussion.

<!---
@huboard:{"milestone_order":65.04795285903717}
-->
