### PR TITLE
removed unused css reference in index.html

### DIFF
--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -1,7 +1,4 @@
 {% extends "base.html" %}
-{% block head %}
-<link rel="stylesheet" type="text/css" href="/server.home.dev.css">
-{% endblock %}
 {% block content %}
 <div id="page"></div>
 {{ page_data|json_script:"pageData" }}


### PR DESCRIPTION
closes #911. Not much review necessary. We weren't using the missing stylesheet that wasn't being generated at any rate.