### PR TITLE
Ensure csrf cookies are set for all server views

### DIFF
--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -3,6 +3,7 @@ import urllib.parse
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import (get_object_or_404,
                               render)
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .models import Notebook, NotebookRevision
 from ..files.models import File
@@ -26,6 +27,7 @@ def _get_iframe_src():
     )
 
 
+@ensure_csrf_cookie
 def notebook_view(request, pk):
     notebook = get_object_or_404(Notebook, pk=pk)
     if 'revision' in request.GET:
@@ -50,6 +52,7 @@ def notebook_view(request, pk):
     })
 
 
+@ensure_csrf_cookie
 def notebook_revisions(request, pk):
     pk = int(pk)
     nb = get_object_or_404(Notebook, pk=pk)
@@ -92,6 +95,7 @@ def notebook_revisions(request, pk):
 
 
 @login_required
+@ensure_csrf_cookie
 def new_notebook_view(request):
     return render(request, 'notebook.html', {
         'user_info': _get_user_info_json(request.user),

--- a/server/views.py
+++ b/server/views.py
@@ -4,6 +4,7 @@ from django.shortcuts import (get_object_or_404,
                               redirect,
                               render)
 from django.db.models import Max
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .notebooks.models import Notebook
 from .base.models import User
@@ -18,6 +19,7 @@ def get_user_info_dict(user):
     return {}
 
 
+@ensure_csrf_cookie
 def index(request):
     notebooks = Notebook.objects \
         .annotate(latest_revision=Max('revisions__created')) \
@@ -37,6 +39,7 @@ def index(request):
     )
 
 
+@ensure_csrf_cookie
 def user(request, name=None):
     user_info = get_user_info_dict(request.user)
     user = get_object_or_404(User, username=name)


### PR DESCRIPTION
The server-side views frequently needs to make write requests via ajax, so be
sure to set the csrf cookie so that these operations succeed.