### PR TITLE
Don't save unchanged language definitions

### DIFF
--- a/src/tools/jsmd-tools.js
+++ b/src/tools/jsmd-tools.js
@@ -276,11 +276,10 @@ ${cell.content}`
 
   // Only save language definitions that aren't identical to the built-in ones
   const customLanguageDefinitions = {}
-  const relevantKeys = ['url', 'module', 'evaluator', 'asyncEvaluator']
   for (const language of Object.keys(state.languageDefinitions)) {
     const src = builtinLanguageDefinitions[language]
     const dst = state.languageDefinitions[language]
-    if (relevantKeys.some(x => src[x] !== dst[x])) {
+    if (['url', 'module', 'evaluator', 'asyncEvaluator'].some(x => src[x] !== dst[x])) {
       customLanguageDefinitions[language] = state.languageDefinitions[language]
     }
   }

--- a/src/tools/jsmd-tools.js
+++ b/src/tools/jsmd-tools.js
@@ -276,9 +276,11 @@ ${cell.content}`
 
   // Only save language definitions that aren't identical to the built-in ones
   const customLanguageDefinitions = {}
+  const relevantKeys = ['url', 'module', 'evaluator', 'asyncEvaluator']
   for (const language of Object.keys(state.languageDefinitions)) {
-    if (JSON.stringify(builtinLanguageDefinitions[language]) !==
-        JSON.stringify(state.languageDefinitions[language])) {
+    const src = builtinLanguageDefinitions[language]
+    const dst = state.languageDefinitions[language]
+    if (relevantKeys.some(x => src[x] !== dst[x])) {
       customLanguageDefinitions[language] = state.languageDefinitions[language]
     }
   }


### PR DESCRIPTION
Fix #1187.

In 4db6194a, the behavior was changed so it would only write out the languageDefinition to the jsmd if it was different from the default.  The idea being, if the user didn't specify the defaults, they probably don't care.  Unfortunately, there is an ephemeral item that was getting tacked onto state's copy of the languageDefinition (`codeMirrorMoreLoaded`) that's causing it to always be different.  This only compares keys that should have an actual difference.

We still need a UX to choose and change language plugins, but this should at least fix things to the currently intended behavior.