### PR TITLE
Fix `npm run start-and-serve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "test": "jest --no-cache",
-    "start-and-serve": "webpack-dev-server --watch --env=dev-client-only",
+    "start-and-serve": "webpack-dev-server --watch --env=dev",
     "start": "webpack --watch --env=dev",
     "build": "webpack",
     "build-production": "webpack --env=production",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,13 +38,13 @@ module.exports = (env) => {
     plugins.push(new UglifyJSPlugin())
   }
 
-  APP_PATH_STRING = `${EDITOR_ORIGIN}/`
-  CSS_PATH_STRING = `${EDITOR_ORIGIN}/`
-
   if (!env.includes('client-only')) {
     // default case: heroku or local python server using docker-compose
     EDITOR_ORIGIN = process.env.SERVER_URI || `http://localhost:${DEV_SERVER_PORT}/`
   }
+
+  APP_PATH_STRING = `${EDITOR_ORIGIN}/`
+  CSS_PATH_STRING = `${EDITOR_ORIGIN}/`
 
   EVAL_FRAME_ORIGIN = EVAL_FRAME_ORIGIN || EDITOR_ORIGIN
 


### PR DESCRIPTION
The "client-only" config is for building a standalone filesystem version of iodide.  When we run with the server, we shouldn't use that.

Also, there was just a dumb order-of-operations bug setting APP_PATH_STRING.