### PR TITLE
remove all use of IODIDE_BUILD_TYPE from notebook UX and use state.notebookInfo.connectionMode

### DIFF
--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -36,6 +36,7 @@ def notebook_view(request, pk):
         'user_can_save': notebook.owner_id == request.user.id,
         'notebook_id': notebook.id,
         'revision_id': notebook_content.id,
+        'connectionMode': 'SERVER'
     }
     if notebook.forked_from is not None:
         notebook_info['forked_from'] = notebook.forked_from.id
@@ -94,7 +95,7 @@ def notebook_revisions(request, pk):
 def new_notebook_view(request):
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),
-        'notebook_info': {'user_can_save': True},
+        'notebook_info': {'user_can_save': True, 'connectionMode': "SERVER"},
         'jsmd': '',
         'iframe_src': _get_iframe_src(),
     })

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -10,7 +10,7 @@ import {
 //
 // })
 
-describe('CellContainer mapStateToProps', () => {
+describe('HeaderMessages mapStateToProps', () => {
   let state
   let ownProps
 
@@ -22,6 +22,7 @@ describe('CellContainer mapStateToProps', () => {
       },
       notebookInfo: {
         user_can_save: true,
+        connectionMode: 'SERVER',
       },
     }
     ownProps = { }

--- a/src/components/menu/__tests__/notebook-menu-subsection.test.js
+++ b/src/components/menu/__tests__/notebook-menu-subsection.test.js
@@ -27,7 +27,7 @@ describe('A nested NotebookMenuSubsection', () => {
     <NotebookMenuSubsection onClick={outerClick}>
       <NotebookMenuItem task={new UserTask({
         title: 'ok',
-        callback: () => { console.log('wow!'); /* innerSentinel = true }, */ },
+        callback: () => { console.debug('wow!'); /* innerSentinel = true }, */ },
 })}
       />
     </NotebookMenuSubsection>

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
+import { connectionModeIsServer } from '../../tools/server-tools'
 import { createNewNotebookOnServer, login } from '../../actions/actions'
 
 export class HeaderMessagesUnconnected extends React.Component {
@@ -49,9 +50,9 @@ export class HeaderMessagesUnconnected extends React.Component {
 
 export function mapStateToProps(state) {
   if (state.viewMode === 'EXPLORE_VIEW') {
-    if (state.userData.name === undefined) {
+    if (state.userData.name === undefined && connectionModeIsServer(state)) {
       return { message: 'NEED_TO_LOGIN' }
-    } else if (!state.notebookInfo.user_can_save) {
+    } else if (!state.notebookInfo.user_can_save && connectionModeIsServer(state)) {
       return { message: 'NEED_TO_MAKE_COPY', revisionId: state.notebookInfo.revision_id }
     }
   }

--- a/src/components/menu/last-saved-text.jsx
+++ b/src/components/menu/last-saved-text.jsx
@@ -9,7 +9,6 @@ export class LastSavedTextUnconnected extends React.Component {
     lastSaved: PropTypes.string,
   }
   render() {
-    console.log(this.props.lastSaved)
     return (
       <Typography
         classes={{ root: 'last-saved-text' }}

--- a/src/components/menu/view-controls.jsx
+++ b/src/components/menu/view-controls.jsx
@@ -1,4 +1,3 @@
-/* global IODIDE_BUILD_TYPE */
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
@@ -9,9 +8,14 @@ import LastSavedText from './last-saved-text'
 
 import tasks from '../../actions/task-definitions'
 
+import { connectionModeIsServer } from '../../tools/server-tools'
+
 export class ViewControlsUnconnected extends React.Component {
   static propTypes = {
     isAuthenticated: PropTypes.bool.isRequired,
+    name: PropTypes.string,
+    avatar: PropTypes.string,
+    isServer: PropTypes.bool.isRequired,
   }
 
   render() {
@@ -19,7 +23,7 @@ export class ViewControlsUnconnected extends React.Component {
       <div className="view-controls">
         <LastSavedText />
 
-        {IODIDE_BUILD_TYPE === 'server' && (
+        {this.props.isServer && (
           <UserMenu
             isAuthenticated={this.props.isAuthenticated}
             loginCallback={tasks.loginGithub.callback}
@@ -42,6 +46,7 @@ export function mapStateToProps(state) {
     isAuthenticated,
     name: state.userData.name,
     avatar: state.userData.avatar,
+    isServer: connectionModeIsServer(state),
   }
 }
 

--- a/src/components/modals/keyboard-shortcut-list.jsx
+++ b/src/components/modals/keyboard-shortcut-list.jsx
@@ -12,7 +12,6 @@ export default class KeyboardShortcutList extends React.Component {
   render() {
     const globalKeys = []
     const commandModeKeys = []
-    // console.log('tasks', this.props.tasks)
     Object.keys(this.props.tasks)
       .filter(k => this.props.tasks[k].displayKeybinding)
       .forEach((k) => {

--- a/src/handle-initial-jsmd.js
+++ b/src/handle-initial-jsmd.js
@@ -1,12 +1,13 @@
-/* global IODIDE_BUILD_TYPE */
 import { stateFromJsmd } from './tools/jsmd-tools'
 import handleUrlQuery from './tools/handle-url-query'
 import { updateAppMessages, importInitialJsmd, evaluateAllCells } from './actions/actions'
-import { getUrlParams } from './editor-state-prototypes'
+import { getUrlParams, getNotebookInfo } from './editor-state-prototypes'
 
 export default async function handleInitialJsmd(store) {
   let state
-  if (window.location.search && IODIDE_BUILD_TYPE !== 'server') {
+  // shorthand for server-loaded, since we haven't actually checked window for server vars yet.
+  const notebookInfo = getNotebookInfo() || undefined
+  if (window.location.search && notebookInfo) {
     // if there is a query string, handle it and skip parsing the local jsmd
     state = await handleUrlQuery()
   } else {
@@ -18,10 +19,9 @@ export default async function handleInitialJsmd(store) {
       state = stateFromJsmd(jsmdElt.innerHTML)
     }
   }
-  // url parameters may override initial jsmd state if specified
-  Object.assign(state, getUrlParams())
-  console.log('INITIAL JSMD STATE', state)
   if (state !== undefined) {
+    // url parameters may override initial jsmd state if specified
+    Object.assign(state, getUrlParams())
     store.dispatch(importInitialJsmd(state))
     if (window.location.search) {
       store.dispatch(updateAppMessages({ message: 'Notebook imported from URL.' }))

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,6 +33,9 @@ import { listenForEvalFramePortReady } from './port-to-eval-frame'
 import './tools/initialize-codemirror-loadmode'
 import './tools/initialize-dom'
 
+// handleInitialJsmd.
+// then handleServerVariables.
+
 handleLanguageDefinitions(store)
 initializeDefaultKeybindings()
 

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,4 +1,3 @@
-/* global IODIDE_BUILD_TYPE */
 import {
   newNotebook,
   getUserData,
@@ -11,6 +10,9 @@ import {
   exportJsmdBundle,
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
+import {
+  connectionModeIsServer,
+} from '../tools/server-tools'
 import { postActionToEvalFrame } from '../port-to-eval-frame'
 
 function newAppMessage(appMessageId, appMessageText, appMessageDetails, appMessageWhen) {
@@ -88,10 +90,9 @@ const notebookReducer = (state = newNotebook(), action) => {
       nextState = action.newState
       cells = nextState.cells.map((cell, i) =>
         Object.assign(newCell(i, cell.cellType), cell))
-
       // FIXME: getting the notebook id from the URL is terribly brittle,
       // already caused a bug in standalone `npm run start-and-serve` mode, see #1007.
-      let notebookId = (IODIDE_BUILD_TYPE && IODIDE_BUILD_TYPE === 'server') ?
+      let notebookId = connectionModeIsServer(nextState) ?
         parseInt(window.location.pathname.split('/').filter(s => s.length).pop(), 10) : undefined
 
       notebookId = Number.isSafeInteger(notebookId) ? notebookId : undefined

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -79,9 +79,14 @@ export const editorOnlyStateProperties = {
     type: 'object',
     properties: {
       user_can_save: { type: 'boolean' },
+      connectionMode: {
+        type: 'string',
+        enum: ['SERVER', 'STANDALONE'],
+      },
     },
     default: {
       user_can_save: false,
+      connectionMode: 'STANDALONE',
     },
   },
   viewMode: {

--- a/src/tools/__tests__/server-tools.test.js
+++ b/src/tools/__tests__/server-tools.test.js
@@ -1,0 +1,32 @@
+import {
+  getConnectionMode,
+  connectionModeIsStandalone,
+  connectionModeIsServer,
+} from '../server-tools'
+
+const makeState = connectionMode => ({ notebookInfo: { connectionMode } })
+
+describe('getConnectionMode', () => {
+  it('correctly reads connection mode', () => {
+    const standalone = makeState('STANDALONE')
+    const server = makeState('SERVER')
+    expect(getConnectionMode(standalone)).toBe('STANDALONE')
+    expect(getConnectionMode(server)).toBe('SERVER')
+  })
+  it('throws if state.notebookInfo.connectionMode does not exist', () => {
+    const malform = { notebookInfo: {} }
+    expect(() => getConnectionMode(malform)).toThrow()
+  })
+})
+
+describe('connectionModeIsStandalone && connectionModeIsServer', () => {
+  it('returns true if connectionMode == "STANDALONE"', () => {
+    const standalone = makeState('STANDALONE')
+    const server = makeState('SERVER')
+    expect(connectionModeIsStandalone(standalone)).toBeTruthy()
+    expect(connectionModeIsStandalone(server)).toBeFalsy()
+    expect(connectionModeIsServer(standalone)).toBeFalsy()
+    expect(connectionModeIsServer(server)).toBeTruthy()
+  })
+})
+

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -1,0 +1,12 @@
+export function getConnectionMode(state) {
+  if (!('connectionMode' in state.notebookInfo)) throw Error('state does not have connectionMode')
+  return state.notebookInfo.connectionMode
+}
+
+export function connectionModeIsStandalone(state) {
+  return getConnectionMode(state) === 'STANDALONE'
+}
+
+export function connectionModeIsServer(state) {
+  return getConnectionMode(state) === 'SERVER'
+}


### PR DESCRIPTION
Closes #1045, #1008, and is a step toward fixing #896 and #980. Unblocks #979.

This phases out `IODIDE_BUILD_TYPE` within the client UX and implements `state.notebookInfo.connectionMode`. Includes helpers around pulling out and checking for mode, along with tests for those helpers.