### PR TITLE
makes the css cell work again, and lays groundwork for #1174

### DIFF
--- a/src/actions/__tests__/jsmd-parser-test.js
+++ b/src/actions/__tests__/jsmd-parser-test.js
@@ -191,3 +191,21 @@ js 2
   })
 })
 
+describe('jsmd hashes are distinct', () => {
+  const jsmdSample = `%% js
+js
+%% js
+js
+%% js
+js`
+
+  it('length of set of hashes is correct', () => {
+    expect(new Set(jsmdParser(jsmdSample).map(c => c.chunkId)).size)
+      .toEqual(3)
+  })
+
+  it('hashes of identical content have correct suffixes', () => {
+    expect(jsmdParser(jsmdSample).map(c => c.chunkId.split('_')[1]))
+      .toEqual(['0', '1', '2'])
+  })
+})

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -37,10 +37,21 @@ export function updateAppMessages(messageObj) {
 }
 
 export function updateJsmdContent(text) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     const jsmdChunks = jsmdParser(text)
+    const reportChunkTypes = Object
+      .keys(getState().languageDefinitions)
+      .concat(['md', 'html', 'css'])
+
     const reportChunks = jsmdChunks
-      .filter(c => c.chunkType === 'md' || c.chunkType === 'html')
+      .filter(c => reportChunkTypes.includes(c.chunkType))
+      .map(c => ({
+        chunkContent: c.chunkContent,
+        chunkType: c.chunkType,
+        chunkId: c.chunkId,
+        evalFlags: c.evalFlags,
+      }))
+
     dispatch({
       // this dispatch really just forwards to the eval frame
       type: 'UPDATE_MARKDOWN_CHUNKS',

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -52,6 +52,7 @@ export const editorOnlyStateProperties = {
       properties: {
         chunkContent: { type: 'string' },
         chunkType: { type: 'string' },
+        chunkId: { type: 'string' },
         evalFlags: {
           type: 'array',
           items: { type: 'string' },

--- a/src/state-schemas/eval-frame-only-state-schemas.js
+++ b/src/state-schemas/eval-frame-only-state-schemas.js
@@ -103,12 +103,11 @@ export const evalFrameOnlyStateProperties = {
       properties: {
         chunkContent: { type: 'string' },
         chunkType: { type: 'string' },
+        chunkId: { type: 'string' },
         evalFlags: {
           type: 'array',
           items: { type: 'string' },
         },
-        startLine: { type: 'integer' },
-        endLine: { type: 'integer' },
       },
       additionalProperties: false,
       default: {},


### PR DESCRIPTION
fixes #1158.

the stuff here with the chunkId based on a hash of the content will be useful for #1174. also, by making sure that each chunk to be rendered in the report has a (mostly) stable ID based on the hash of its contents, i think we can avoid some re-renders in react