### PR TITLE
Build webpack in test-javascript job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       - run: npm install
       - *save_javascript_cache
       - run: npm run lint
+      - run: npm run build
       - run: npm test
 
   test-python:


### PR DESCRIPTION
This is an incomplete fix for #1127, intended to make sure we don't inadvertently merge PRs which break the entire webpack build (as happened yesterday with #947).