### PR TITLE
removes state.notebookId, fixes issue with brittle url parsing to retrieve notebookId, utilizes state.notebookInfo.notebook_id instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4418,14 +4418,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4440,20 +4438,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4570,8 +4565,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4583,7 +4577,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4598,7 +4591,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4606,14 +4598,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4632,7 +4622,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4713,8 +4702,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4726,7 +4714,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4848,7 +4835,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -306,6 +306,7 @@ export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
           message,
           details: `${message} <br />Notebook saved`,
         }))
+        console.warn('json id', json, json.id)
         dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
         window.history.replaceState({}, '', `/notebooks/${json.id}`)
         dispatch({ type: 'NOTEBOOK_SAVED' })

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -306,7 +306,6 @@ export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
           message,
           details: `${message} <br />Notebook saved`,
         }))
-        console.warn('json id', json, json.id)
         dispatch({ type: 'ADD_NOTEBOOK_ID', id: json.id })
         window.history.replaceState({}, '', `/notebooks/${json.id}`)
         dispatch({ type: 'NOTEBOOK_SAVED' })

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -1,6 +1,7 @@
 import CodeMirror from 'codemirror'
 
 import { exportJsmdToString } from '../tools/jsmd-tools'
+import { getNotebookID } from '../tools/server-tools'
 import { getCellById, isCommandMode } from '../tools/notebook-utils'
 import { postActionToEvalFrame } from '../port-to-eval-frame'
 
@@ -118,12 +119,12 @@ export function changeMode(mode) {
 export function setViewMode(viewMode) {
   return (dispatch, getState) => {
     const state = getState()
-
-    if (state.notebookId) {
+    const notebookId = getNotebookID(state)
+    if (notebookId) {
       // if there is a notebook id, then persist the fact that this is a Report
       // in the url
       const params = (viewMode === 'REPORT_VIEW') ? '?viewMode=report' : ''
-      window.history.replaceState({}, '', `/notebooks/${state.notebookId}/${params}`)
+      window.history.replaceState({}, '', `/notebooks/${notebookId}/${params}`)
     }
     dispatch({
       type: 'SET_VIEW_MODE',
@@ -315,13 +316,12 @@ export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
 export function saveNotebookToServer() {
   return (dispatch, getState) => {
     const state = getState()
-
-    const notebookInServer = Boolean(state.notebookId)
-
+    const notebookId = getNotebookID(state)
+    const notebookInServer = Boolean(notebookId)
     if (notebookInServer) {
       const postRequestOptions = getNotebookSaveRequestOptions(state)
       // Update Exisiting Notebook
-      fetchWithCSRFTokenAndJSONContent(`/api/v1/notebooks/${state.notebookId}/revisions/`, postRequestOptions)
+      fetchWithCSRFTokenAndJSONContent(`/api/v1/notebooks/${notebookId}/revisions/`, postRequestOptions)
         .then(response => response.json())
         .then(() => {
           const message = 'Updated Notebook'

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -34,7 +34,7 @@ function getUrlParams() {
   return { viewMode: report ? 'REPORT_VIEW' : 'EXPLORE_VIEW' }
 }
 
-function getUserData() {
+function getUserDataFromDocument() {
   const userData = document.getElementById('userData')
   if (userData) {
     return { userData: JSON.parse(userData.textContent) }
@@ -42,7 +42,7 @@ function getUserData() {
   return {}
 }
 
-function getNotebookInfo() {
+function getNotebookInfoFromDocument() {
   const notebookInfo = document.getElementById('notebookInfo')
   if (notebookInfo) {
     return { notebookInfo: JSON.parse(notebookInfo.textContent) }
@@ -52,8 +52,8 @@ function getNotebookInfo() {
 
 export {
   getUrlParams,
-  getUserData,
-  getNotebookInfo,
+  getUserDataFromDocument,
+  getNotebookInfoFromDocument,
   newCell,
   newCellID,
   newNotebook,

--- a/src/editor-state-prototypes.js
+++ b/src/editor-state-prototypes.js
@@ -33,27 +33,8 @@ function getUrlParams() {
   const report = queryParams.viewMode === 'report'
   return { viewMode: report ? 'REPORT_VIEW' : 'EXPLORE_VIEW' }
 }
-
-function getUserDataFromDocument() {
-  const userData = document.getElementById('userData')
-  if (userData) {
-    return { userData: JSON.parse(userData.textContent) }
-  }
-  return {}
-}
-
-function getNotebookInfoFromDocument() {
-  const notebookInfo = document.getElementById('notebookInfo')
-  if (notebookInfo) {
-    return { notebookInfo: JSON.parse(notebookInfo.textContent) }
-  }
-  return {}
-}
-
 export {
   getUrlParams,
-  getUserDataFromDocument,
-  getNotebookInfoFromDocument,
   newCell,
   newCellID,
   newNotebook,

--- a/src/handle-initial-jsmd.js
+++ b/src/handle-initial-jsmd.js
@@ -1,12 +1,12 @@
 import { stateFromJsmd } from './tools/jsmd-tools'
 import handleUrlQuery from './tools/handle-url-query'
 import { updateAppMessages, importInitialJsmd, evaluateAllCells } from './actions/actions'
-import { getUrlParams, getNotebookInfo } from './editor-state-prototypes'
+import { getUrlParams, getNotebookInfoFromDocument } from './editor-state-prototypes'
 
 export default async function handleInitialJsmd(store) {
   let state
   // shorthand for server-loaded, since we haven't actually checked window for server vars yet.
-  const notebookInfo = getNotebookInfo() || undefined
+  const notebookInfo = getNotebookInfoFromDocument() || undefined
   if (window.location.search && notebookInfo) {
     // if there is a query string, handle it and skip parsing the local jsmd
     state = await handleUrlQuery()

--- a/src/handle-initial-jsmd.js
+++ b/src/handle-initial-jsmd.js
@@ -1,7 +1,8 @@
 import { stateFromJsmd } from './tools/jsmd-tools'
 import handleUrlQuery from './tools/handle-url-query'
 import { updateAppMessages, importInitialJsmd, evaluateAllCells } from './actions/actions'
-import { getUrlParams, getNotebookInfoFromDocument } from './editor-state-prototypes'
+import { getUrlParams } from './editor-state-prototypes'
+import { getNotebookInfoFromDocument } from './tools/server-tools'
 
 export default async function handleInitialJsmd(store) {
   let state

--- a/src/handle-server-variables.js
+++ b/src/handle-server-variables.js
@@ -1,4 +1,4 @@
-import { getNotebookInfoFromDocument } from './editor-state-prototypes'
+import { getNotebookInfoFromDocument } from './tools/server-tools'
 import { updateNotebookInfo } from './actions/actions'
 
 export default function handleServerVariables(store) {

--- a/src/handle-server-variables.js
+++ b/src/handle-server-variables.js
@@ -1,8 +1,8 @@
-import { getNotebookInfo } from './editor-state-prototypes'
+import { getNotebookInfoFromDocument } from './editor-state-prototypes'
 import { updateNotebookInfo } from './actions/actions'
 
 export default function handleServerVariables(store) {
-  const nbObj = getNotebookInfo()
+  const nbObj = getNotebookInfoFromDocument()
   if (Object.keys(nbObj).length > 0) {
     store.dispatch(updateNotebookInfo(nbObj.notebookInfo))
   }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -11,7 +11,7 @@ import {
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
 import {
-  connectionModeIsServer,
+  getNotebookID,
 } from '../tools/server-tools'
 import { postActionToEvalFrame } from '../port-to-eval-frame'
 
@@ -90,12 +90,8 @@ const notebookReducer = (state = newNotebook(), action) => {
       nextState = action.newState
       cells = nextState.cells.map((cell, i) =>
         Object.assign(newCell(i, cell.cellType), cell))
-      // FIXME: getting the notebook id from the URL is terribly brittle,
-      // already caused a bug in standalone `npm run start-and-serve` mode, see #1007.
-      let notebookId = connectionModeIsServer(nextState) ?
-        parseInt(window.location.pathname.split('/').filter(s => s.length).pop(), 10) : undefined
 
-      notebookId = Number.isSafeInteger(notebookId) ? notebookId : undefined
+      const notebookId = getNotebookID(nextState)
 
       return Object.assign(
         newNotebook(), nextState, { cells, notebookId },

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -108,8 +108,8 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case 'ADD_NOTEBOOK_ID': {
-      const { notebookId } = action
-      const { notebookInfo } = state
+      const notebookId = action.id
+      const notebookInfo = Object.assign({}, state.notebookInfo)
       notebookInfo.notebook_id = notebookId
       return Object.assign({}, state, { notebookInfo })
     }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -92,9 +92,10 @@ const notebookReducer = (state = newNotebook(), action) => {
         Object.assign(newCell(i, cell.cellType), cell))
 
       const notebookId = getNotebookID(nextState)
-
+      const { notebookInfo } = nextState
+      notebookInfo.notebook_id = notebookId
       return Object.assign(
-        newNotebook(), nextState, { cells, notebookId },
+        newNotebook(), nextState, { cells, notebookInfo },
         getUserData(), getNotebookInfo(),
       )
     }
@@ -107,7 +108,10 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case 'ADD_NOTEBOOK_ID': {
-      return Object.assign({}, state, { notebookId: action.id })
+      const { notebookId } = action
+      const { notebookInfo } = state
+      notebookInfo.notebook_id = notebookId
+      return Object.assign({}, state, { notebookInfo })
     }
 
     case 'CHANGE_PAGE_TITLE':

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,7 +1,7 @@
 import {
   newNotebook,
-  getUserData,
-  getNotebookInfo,
+  getUserDataFromDocument,
+  getNotebookInfoFromDocument,
   newCell,
   newCellID,
 } from '../editor-state-prototypes'
@@ -10,9 +10,7 @@ import {
   exportJsmdBundle,
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
-import {
-  getNotebookID,
-} from '../tools/server-tools'
+
 import { postActionToEvalFrame } from '../port-to-eval-frame'
 
 function newAppMessage(appMessageId, appMessageText, appMessageDetails, appMessageWhen) {
@@ -43,7 +41,7 @@ const notebookReducer = (state = newNotebook(), action) => {
 
   switch (action.type) {
     case 'RESET_NOTEBOOK':
-      return Object.assign(newNotebook(), getUserData())
+      return Object.assign(newNotebook(), getUserDataFromDocument())
 
     case 'EXPORT_NOTEBOOK': {
       const exportState = Object.assign(
@@ -91,12 +89,9 @@ const notebookReducer = (state = newNotebook(), action) => {
       cells = nextState.cells.map((cell, i) =>
         Object.assign(newCell(i, cell.cellType), cell))
 
-      const notebookId = getNotebookID(nextState)
-      const { notebookInfo } = nextState
-      notebookInfo.notebook_id = notebookId
       return Object.assign(
-        newNotebook(), nextState, { cells, notebookInfo },
-        getUserData(), getNotebookInfo(),
+        newNotebook(), nextState, { cells },
+        getUserDataFromDocument(), getNotebookInfoFromDocument(),
       )
     }
 
@@ -222,6 +217,6 @@ const notebookReducer = (state = newNotebook(), action) => {
   }
 }
 
-export { getUserData }
+export { getUserDataFromDocument }
 
 export default notebookReducer

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -1,7 +1,5 @@
 import {
   newNotebook,
-  getUserDataFromDocument,
-  getNotebookInfoFromDocument,
   newCell,
   newCellID,
 } from '../editor-state-prototypes'
@@ -10,6 +8,8 @@ import {
   exportJsmdBundle,
   titleToHtmlFilename,
 } from '../tools/jsmd-tools'
+
+import { getNotebookInfoFromDocument, getUserDataFromDocument } from '../tools/server-tools'
 
 import { postActionToEvalFrame } from '../port-to-eval-frame'
 
@@ -216,7 +216,5 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
   }
 }
-
-export { getUserDataFromDocument }
 
 export default notebookReducer

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -75,12 +75,14 @@ export const editorOnlyStateProperties = {
     type: 'object',
     properties: {
       user_can_save: { type: 'boolean' },
+      notebook_id: { type: 'integer' },
       connectionMode: {
         type: 'string',
         enum: ['SERVER', 'STANDALONE'],
       },
     },
     default: {
+      notebook_id: undefined,
       user_can_save: false,
       connectionMode: 'STANDALONE',
     },

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -71,10 +71,6 @@ export const editorOnlyStateProperties = {
     additionalProperties: false,
     default: {},
   },
-  notebookId: {
-    type: ['integer', 'null'],
-    default: undefined,
-  },
   notebookInfo: {
     type: 'object',
     properties: {

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ import { createLogger } from 'redux-logger'
 
 import createValidatedReducer from './reducers/create-validated-reducer'
 import reducer from './reducers/reducer'
-import { getUserData, newNotebook, stateSchema } from './editor-state-prototypes'
+import { getUserDataFromDocument, newNotebook, stateSchema } from './editor-state-prototypes'
 
 let enhancer
 let finalReducer
@@ -27,7 +27,7 @@ if (IODIDE_BUILD_MODE === 'production') {
 }
 const store = createStore(
   finalReducer,
-  Object.assign(newNotebook(), getUserData()),
+  Object.assign(newNotebook(), getUserDataFromDocument()),
   enhancer,
 )
 

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,8 @@ import { createLogger } from 'redux-logger'
 
 import createValidatedReducer from './reducers/create-validated-reducer'
 import reducer from './reducers/reducer'
-import { getUserDataFromDocument, newNotebook, stateSchema } from './editor-state-prototypes'
+import { newNotebook, stateSchema } from './editor-state-prototypes'
+import { getUserDataFromDocument } from './tools/server-tools'
 
 let enhancer
 let finalReducer

--- a/src/tools/__tests__/server-tools.test.js
+++ b/src/tools/__tests__/server-tools.test.js
@@ -43,20 +43,4 @@ describe('getNotebookID', () => {
     // notebook_id is still 100 in nb.notebookInfo, and we should still return undefined.
     expect(getNotebookID(nb)).toBe(undefined)
   })
-  it('throws if there is no notebook_id', () => {
-    const nb = makeState('SERVER')
-    delete nb.notebookInfo.notebook_id
-    expect(() => getNotebookID(nb)).toThrow()
-  })
-  it('throws if notebook_id is not the correct type', () => {
-    const nb = makeState('SERVER')
-    nb.notebookInfo.notebook_id = undefined
-    expect(() => getNotebookID(nb)).toThrow()
-    nb.notebookInfo.notebook_id = 'some string for now'
-    expect(() => { getNotebookID(nb) }).toThrow()
-  })
-  it('throws if there is no notebookInfo', () => {
-    const nb = {}
-    expect(() => { getNotebookID(nb) }).toThrow()
-  })
 })

--- a/src/tools/__tests__/server-tools.test.js
+++ b/src/tools/__tests__/server-tools.test.js
@@ -1,10 +1,12 @@
 import {
   getConnectionMode,
+  getNotebookID,
   connectionModeIsStandalone,
   connectionModeIsServer,
 } from '../server-tools'
 
-const makeState = connectionMode => ({ notebookInfo: { connectionMode } })
+const NOTEBOOK_ID = 100
+const makeState = connectionMode => ({ notebookInfo: { connectionMode, notebook_id: NOTEBOOK_ID } })
 
 describe('getConnectionMode', () => {
   it('correctly reads connection mode', () => {
@@ -30,3 +32,31 @@ describe('connectionModeIsStandalone && connectionModeIsServer', () => {
   })
 })
 
+describe('getNotebookID', () => {
+  it('returns a noteobokID if one exists and one is on a server', () => {
+    const nb = makeState('SERVER')
+    expect(getNotebookID(nb)).toBe(NOTEBOOK_ID)
+  })
+  it('returns undefined if the notebook is in standalone mode', () => {
+    const nb = makeState('STANDALONE')
+    // this is an edge case, but here
+    // notebook_id is still 100 in nb.notebookInfo, and we should still return undefined.
+    expect(getNotebookID(nb)).toBe(undefined)
+  })
+  it('throws if there is no notebook_id', () => {
+    const nb = makeState('SERVER')
+    delete nb.notebookInfo.notebook_id
+    expect(() => getNotebookID(nb)).toThrow()
+  })
+  it('throws if notebook_id is not the correct type', () => {
+    const nb = makeState('SERVER')
+    nb.notebookInfo.notebook_id = undefined
+    expect(() => getNotebookID(nb)).toThrow()
+    nb.notebookInfo.notebook_id = 'some string for now'
+    expect(() => { getNotebookID(nb) }).toThrow()
+  })
+  it('throws if there is no notebookInfo', () => {
+    const nb = {}
+    expect(() => { getNotebookID(nb) }).toThrow()
+  })
+})

--- a/src/tools/__tests__/server-tools.test.js
+++ b/src/tools/__tests__/server-tools.test.js
@@ -43,4 +43,9 @@ describe('getNotebookID', () => {
     // notebook_id is still 100 in nb.notebookInfo, and we should still return undefined.
     expect(getNotebookID(nb)).toBe(undefined)
   })
+  it('throws if state.notebookInfo.notebook_id is not an integer nor undefined', () => {
+    const nb = makeState('SERVER')
+    nb.notebookInfo.notebook_id = 'some string'
+    expect(() => getNotebookID(nb)).toThrow()
+  })
 })

--- a/src/tools/__tests__/server-tools.test.js
+++ b/src/tools/__tests__/server-tools.test.js
@@ -33,9 +33,11 @@ describe('connectionModeIsStandalone && connectionModeIsServer', () => {
 })
 
 describe('getNotebookID', () => {
-  it('returns a noteobokID if one exists and one is on a server', () => {
+  it('returns a noteobookID if one exists and one is on a server. Otherwise returns undefined.', () => {
     const nb = makeState('SERVER')
     expect(getNotebookID(nb)).toBe(NOTEBOOK_ID)
+    nb.notebookInfo.notebook_id = undefined
+    expect(getNotebookID(nb)).toBe(undefined)
   })
   it('returns undefined if the notebook is in standalone mode', () => {
     const nb = makeState('STANDALONE')

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -13,7 +13,5 @@ export function connectionModeIsServer(state) {
 
 export function getNotebookID(state) {
   if (!connectionModeIsServer(state)) return undefined
-  if (!(('notebook_id') in state.notebookInfo) ||
-    !Number.isSafeInteger(state.notebookInfo.notebook_id)) { throw Error('notebookInfo does not have notebook_id') }
   return state.notebookInfo.notebook_id
 }

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -13,5 +13,7 @@ export function connectionModeIsServer(state) {
 
 export function getNotebookID(state) {
   if (!connectionModeIsServer(state)) return undefined
-  return state.notebookInfo.notebook_id
+  const notebookID = state.notebookInfo.notebook_id
+  if (!Number.isSafeInteger(notebookID) && notebookID !== undefined) throw Error('notebook_id must be undefined or an integer')
+  return notebookID
 }

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -10,3 +10,10 @@ export function connectionModeIsStandalone(state) {
 export function connectionModeIsServer(state) {
   return getConnectionMode(state) === 'SERVER'
 }
+
+export function getNotebookID(state) {
+  if (!connectionModeIsServer(state)) return undefined
+  if (!(('notebook_id') in state.notebookInfo) ||
+    !Number.isSafeInteger(state.notebookInfo.notebook_id)) { throw Error('notebookInfo does not have notebook_id') }
+  return state.notebookInfo.notebook_id
+}

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -1,3 +1,19 @@
+export function getUserDataFromDocument() {
+  const userData = document.getElementById('userData')
+  if (userData) {
+    return { userData: JSON.parse(userData.textContent) }
+  }
+  return {}
+}
+
+export function getNotebookInfoFromDocument() {
+  const notebookInfo = document.getElementById('notebookInfo')
+  if (notebookInfo) {
+    return { notebookInfo: JSON.parse(notebookInfo.textContent) }
+  }
+  return {}
+}
+
 export function getConnectionMode(state) {
   if (!('connectionMode' in state.notebookInfo)) throw Error('state does not have connectionMode')
   return state.notebookInfo.connectionMode


### PR DESCRIPTION
closes #1071, #1022. I've done some QA and it appears to fix the issue, but I want to be sure. Please test this thoroughly:

1.) on server, from `/new`, make sure that it saves appropriately and there are no errors
2.) from a saved notebook, make changes to the title and save. It should not fork. Also, check to see that the title updates on the server page, and also that under revisions it updates and save as you would expect.
3.) make sure reload + save does not fork.