### PR TITLE
Set alias for Report CSS

### DIFF
--- a/src/eval-frame/components/eval-container.jsx
+++ b/src/eval-frame/components/eval-container.jsx
@@ -15,6 +15,10 @@ export class EvalContainerUnconnected extends React.Component {
     reportOnly: PropTypes.bool.isRequired,
   }
 
+  componentDidMount() {
+    document.querySelector('.fixed-position-container:first-child').setAttribute('id', 'report')
+  }
+
   render() {
     const { reportOnly } = this.props
     return (


### PR DESCRIPTION
Solves Issue #1000 

This might be a hacky fix.
We can edit the report CSS by referencing `#report`
Something such as 
```
#report {
  background:#555;
}
```

in the CSS cell would change the report background.