### PR TITLE
Make deploying Pyodide alongside Iodide work

### DIFF
--- a/bin/install_pyodide
+++ b/bin/install_pyodide
@@ -1,7 +1,5 @@
 #!/bin/sh
-PYODIDE_VERSION="${PYODIDE_VERSION:-0.1.11}"
 if [ ! -d $1-$PYODIDE_VERSION ]; then
   mkdir -p $1-$PYODIDE_VERSION;
   curl -L https://github.com/iodide-project/pyodide/releases/download/$PYODIDE_VERSION/pyodide-build-$PYODIDE_VERSION.tar.bz2 | tar jx -C $1-$PYODIDE_VERSION
 fi
-ln -sf $1-$PYODIDE_VERSION $1

--- a/server/settings.py
+++ b/server/settings.py
@@ -196,3 +196,6 @@ STATIC_URL = EVAL_FRAME_ORIGIN
 # Create hashed+gzipped versions of assets during collectstatic,
 # which will then be served by WhiteNoise with a suitable max-age.
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+# Add a MIME type for .wasm files (which is not included in WhiteNoise's defaults)
+WHITENOISE_MIMETYPES = {'.wasm': 'application/wasm'}

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -50,6 +50,8 @@ function loadLanguagePlugin(pluginData, historyId, cell, dispatch) {
         // see the following for asynchronous loading of scripts from strings:
         // https://developer.mozilla.org/en-US/docs/Games/Techniques/Async_scripts
 
+        window.languagePluginUrl = url
+
         // Here, we wrap whatever the return value of the eval into a promise.
         // If it is simply evaling a code block, then it returns undefined.
         // But if it returns a Promise, then we can wait for that promise to resolve
@@ -64,6 +66,7 @@ function loadLanguagePlugin(pluginData, historyId, cell, dispatch) {
           postMessageToEditor('POST_LANGUAGE_DEF_TO_EDITOR', pluginData)
           dispatch(updateCellProperties(cell.id, { evalStatus, rendered }))
           dispatch(updateValueInHistory(historyId, value))
+          delete window.languagePluginUrl
           resolve()
         })
       })

--- a/src/state-schemas/language-definitions.js
+++ b/src/state-schemas/language-definitions.js
@@ -1,3 +1,5 @@
+/* global PYODIDE_VERSION */
+
 // This defines the "built-in" language definitions
 
 export const jsLanguageDefinition = {
@@ -17,7 +19,7 @@ const pyLanguageDefinition = {
   displayName: 'Python',
   codeMirrorMode: 'python',
   keybinding: 'p',
-  url: 'https://iodide.io/pyodide-demo/pyodide.js',
+  url: `/pyodide-${PYODIDE_VERSION}/pyodide.js`,
   module: 'pyodide',
   evaluator: 'runPython',
   asyncEvaluator: 'runPythonAsync',

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -21,5 +21,6 @@ global.IODIDE_JS_PATH = 'testing IODIDE_JS_PATH'
 global.IODIDE_CSS_PATH = 'testing IODIDE_CSS_PATH'
 global.IODIDE_VERSION = 'testing IODIDE_VERSION'
 global.IODIDE_EVAL_FRAME_ORIGIN = 'testing IODIDE_EVAL_FRAME_ORIGIN'
+global.PYODIDE_VERSION = 'testing PYODIDE_VERSION'
 
 Enzyme.configure({ adapter: new Adapter() })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,9 @@ let CSS_PATH_STRING
 let { EDITOR_ORIGIN } = process.env
 let { EVAL_FRAME_ORIGIN } = process.env
 
+const PYODIDE_VERSION = process.env.PYODIDE_VERSION || '0.2.0'
+process.env.PYODIDE_VERSION = PYODIDE_VERSION
+
 const APP_VERSION_STRING = process.env.APP_VERSION_STRING || 'dev'
 
 const APP_DIR = path.resolve(__dirname, 'src/')
@@ -129,6 +132,7 @@ module.exports = (env) => {
         IODIDE_CSS_PATH: JSON.stringify(CSS_PATH_STRING),
         IODIDE_BUILD_MODE: JSON.stringify((env && env.startsWith('dev')) ? 'dev' : 'production'),
         IODIDE_REDUX_LOG_MODE: JSON.stringify(reduxLogMode),
+        PYODIDE_VERSION: JSON.stringify(PYODIDE_VERSION),
       }),
       new MiniCssExtractPlugin({ filename: `[name].${APP_VERSION_STRING}.css` }),
       new WriteFilePlugin(),


### PR DESCRIPTION
This is a follow-on to #1122 to actually make everything work.

1. Had to add a mimetype for WebAssembly to Whitenoise (since browsers require that the .wasm mimetype is correct)

2. Provides a way to pass a base URL to Pyodide's language plugin loader.  This is important so that Pyodide knows the URL at which to find all it's other resources, whether loaded from github pages, a local development checkout or on Heroku.  It's a bit of a hacky pattern (setting a variable on `window` temporarily), but fwiw, this is a similar pattern to what emscripten does all over the place to load complex things.  I'm definitely open to suggestions there.  This will require https://github.com/iodide-project/pyodide/pull/259 to be merged before it will work.

3. Setting the version of Pyodide to install in `webpack.config.js` and using that in both the `install_pyodide` script and from `language-definitions.js`.  I think having the pyodide version in the url is a good thing for caching reasons, and shouldn't be an issue now that we've removed `meta.languages` so there's no "sticky" path to the language plugin in the notebooks anymore.

I feel like this is sewing Iodide and Pyodide a little more at the hip, which wasn't really my intention.  (2) would be a good idea to make language plugins "URL portable" in any event.  The other things are really sort of deployment stuff, which could always change pretty easily if we want to deploy Pyodide separately from Iodide again in the future.