### PR TITLE
fix language changing and update display name of Python

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -142,7 +142,9 @@ export function updateInputContent(text) {
 
 export function changeCellType(cellType, language = 'js') {
   return (dispatch, getState) => {
-    if (isCommandMode(getState()) && getSelectedCell(getState()).cellType !== cellType) {
+    if (isCommandMode(getState())
+      && (getSelectedCell(getState()).cellType !== cellType
+      || getSelectedCell(getState()).language !== language)) {
       dispatch({
         type: 'CHANGE_CELL_TYPE',
         cellType,

--- a/src/state-schemas/language-definitions.js
+++ b/src/state-schemas/language-definitions.js
@@ -14,7 +14,7 @@ export const jsLanguageDefinition = {
 
 const pyLanguageDefinition = {
   languageId: 'py',
-  displayName: 'python',
+  displayName: 'Python',
   codeMirrorMode: 'python',
   keybinding: 'p',
   url: 'https://iodide.io/pyodide-demo/pyodide.js',


### PR DESCRIPTION
another tiny one, this fixes the kbd and menu items for changing cell languages, and updates the display name for python to caps to match the other items in the menu.

this can merge as soon as CI passes