### PR TITLE
Fix async language plugin loading

### DIFF
--- a/src/components/reps/__tests__/error-handler.jsx
+++ b/src/components/reps/__tests__/error-handler.jsx
@@ -17,7 +17,7 @@ describe('errorHandler shouldHandle', () => {
       () => undefined,
       (err) => {
         expect(trimStack(err).split('\n').length).toBe(2)
-      }
+      },
     )
   })
 })

--- a/src/components/reps/__tests__/error-handler.jsx
+++ b/src/components/reps/__tests__/error-handler.jsx
@@ -14,11 +14,10 @@ describe('errorHandler shouldHandle', () => {
       evaluator: 'eval',
     }
     let err;
-    try {
-      runCodeWithLanguage(language, code)
-    } catch (e) {
-      err = e
-    }
-    expect(trimStack(err).split('\n').length).toBe(2)
+    runCodeWithLanguage(language, code).then(
+      () => undefined,
+      (err) => {
+        expect(trimStack(err).split('\n').length).toBe(2)
+      })
   })
 })

--- a/src/components/reps/__tests__/error-handler.jsx
+++ b/src/components/reps/__tests__/error-handler.jsx
@@ -13,11 +13,11 @@ describe('errorHandler shouldHandle', () => {
       module: 'window',
       evaluator: 'eval',
     }
-    let err;
     runCodeWithLanguage(language, code).then(
       () => undefined,
       (err) => {
         expect(trimStack(err).split('\n').length).toBe(2)
-      })
+      }
+    )
   })
 })

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -136,11 +136,11 @@ export function consoleHistoryStepBack(consoleCursorDelta) {
 export function evalConsoleInput(languageId) {
   return (dispatch, getState) => {
     const state = getState()
-    let output
     const code = state.consoleText
     // exit if there is no code in the console to  eval
     if (!code) { return undefined }
     const evalLanguageId = languageId === undefined ? state.languageLastUsed : languageId
+    const language = state.loadedLanguages[evalLanguageId]
 
     // FIXME: deal with side-effects for console evals
     // // clear stuff relating to the side effect target before evaling
@@ -152,31 +152,23 @@ export function evalConsoleInput(languageId) {
 
     // dispatch(temporarilySaveRunningCellID(cell.id))
     dispatch(incrementExecutionNumber())
-    try {
-      output = runCodeWithLanguage(state.loadedLanguages[evalLanguageId], code)
-    } catch (e) {
-      output = e
-      // evalStatus = 'ERROR'
-    }
-    // clear the console input and text cache immediately after eval
-    dispatch(updateConsoleText(''))
-    dispatch({ type: 'CLEAR_CONSOLE_TEXT_CACHE' })
 
-    const updateAfterEvaluation = () => {
+    const updateAfterEvaluation = (output) => {
       // const cellProperties = { rendered: true }
       // if (evalStatus === 'ERROR') {
       //   cellProperties.evalStatus = evalStatus
       // }
       // dispatch(updateCellProperties(cell.id, cellProperties))
+      dispatch(updateConsoleText(''))
+      dispatch({ type: 'CLEAR_CONSOLE_TEXT_CACHE' })
       dispatch(appendToEvalHistory(null, code, output))
       dispatch(updateUserVariables())
     }
 
-    const evaluation = Promise.resolve()
-      .then(updateAfterEvaluation)
+    return runCodeWithLanguage(language, code)
+      .then(output => updateAfterEvaluation(output))
       .then(waitForExplicitContinuationStatusResolution)
       // .then(() => dispatch(temporarilySaveRunningCellID(undefined)))
-    return evaluation
   }
 }
 
@@ -195,33 +187,25 @@ function evaluateCodeCell(cell) {
 
     dispatch(temporarilySaveRunningCellID(cell.id))
 
-    ensureLanguageAvailable(cell.language, cell, state, dispatch)
-      .then((language) => {
-        let output
-        let evalStatus
-        try {
-          output = runCodeWithLanguage(language, code)
-        } catch (e) {
-          output = e
-          evalStatus = 'ERROR'
-        }
-        const updateCellAfterEvaluation = () => {
-          const cellProperties = { rendered: true }
-          if (evalStatus === 'ERROR') {
-            cellProperties.evalStatus = evalStatus
-          }
-          dispatch(updateCellProperties(cell.id, cellProperties))
-          // dispatch(incrementExecutionNumber())
-          dispatch(appendToEvalHistory(cell.id, cell.content, output))
-          dispatch(updateUserVariables())
-        }
+    const updateCellAfterEvaluation = (output, evalStatus) => {
+      const cellProperties = { rendered: true }
+      if (evalStatus === 'ERROR') {
+        cellProperties.evalStatus = evalStatus
+      }
+      dispatch(updateCellProperties(cell.id, cellProperties))
+      // dispatch(incrementExecutionNumber())
+      dispatch(appendToEvalHistory(cell.id, cell.content, output))
+      dispatch(updateUserVariables())
+    }
 
-        const evaluation = Promise.resolve()
-          .then(updateCellAfterEvaluation)
-          .then(waitForExplicitContinuationStatusResolution)
-          .then(() => dispatch(temporarilySaveRunningCellID(undefined)))
-        return evaluation
-      })
+    return ensureLanguageAvailable(cell.language, cell, state, dispatch)
+      .then(language => runCodeWithLanguage(language, code))
+      .then(
+        output => updateCellAfterEvaluation(output),
+        output => updateCellAfterEvaluation(output, 'ERROR'),
+      )
+      .then(waitForExplicitContinuationStatusResolution)
+      .then(() => dispatch(temporarilySaveRunningCellID(undefined)));
   }
 }
 

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -166,7 +166,7 @@ export function evalConsoleInput(languageId) {
     }
 
     return runCodeWithLanguage(language, code)
-      .then(output => updateAfterEvaluation(output))
+      .then(updateAfterEvaluation)
       .then(waitForExplicitContinuationStatusResolution)
       // .then(() => dispatch(temporarilySaveRunningCellID(undefined)))
   }

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -134,5 +134,12 @@ export function ensureLanguageAvailable(languageId, cell, state, dispatch) {
 
 export function runCodeWithLanguage(language, code) {
   const { module, evaluator } = language
-  return window[module][evaluator](code)
+
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(window[module][evaluator](code))
+    } catch (e) {
+      reject(e)
+    }
+  })
 }


### PR DESCRIPTION
Ensures that a cell has finished execution and returned an output value before executing the next cell, so that run all works on implicitly loaded languages.

As reported on gitter by @bcolloran.