### PR TITLE
Add gravatar support for when not using github social auth (fixes: #1077)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ django-rest-framework = "*"
 faker = "*"
 mock = "*"
 dockerflow = "*"
+pytest-env = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "abd84c8f6c05c8af6129cf3d800daab9816068ff68f197ceaea15ff70419d6cb"
+            "sha256": "d0f427fdb5d7daf04f4c73b72059f51485816ddd693f6b25358ef130cb3eb722"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,6 +15,20 @@
         ]
     },
     "default": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "version": "==1.2.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
@@ -121,6 +135,14 @@
             ],
             "version": "==2.0.0"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "version": "==4.3.0"
+        },
         "oauthlib": {
             "hashes": [
                 "sha256:ac35665a61c1685c56336bda97d5eefa246f1202618a1d6f34fccb1bdd404162",
@@ -141,6 +163,13 @@
                 "sha256:bfcff1a3878eebf559392c2130a17f612a03f96a0d44c3559d9c1e62a4235a2d"
             ],
             "version": "==5.0.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+            ],
+            "version": "==0.8.0"
         },
         "psycopg2": {
             "hashes": [
@@ -212,12 +241,32 @@
             ],
             "version": "==2.7.5"
         },
+        "py": {
+            "hashes": [
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+            ],
+            "version": "==1.7.0"
+        },
         "pyjwt": {
             "hashes": [
                 "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
                 "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
             ],
             "version": "==1.6.4"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310",
+                "sha256:6f6c1efc8d0ccc21f8f6c34d8330baca883cf109b66b3df954b0a117e5528fb4"
+            ],
+            "version": "==3.9.2"
+        },
+        "pytest-env": {
+            "hashes": [
+                "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"
+            ],
+            "version": "==0.6.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -290,7 +339,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version < '4' and python_version != '3.2.*'",
             "version": "==1.23"
         },
         "whitenoise": {
@@ -350,7 +398,6 @@
                 "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
                 "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==0.8.0"
         },
         "py": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 DJANGO_SETTINGS_MODULE = server.settings
 python_files = tests.py test_*.py *_tests.py
 testpaths = server
+env =
+    GITHUB_CLIENT_ID=
+    GITHUB_CLIENT_SECRET=
+    USE_GRAVATAR=1

--- a/server/gravatar/middleware.py
+++ b/server/gravatar/middleware.py
@@ -1,0 +1,19 @@
+import hashlib
+
+
+class GravatarMiddleware(object):
+    '''
+    Simple middleware to set the user's avatar url to a gravatar (if not
+    already set)
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        user = request.user
+        if user.is_authenticated and not user.avatar:
+            user.avatar = 'http://www.gravatar.com/avatar/{}?d=identicon'.format(
+                hashlib.md5(user.email.encode('utf-8')).hexdigest()
+            )
+            user.save()
+        return self.get_response(request)

--- a/server/settings.py
+++ b/server/settings.py
@@ -48,6 +48,9 @@ SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 # OpenIDC (aka auth0 identity/authentication)
 USE_OPENIDC_AUTH = env.bool("USE_OPENIDC_AUTH", default=False)
 
+# Use Gravatar middleware to display user avatars
+USE_GRAVATAR = env.bool("USE_GRAVATAR", default=not SOCIAL_AUTH_GITHUB_KEY)
+
 # Maximum file length for uploaded data / assets
 MAX_FILENAME_LENGTH = 120
 MAX_FILE_SIZE = 1024*1024*10  # 10 megabytes is the default
@@ -67,7 +70,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'rest_framework',
-    'social_django',
     'server.base',
     'server.notebooks',
     'server.files',
@@ -88,15 +90,18 @@ if DOCKERFLOW_ENABLED:
     INSTALLED_APPS.append('dockerflow.django')
     MIDDLEWARE.append('dockerflow.django.middleware.DockerflowMiddleware')
 
-if SOCIAL_AUTH_GITHUB_KEY:
+if USE_OPENIDC_AUTH:
+    INSTALLED_APPS.append('server.openidc')
+    MIDDLEWARE.append('server.openidc.middleware.OpenIDCAuthMiddleware')
+elif SOCIAL_AUTH_GITHUB_KEY:
+    INSTALLED_APPS.append('social_django')
     MIDDLEWARE.extend([
         'social_django.middleware.SocialAuthExceptionMiddleware',
         'server.github.middleware.GithubAuthMiddleware'
     ])
 
-if USE_OPENIDC_AUTH:
-    INSTALLED_APPS.append('server.openidc')
-    MIDDLEWARE.append('server.openidc.middleware.OpenIDCAuthMiddleware')
+if USE_GRAVATAR:
+    MIDDLEWARE.append('server.gravatar.middleware.GravatarMiddleware')
 
 ROOT_URLCONF = 'server.urls'
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -2,7 +2,6 @@ import sys
 import os
 
 import pytest
-from rest_framework.test import APIClient
 
 from server.base.models import User
 from server.files.models import File
@@ -13,26 +12,17 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 @pytest.fixture
-def client():
-    """
-    A django-rest-framework APIClient instance:
-    http://www.django-rest-framework.org/api-guide/testing/#apiclient
-    """
-    return APIClient()
-
-
-@pytest.fixture
 def fake_user(transactional_db):
-    return User.objects.create(username="testuser1",
-                               email="user@foo.com",
-                               password="123")
+    user = User.objects.create(username="testuser1",
+                               email="user@foo.com")
+    return user
 
 
 @pytest.fixture
 def fake_user2(transactional_db):
-    return User.objects.create(username="testuser2",
-                               email="user@bar.com",
-                               password="123")
+    user = User.objects.create(username="testuser2",
+                               email="user@bar.com")
+    return user
 
 
 @pytest.fixture

--- a/server/tests/test_file_api.py
+++ b/server/tests/test_file_api.py
@@ -8,7 +8,7 @@ from helpers import get_rest_framework_time_string
 
 
 def test_post_to_file_api(fake_user, client, test_notebook):
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     with tempfile.NamedTemporaryFile(mode='w+') as f:
         f.write('hello')
         f.seek(0)

--- a/server/tests/test_notebook_api.py
+++ b/server/tests/test_notebook_api.py
@@ -76,7 +76,7 @@ def test_create_notebook_not_logged_in(transactional_db, client, notebook_post_b
 
 def test_create_notebook_logged_in(fake_user, client, notebook_post_blob):
     # should be able to create notebook if logged in
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     resp = client.post(reverse('notebooks-list'), notebook_post_blob)
     assert resp.status_code == 201
     assert Notebook.objects.count() == 1
@@ -96,14 +96,14 @@ def test_delete_notebook_not_logged_in(test_notebook, client):
 
 def test_delete_notebook_not_owner(fake_user, fake_user2, test_notebook, client):
     # should not be able to delete if not owner of the notebook
-    client.force_authenticate(user=fake_user2)
+    client.force_login(fake_user2)
     resp = client.delete(reverse('notebooks-detail', kwargs={'pk': test_notebook.id}))
     assert resp.status_code == 403
 
 
 def test_delete_notebook_owner(fake_user, test_notebook, client):
     # however, it should succeed if we are the owner
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     resp = client.delete(reverse('notebooks-detail', kwargs={'pk': test_notebook.id}))
     assert resp.status_code == 204
     assert Notebook.objects.count() == 0
@@ -138,7 +138,7 @@ def test_fork_notebook_not_logged_in(client, notebook_fork_post_blob):
 
 
 def test_incorrect_fork_notebook(client, fake_user, incorrect_notebook_fork_post_blob):
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     resp = client.post(reverse('notebooks-list'), incorrect_notebook_fork_post_blob)
     assert resp.status_code == 400
 
@@ -147,7 +147,7 @@ def test_fork_notebook_logged_in(client,
                                  fake_user,
                                  fake_user2,
                                  test_notebook):
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     blob = {
         'title': 'My cool notebook',
         'content': 'Fake notebook content',
@@ -162,7 +162,7 @@ def test_fork_notebook_and_delete_original(client, fake_user,
                                            fake_user2,
                                            test_notebook,
                                            notebook_fork_post_blob):
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     revision = test_notebook.revisions.latest('created')
     response = client.post(reverse('notebooks-list'), {
         'title': 'test',

--- a/server/tests/test_notebook_revision_api.py
+++ b/server/tests/test_notebook_revision_api.py
@@ -66,7 +66,7 @@ def test_create_notebook_revision_non_owner(fake_user, fake_user2, test_notebook
     post_blob = {"title": "My cool notebook",
                  "content": "*modified test content"}
     # should not be able to add a revision if not owner of notebook
-    client.force_authenticate(user=fake_user2)
+    client.force_login(fake_user2)
     resp = client.post(
         reverse("notebook-revisions-list", kwargs={"notebook_id": test_notebook.id}),
         post_blob,
@@ -80,7 +80,7 @@ def test_create_notebook_revision(fake_user, test_notebook, client):
                  "content": "*modified test content"}
 
     # should be able to create a revision if we are the owner
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     resp = client.post(
         reverse("notebook-revisions-list", kwargs={"notebook_id": test_notebook.id}),
         post_blob,
@@ -107,7 +107,7 @@ def test_delete_notebook_revision_not_logged_in(test_notebook, client):
 
 def test_delete_notebook_revision_not_owner(fake_user, fake_user2, test_notebook, client):
     # should not be able to delete if not owner of the notebook revision
-    client.force_authenticate(user=fake_user2)
+    client.force_login(fake_user2)
     resp = client.delete(reverse("notebook-revisions-detail", kwargs={
         'notebook_id': test_notebook.id,
         'pk': test_notebook.revisions.last().id
@@ -117,7 +117,7 @@ def test_delete_notebook_revision_not_owner(fake_user, fake_user2, test_notebook
 
 def test_delete_notebook_revision_owner(fake_user, test_notebook, client):
     # however, it should succeed if we are the owner
-    client.force_authenticate(user=fake_user)
+    client.force_login(user=fake_user)
     resp = client.delete(reverse("notebook-revisions-detail", kwargs={
         'notebook_id': test_notebook.id,
         'pk': test_notebook.revisions.last().id

--- a/server/tests/test_server_pages.py
+++ b/server/tests/test_server_pages.py
@@ -22,6 +22,19 @@ def test_index_view(client, two_test_notebooks):
                                                                  'notebookList'])
 
 
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_index_view_with_gravatar(client, fake_user, logged_in):
+    if logged_in:
+        client.force_login(fake_user)
+    resp = client.get(reverse('index'))
+    assert resp.status_code == 200
+    expected_user_info = {
+        'name': fake_user.username,
+        'avatar': 'http://www.gravatar.com/avatar/eaee5961bc7ad96538a4933cb069fda9?d=identicon'
+    } if logged_in else {}
+    assert _get_page_data(str(resp.content))['userInfo'] == expected_user_info
+
+
 @pytest.mark.parametrize("username", ['testuser', 'test-user', 'testuser@foo.com'])
 def test_user_view_with_different_names(transactional_db, client, username):
     test_user = User.objects.create(


### PR DESCRIPTION
This revealed some flaws in the way we were handling authentication
in the unit tests (i.e. we would incorrectly use github auth if the
user had configured that for their dev server), which are also addressed
here.