### PR TITLE
Async language evaluator

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -165,7 +165,11 @@ export function evalConsoleInput(languageId) {
       dispatch(updateUserVariables())
     }
 
-    return runCodeWithLanguage(language, code)
+    const messageCallback = (msg) => {
+      dispatch(appendToEvalHistory(null, msg, undefined, { historyType: 'CELL_EVAL_INFO' }))
+    }
+
+    return runCodeWithLanguage(language, code, messageCallback)
       .then(updateAfterEvaluation)
       .then(waitForExplicitContinuationStatusResolution)
       // .then(() => dispatch(temporarilySaveRunningCellID(undefined)))
@@ -198,8 +202,12 @@ function evaluateCodeCell(cell) {
       dispatch(updateUserVariables())
     }
 
+    const messageCallback = (msg) => {
+      dispatch(appendToEvalHistory(cell.id, msg, undefined, { historyType: 'CELL_EVAL_INFO' }))
+    }
+
     return ensureLanguageAvailable(cell.language, cell, state, dispatch)
-      .then(language => runCodeWithLanguage(language, code))
+      .then(language => runCodeWithLanguage(language, code, messageCallback))
       .then(
         output => updateCellAfterEvaluation(output),
         output => updateCellAfterEvaluation(output, 'ERROR'),

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -137,7 +137,7 @@ export function runCodeWithLanguage(language, code, messageCallback) {
 
   if (asyncEvaluator !== undefined) {
     const messageCb = (messageCallback === undefined) ? () => {} : messageCallback
-    window[module][asyncEvaluator](code, messageCb)
+    return window[module][asyncEvaluator](code, messageCb)
   }
   return new Promise((resolve, reject) => {
     try {

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -132,9 +132,13 @@ export function ensureLanguageAvailable(languageId, cell, state, dispatch) {
   return new Promise((resolve, reject) => reject())
 }
 
-export function runCodeWithLanguage(language, code) {
-  const { module, evaluator } = language
+export function runCodeWithLanguage(language, code, messageCallback) {
+  const { module, evaluator, asyncEvaluator } = language
 
+  if (asyncEvaluator !== undefined) {
+    const messageCb = (messageCallback === undefined) ? () => {} : messageCallback
+    window[module][asyncEvaluator](code, messageCb)
+  }
   return new Promise((resolve, reject) => {
     try {
       resolve(window[module][evaluator](code))

--- a/src/state-schemas/language-definitions.js
+++ b/src/state-schemas/language-definitions.js
@@ -20,6 +20,7 @@ const pyLanguageDefinition = {
   url: 'https://iodide.io/pyodide-demo/pyodide.js',
   module: 'pyodide',
   evaluator: 'runPython',
+  asyncEvaluator: 'runPythonAsync',
   pluginType: 'language',
 }
 

--- a/src/state-schemas/mirrored-state-schema.js
+++ b/src/state-schemas/mirrored-state-schema.js
@@ -22,6 +22,7 @@ const languageSchema = {
     keybinding: { type: 'string' },
     module: { type: 'string' },
     evaluator: { type: 'string' },
+    asyncEvaluator: { type: 'string' },
     url: { type: 'string' },
   },
   additionalProperties: false,


### PR DESCRIPTION
**This is a follow-on to #1014, which makes the implementation here much easier.**  We probably want to do final review/merge on that first.  Otherwise, just look at the final commit here.

This implements the ability for language evaluators to be asynchronous, as outlined in #1025.  An optional message callback can be sent which will append messages to the console history as any asynchronous stuff happens.  We'll probably want some spinner or something as well, but I think that's probably better explored as a UX issue on its own.

This won't actually do anything with the Python plugin until https://github.com/iodide-project/pyodide/pull/217 is merged.