### PR TITLE
Add pyodide resources to Iodide build

### DIFF
--- a/bin/install_pyodide
+++ b/bin/install_pyodide
@@ -1,0 +1,6 @@
+#!/bin/sh
+set PYODIDE_VERSION=0.1.11
+if [ ! -d $1 ]; then
+  mkdir $1;
+  curl -L https://github.com/iodide-project/pyodide/releases/download/$PYODIDE_VERSION/pyodide-build-$PYODIDE_VERSION.tar.bz2 | tar jx -C $1
+fi

--- a/bin/install_pyodide
+++ b/bin/install_pyodide
@@ -1,6 +1,7 @@
 #!/bin/sh
 PYODIDE_VERSION="${PYODIDE_VERSION:-0.1.11}"
-if [ ! -d $1 ]; then
-  mkdir $1;
-  curl -L https://github.com/iodide-project/pyodide/releases/download/$PYODIDE_VERSION/pyodide-build-$PYODIDE_VERSION.tar.bz2 | tar jx -C $1
+if [ ! -d $1-$PYODIDE_VERSION ]; then
+  mkdir -p $1-$PYODIDE_VERSION;
+  curl -L https://github.com/iodide-project/pyodide/releases/download/$PYODIDE_VERSION/pyodide-build-$PYODIDE_VERSION.tar.bz2 | tar jx -C $1-$PYODIDE_VERSION
 fi
+ln -sf $1-$PYODIDE_VERSION $1

--- a/bin/install_pyodide
+++ b/bin/install_pyodide
@@ -1,5 +1,5 @@
 #!/bin/sh
-set PYODIDE_VERSION=0.1.11
+PYODIDE_VERSION="${PYODIDE_VERSION:-0.1.11}"
 if [ ! -d $1 ]; then
   mkdir $1;
   curl -L https://github.com/iodide-project/pyodide/releases/download/$PYODIDE_VERSION/pyodide-build-$PYODIDE_VERSION.tar.bz2 | tar jx -C $1

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -8,10 +8,6 @@ set -euo pipefail
 # Uses the node binaries/packages installed by the nodejs buildpack previously.
 npm install && npm run build
 
-# Pull in the Pyodide static resources
-git clone --depth=1 --branch=master https://github.com/iodide-project/pyodide-demo.git build/pyodide
-rm -rf build/pyodide/.git
-
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required
 # since WhiteNoise's Django storage backend only gzips assets handled by

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -4,15 +4,19 @@
 # Make non-zero exit codes & other errors fatal.
 set -euo pipefail
 
-# Create a `prod/` directory containing built/minified versions of the frontend assets.
+# Create a `build/` directory containing built/minified versions of the frontend assets.
 # Uses the node binaries/packages installed by the nodejs buildpack previously.
 npm install && npm run build
+
+# Pull in the Pyodide static resources
+git clone --depth=1 --branch=master https://github.com/iodide-project/pyodide-demo.git build/pyodide
+rm -rf build/pyodide/.git
 
 # Generate gzipped versions of files that would benefit from compression, that
 # WhiteNoise can then serve in preference to the originals. This is required
 # since WhiteNoise's Django storage backend only gzips assets handled by
 # collectstatic, and so does not affect files in the `dist/` directory.
-python -m whitenoise.compress prod
+python -m whitenoise.compress build
 
 # Remove nodejs files to reduce slug size (and avoid environment variable
 # pollution from the nodejs profile script), since they are no longer

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "stackframe": "^1.0.4",
-    "universal-router": "^7.0.0"
+    "universal-router": "^7.0.0",
+    "webpack-shell-plugin": "^0.5.0"
   },
   "devDependencies": {
     "babel-core": "6.26.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const path = require('path')
 const CreateFileWebpack = require('create-file-webpack')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
+const WebpackShellPlugin = require('webpack-shell-plugin')
 const WriteFilePlugin = require('write-file-webpack-plugin')
 const _ = require('lodash')
 
@@ -131,6 +132,10 @@ module.exports = (env) => {
       }),
       new MiniCssExtractPlugin({ filename: `[name].${APP_VERSION_STRING}.css` }),
       new WriteFilePlugin(),
+      // Use an external helper script, due to https://github.com/1337programming/webpack-shell-plugin/issues/41
+      new WebpackShellPlugin({
+        onBuildStart: [`bin/install_pyodide ${BUILD_DIR}/pyodide`]
+      })
     ],
     devServer: {
       contentBase: path.join(__dirname, 'build'),


### PR DESCRIPTION
@wlach: I have no idea if this is the right approach.

`pyodide-demo` (which should probably be renamed to `pyodide-deploy` at some point) is repo where the pyodide built resources get uploaded to by CI.

This works with the local `make up` server, and I can load a language plugin as follows:

```
{
  "languageId": "py",
  "displayName": "Python",
  "codeMirrorMode": "python",
  "keybinding": "p",
  "url": "/pyodide/pyodide.js",
  "module": "pyodide",
  "evaluator": "runPython",
  "asyncEvaluator": "runPythonAsync",
  "pluginType": "language"
}
```

EDIT:

To add some context for this change.  @rth's work to get Scipy working includes a Scipy package that is larger than 100MB, exceeding the maximum file size limit for Github pages.  I'd like to merge that and start making that publicly available, even though the long term plan is to do some "hard things" to get that size down.  

By deploying to Heroku we can get around this limit.  We don't *have to* include it as part of Iodide's deployment (it could be its own static Heroku project, or use some other hosting), but it seems like it saves a little effort for now to do it that way.  This also gives you a local copy of pyodide as part of `npm run build`, which could be handy for doing local/offline demos, but again not critical.