### PR TITLE
Make sure Iodide logo gets rendered by zilla slab

### DIFF
--- a/src/shared/iodide-logo.jsx
+++ b/src/shared/iodide-logo.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { css } from 'emotion'
-import Typography from '@material-ui/core/Typography'
 
 export default class IodideLogo extends React.Component {
   render() {
     return (
-      <Typography
-        variant="title"
+      <h2
         className={css`
+          margin: 0;
           font-family: 'Zilla Slab', serif;
           font-size: 30px;
           font-weight: 300;`}
@@ -21,7 +20,7 @@ export default class IodideLogo extends React.Component {
         >
           Iodide
         </a>
-      </Typography>
+      </h2>
     );
   }
 }


### PR DESCRIPTION
The css generated from material ui, when compiled down, had different
than expected behaviour on the server. Get around this by avoiding
using the "typography" component for the logo and just using a
regular old "h2".