### PR TITLE
on notebook load, compare autosave.originalCopy with autosave.dirtyCopy

### DIFF
--- a/src/tools/autosave.js
+++ b/src/tools/autosave.js
@@ -25,7 +25,9 @@ function saveAutosaveState(autosaveKey, autosaveState) {
 function checkForAutosave(store) {
   const state = store.getState()
   const autosaveState = getAutosaveState(state)
-  if (autosaveState && autosaveState.dirtyCopy) {
+  if (autosaveState &&
+      autosaveState.dirtyCopy &&
+      autosaveState.dirtyCopy !== autosaveState.originalCopy) {
     store.dispatch(setPreviousAutosave(true))
   }
 }


### PR DESCRIPTION
fixes #1141 - now the autosave dirty & original copies are checked for equality before alerting the user there is a more recent version.

@wlach, while working through this case, I'm wondering what the utility of `autosave.originalCopy` is when we also happen to have the actual generated jsmd to pull from. Could we not actually just compare the `dirtyCopy` to that on pageload?