### PR TITLE
Fix #1035: Make error tracebacks stop before going into Iodide code

### DIFF
--- a/src/components/reps/error-handler.jsx
+++ b/src/components/reps/error-handler.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import ErrorStackParser from 'error-stack-parser'
 import StackFrame from 'stackframe'
 
+import { runCodeWithLanguage } from '../../eval-frame/actions/language-actions'
+
 
 ErrorStackParser.parseV8OrIE = (error) => {
   const filtered = error.stack.split('\n').filter(
@@ -102,7 +104,7 @@ export default {
 
     for (const frame of frames) {
       if ((frame.functionName !== undefined &&
-           frame.functionName.startsWith('evaluateCodeCell')) ||
+           frame.functionName.startsWith(runCodeWithLanguage.name)) ||
           (frame.functionName === undefined &&
            frame.fileName !== 'cell')) {
         break


### PR DESCRIPTION
In a production build, the name of the function that we want to stop at gets mangled.  By using `function.name` rather than a hardcoded string, it seems to work in both production and development.