### PR TITLE
Add a datetime helper function to django server tests

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,9 +1,14 @@
+import sys
+import os
+
 import pytest
 from rest_framework.test import APIClient
 
 from server.base.models import User
 from server.notebooks.models import (Notebook,
                                      NotebookRevision)
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture

--- a/server/tests/helpers/helpers.py
+++ b/server/tests/helpers/helpers.py
@@ -1,0 +1,7 @@
+# Misc. helper functions for unit tests
+
+
+# this helper function returns a time string in the same format as presented
+# by django rest framework (e.g. `2018-09-13T21:37:04.353408Z`)
+def get_rest_framework_time_string(t):
+    return t.isoformat()[:-6] + 'Z'

--- a/server/tests/test_notebook_api.py
+++ b/server/tests/test_notebook_api.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from server.notebooks.models import (Notebook,
                                      NotebookRevision)
+from helpers import get_rest_framework_time_string
 
 
 def test_notebook_list(client, two_test_notebooks):
@@ -27,7 +28,7 @@ def test_notebook_detail(client, test_notebook):
         "title": initial_revision.title,
         "latest_revision": {
             "content": initial_revision.content,
-            "created": initial_revision.created.isoformat()[:-6] + 'Z',
+            "created": get_rest_framework_time_string(initial_revision.created),
             "id": initial_revision.id,
             "title": initial_revision.title
         }
@@ -46,7 +47,7 @@ def test_notebook_detail(client, test_notebook):
         "title": "Second revision",
         "latest_revision": {
             "content": new_revision.content,
-            "created": new_revision.created.isoformat()[:-6] + 'Z',
+            "created": get_rest_framework_time_string(new_revision.created),
             "id": new_revision.id,
             "title": new_revision.title
         }

--- a/server/tests/test_notebook_revision_api.py
+++ b/server/tests/test_notebook_revision_api.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from server.notebooks.models import NotebookRevision
+from helpers import get_rest_framework_time_string
 
 
 def test_read_notebook_revisions(fake_user, two_test_notebooks, client):
@@ -21,7 +22,7 @@ def test_read_notebook_revisions(fake_user, two_test_notebooks, client):
     resp = client.get(reverse('notebook-revisions-list', kwargs={'notebook_id': test_notebook.id}))
     assert resp.status_code == 200
     assert resp.json() == [{
-        'created': revision.created.isoformat()[:-6] + 'Z',
+        'created': get_rest_framework_time_string(revision.created),
         'id': revision.id,
         'title': revision.title
     } for revision in NotebookRevision.objects.filter(notebook=test_notebook)]
@@ -34,7 +35,7 @@ def test_read_notebook_revisions(fake_user, two_test_notebooks, client):
     }))
     assert resp.json() == {
         'content': test_revision.content,
-        'created': test_revision.created.isoformat()[:-6] + 'Z',
+        'created': get_rest_framework_time_string(test_revision.created),
         'id': test_revision.id,
         'title': test_revision.title
     }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[pytest]
+norecursedirs=server/tests/helpers
+
 [flake8]
 max-line-length=100
 exclude=


### PR DESCRIPTION
Add and use a test helper function for simulating the way DRF serializes
python datetimes.