### PR TITLE
run highlighted selections (partial chunks, multiple selections, etc.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
     steps:
       - checkout
       - *restore_javascript_cache
+      - run: rm -rf node_modules/*/.git
       - run: npm install
       - *save_javascript_cache
       - run: npm run lint
@@ -44,6 +45,7 @@ jobs:
     steps:
       - checkout
       - *restore_javascript_cache
+      - run: rm -rf node_modules/*/.git
       - run: npm install
       - *save_javascript_cache
       - run: npm run build

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -3,6 +3,7 @@
 import {
   selectionToChunks,
   removeDuplicatePluginChunksInSelectionSet,
+  padOutFetchChunk,
 } from '../actions'
 
 import { jsmdParser } from '../jsmd-parser'
@@ -274,5 +275,38 @@ describe('removeDuplicatePluginChunksInSelectionSet', () => {
     expect(chunk1[0].chunkContent).toBe(FULL_PLUGIN_CHUNK)
     expect(chunk2.filter(c => c.chunkContent === FULL_PLUGIN_CHUNK).length).toBe(0)
     expect(chunk2.filter(c => c.chunkType === 'plugin').length).toBe(1)
+  })
+})
+const FULL_FETCH_CHUNK = `js: https://whatever.com
+css: https://another-domain.biz
+file: /files/gritty-data.csv`
+
+const moreFetchSelections = [
+  {
+    start: 3,
+    selectedText: `js: https://whatever.com
+css: https://another-domain.biz
+file: /files/gri`,
+    expectedValue: FULL_FETCH_CHUNK,
+    side: 'end',
+  },
+  {
+    start: 1,
+    selectedText: `hatever.com
+css: https://another-domain.biz
+file: /files/gritty-data.csv`,
+    expectedValue: FULL_FETCH_CHUNK,
+    side: 'start',
+  },
+]
+
+describe('padOutFetchChunk', () => {
+  const fullText = jsmdChunks[2].chunkContent
+  it('pads out the selection area of a fetch chunk selection to go to start / end of line', () => {
+    moreFetchSelections.forEach((selection) => {
+      const { selectedText, side, start } = selection
+      const editedChunk = padOutFetchChunk(selectedText, fullText, start, side)
+      expect(editedChunk).toBe(selection.expectedValue)
+    })
   })
 })

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -4,7 +4,7 @@ import {
   selectionToChunks,
   removeDuplicatePluginChunksInSelectionSet,
   padOutFetchChunk,
-} from '../actions'
+} from '../jsmd-selection'
 
 import { jsmdParser } from '../jsmd-parser'
 

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -1,0 +1,215 @@
+// import CodeMirror from 'codemirror'
+
+import {
+  selectionToChunks,
+  padOutFetchChunk,
+  getAllSelections,
+} from '../actions'
+
+import { jsmdParser } from '../jsmd-parser'
+
+document.body.innerHTML = ''
+
+const NOTEBOOK = `
+%% js
+
+var x = 10
+var y = 20
+var z = 30
+
+%% fetch
+
+js: https://whatever.com
+css: https://another-domain.biz
+file: /files/gritty-data.csv
+
+%% py
+import numpy
+x = [1,2,3,4,5]
+
+%% plugin
+
+{
+  "languageId": "jsx",
+  "displayName": "jsx",
+  "codeMirrorMode": "jsx",
+  "keybinding": "x",
+  "url": "https://raw.githubusercontent.com/hamilton/iodide-jsx/master/docs/evaluate-jsx.js",
+  "module": "jsx",
+  "evaluator": "evaluateJSX",
+  "pluginType": "language"
+}
+
+%% js
+
+var x = 10
+var y = 20
+var z = 30
+
+`
+
+const fetchSelections = [
+  {
+    start: 9,
+    end: 9,
+    selectedText: ': https',
+    expectedValue: 'js: https://whatever.com',
+  },
+  {
+    start: 10,
+    end: 10,
+    selectedText: ': https',
+    expectedValue: 'css: https://another-domain.biz',
+  },
+  {
+    start: 11,
+    end: 11,
+    selectedText: ': https',
+    expectedValue: 'file: /files/gritty-data.csv',
+  },
+  {
+    start: 9,
+    end: 10,
+    selectedText: 's://whatever.com\ncss: ht',
+    expectedValue: 'js: https://whatever.com\ncss: https://another-domain.biz',
+  },
+  {
+    start: 10,
+    end: 11,
+    selectedText: '//another-domain.biz\nfile: /file',
+    expectedValue: 'css: https://another-domain.biz\nfile: /files/gritty-data.csv',
+  },
+]
+
+
+// line 11.
+const SELECTION_A = `https://another-domain.biz
+file: /files/gritty-data.csv
+
+%% py
+import numpy
+x = [1,2,3,4,5]
+
+`
+
+// lines 5-10. fetch as end chunk needs to go to end of line.
+const SELECTION_B = `var y = 20
+var z = 30
+
+%% fetch
+
+js: h`
+
+// lines 16-24. start of plugin chunk
+const SELECTION_C = `[1,2,3,4,5]
+
+%% plugin
+
+{
+  "languageId": "jsx",
+  "displayName": "jsx",
+  "codeMirrorMode": "jsx",
+  "key`
+
+// lines 27-36. end of plugin chunk
+const SELECTION_D = `"url": "https://raw.githubusercontent.com/hamilton/iodide-jsx/master/docs/evaluate-jsx.js",
+"module": "jsx",
+"evaluator": "evaluateJSX",
+"pluginType": "language"
+}
+
+%% js
+
+var x = 10
+var y = 20`
+
+const FULL_PLUGIN_CHUNK = `
+{
+  "languageId": "jsx",
+  "displayName": "jsx",
+  "codeMirrorMode": "jsx",
+  "keybinding": "x",
+  "url": "https://raw.githubusercontent.com/hamilton/iodide-jsx/master/docs/evaluate-jsx.js",
+  "module": "jsx",
+  "evaluator": "evaluateJSX",
+  "pluginType": "language"
+}
+`
+
+describe('selectionToChunks', () => {
+  const jsmdChunks = jsmdParser(NOTEBOOK)
+
+  it('correctly backs out various fetch selections', () => {
+    fetchSelections.forEach((line) => {
+      const [chunk] = selectionToChunks(line, jsmdChunks)
+      expect(chunk.chunkContent).toBe(line.expectedValue)
+    })
+  })
+
+  const selectionParamsA = {
+    start: 10,
+    end: 16,
+    selectedText: SELECTION_A,
+  }
+
+  const selectedChunksA = selectionToChunks(selectionParamsA, jsmdChunks)
+  const [firstChunkA, secondChunkA] = selectedChunksA
+  it('partial %% fetch ... %% py selection, properly backs out first chunk type + full content', () => {
+    expect(firstChunkA.chunkType).toBe('fetch')
+    expect(firstChunkA.chunkContent).toBe('css: https://another-domain.biz\nfile: /files/gritty-data.csv\n')
+  })
+  it('partial %% fetch ... %% py selection, second chunk type + content identified', () => {
+    expect(secondChunkA.chunkType).toBe('py')
+    expect(secondChunkA.chunkContent).toBe('import numpy\nx = [1,2,3,4,5]\n\n')
+  })
+
+  const selectionParamsB = {
+    start: 5,
+    end: 9,
+    selectedText: SELECTION_B,
+  }
+
+  const selectedChunksB = selectionToChunks(selectionParamsB, jsmdChunks)
+  const [firstChunkB, secondChunkB] = selectedChunksB
+  it('%%js  ... %% fetch ... selection, properly backs out first chunk type + full content', () => {
+    expect(firstChunkB.chunkType).toBe('js')
+    expect(firstChunkB.chunkContent).toBe('var y = 20\nvar z = 30\n')
+  })
+  it('%% js ... %% fetch ... selection, properly completes fetch chunk line', () => {
+    expect(secondChunkB.chunkType).toBe('fetch')
+    expect(secondChunkB.chunkContent).toBe('\njs: https://whatever.com')
+  })
+
+
+  const selectionParamsC = {
+    start: 16,
+    end: 24,
+    selectedText: SELECTION_C,
+  }
+  const selectedChunksC = selectionToChunks(selectionParamsC, jsmdChunks)
+  const [firstChunkC, secondChunkC] = selectedChunksC
+  it('correctly infers the first chunk type from the partial selection', () => {
+    expect(firstChunkC.chunkType).toBe('py')
+    expect(firstChunkC.chunkContent).toBe('[1,2,3,4,5]\n')
+  })
+  it('correctly identifies the second (declared) chunk type from the selection', () => {
+    expect(secondChunkC.chunkType).toBe('plugin')
+    expect(secondChunkC.chunkContent).toBe(FULL_PLUGIN_CHUNK)
+  })
+
+  const selectionParamsD = {
+    start: 25,
+    end: 34,
+    selectedText: SELECTION_D,
+  }
+  const selectedChunksD = selectionToChunks(selectionParamsD, jsmdChunks)
+  const [firstChunkD, secondChunkD] = selectedChunksD
+  it('correctly infers the first chunk type from the partial selection', () => {
+    expect(firstChunkD.chunkType).toBe('plugin')
+    expect(firstChunkD.chunkContent).toBe(FULL_PLUGIN_CHUNK)
+  })
+  it('correctly identifies the second (declared) chunk type from the selection', () => {
+    expect(secondChunkD.chunkType).toBe('js')
+    expect(secondChunkD.chunkContent).toBe('\nvar x = 10\nvar y = 20')
+  })
+})

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -136,11 +136,20 @@ const FULL_PLUGIN_CHUNK = `
 }
 `
 
+const partialPluginSelections = [
+  {
+    start: 22,
+    end: 22,
+    selectedText: 'orMode": "j',
+    expectedValue: FULL_PLUGIN_CHUNK,
+  },
+]
+
 describe('selectionToChunks', () => {
   const jsmdChunks = jsmdParser(NOTEBOOK)
 
-  it('correctly backs out various fetch selections', () => {
-    fetchSelections.forEach((line) => {
+  it('correctly backs out various fetch selections and plugin chunks', () => {
+    [...fetchSelections, ...partialPluginSelections].forEach((line) => {
       const [chunk] = selectionToChunks(line, jsmdChunks)
       expect(chunk.chunkContent).toBe(line.expectedValue)
     })

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -237,8 +237,6 @@ describe('selectionToChunks', () => {
   })
 })
 
-// FIXME: write tests for remove
-
 const pluginChunkA = {
   start: 20, end: 20, selectedText: 'geId": "js',
 }

--- a/src/actions/__tests__/jsmd-selection.test.js
+++ b/src/actions/__tests__/jsmd-selection.test.js
@@ -2,8 +2,6 @@
 
 import {
   selectionToChunks,
-  padOutFetchChunk,
-  getAllSelections,
 } from '../actions'
 
 import { jsmdParser } from '../jsmd-parser'

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -262,7 +262,7 @@ export function selectionToChunks(originalSelection, jsmdChunks) {
   if (startingChunk.chunkType === 'plugin') {
     selection[0].chunkContent = startingChunk.chunkContent
   }
-  if (startingChunk.endType === 'plugin') {
+  if (endingChunk.chunkType === 'plugin') {
     selection[selection.length - 1].chunkContent = endingChunk.chunkContent
   }
   return selection

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -194,6 +194,15 @@ function getChunkContainingLine(jsmdChunks, line) {
   return activeChunk
 }
 
+function triggerTextInEvalFrame(chunk) {
+    return {
+      type: 'TRIGGER_TEXT_IN_FRAME',
+      evalText: chunk.chunkContent,
+      evalType: chunk.chunkType,
+      evalFrags: chunk.evalFlags
+    }
+}
+
 export function evaluateText(chunk = undefined) {
   return (dispatch, getState) => {
     const cm = window.ACTIVE_CODEMIRROR
@@ -221,6 +230,16 @@ export function evaluateText(chunk = undefined) {
         chunkId: activeChunk.chunkId,
       })
     } else {
+      const selection = jsmdParser(doc.getSelection())
+      if (selection[0].chunkType === '') {
+        console.log(selection[0])
+        selection[0].chunkType = getChunkContainingLine(getState().jsmdChunks, doc.getCursor('from')).chunkType
+      }
+      return Promise.all(selection.map(chunk => {
+          return Promise.resolve(dispatch(triggerTextInEvalFrame(chunk)))
+      })
+
+      // parse selection.
       // FIXME handle case of code selected
       // in this case, eval the first selection
       // probably via codemirror doc.listSelections()[0],

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -11,6 +11,7 @@ import { mirroredStateProperties } from '../state-schemas/mirrored-state-schema'
 import { fetchWithCSRFTokenAndJSONContent } from './../shared/fetch-with-csrf-token'
 
 import { jsmdParser } from './jsmd-parser'
+import { getAllSelections, selectionToChunks, removeDuplicatePluginChunksInSelectionSet } from './jsmd-selection'
 
 export function updateAppMessages(messageObj) {
   const { message } = messageObj
@@ -188,7 +189,7 @@ export function addLanguage(languageDefinition) {
 }
 
 
-function getChunkContainingLine(jsmdChunks, line) {
+export function getChunkContainingLine(jsmdChunks, line) {
   const [activeChunk] = jsmdChunks
     .filter(c => c.startLine <= line && line <= c.endLine)
   return activeChunk
@@ -203,83 +204,6 @@ function triggerTextInEvalFrame(chunk) {
   })
 }
 
-export function getAllSelections(doc) {
-  const selections = doc.getSelections()
-  const selectionLines = doc.listSelections()
-  const selectionSet = selections.map((sel, i) => {
-    // head & anchor depends on how you drag, so we have to sort by line+ch.
-    const startEnd = [selectionLines[i].anchor, selectionLines[i].head]
-    startEnd.sort((a, b) => {
-      if (a.line > b.line) return 1
-      else if (a.line < b.line) return 0
-      return a.ch > b.ch
-    })
-    return {
-      start: startEnd[0].line,
-      end: startEnd[1].line,
-      selectedText: sel,
-    }
-  })
-  return selectionSet
-}
-
-export function padOutFetchChunk(selectedChunkContent, fullChunkContent, lineNumber, side) {
-  const lineToReplace = fullChunkContent.split('\n')[lineNumber]
-  const content = selectedChunkContent.split('\n')
-  content[side === 'start' ? 0 : content.length - 1] = lineToReplace
-  return content.join('\n')
-}
-
-export function selectionToChunks(originalSelection, jsmdChunks) {
-  const {
-    start, end,
-  } = originalSelection
-  const { selectedText } = originalSelection
-  const startingChunk = getChunkContainingLine(jsmdChunks, start)
-  const endingChunk = getChunkContainingLine(jsmdChunks, end)
-
-  const selection = jsmdParser(selectedText)
-
-  if (selection[0].chunkType === '') {
-    selection[0].chunkType = startingChunk.chunkType
-  }
-  if (startingChunk.chunkType === 'fetch') {
-    selection[0].chunkContent = padOutFetchChunk(
-      selection[0].chunkContent,
-      startingChunk.chunkContent, start - startingChunk.startLine - 1, 'start',
-    )
-  }
-  if (endingChunk.chunkType === 'fetch') {
-    const lastSelectedChunk = selection[selection.length - 1]
-    lastSelectedChunk.chunkContent = padOutFetchChunk(
-      lastSelectedChunk.chunkContent, endingChunk.chunkContent,
-      end - endingChunk.startLine - 1,
-      'end',
-    )
-    selection[selection.length - 1] = lastSelectedChunk
-  }
-
-  if (startingChunk.chunkType === 'plugin') {
-    selection[0].chunkContent = startingChunk.chunkContent
-  }
-  if (endingChunk.chunkType === 'plugin') {
-    selection[selection.length - 1].chunkContent = endingChunk.chunkContent
-  }
-  return selection
-}
-
-export function removeDuplicatePluginChunksInSelectionSet() {
-  const plugins = new Set()
-  return selection => selection.map((chunk) => {
-    if (chunk.chunkType === 'plugin') {
-      if (plugins.has(chunk.chunkContent)) {
-        return undefined
-      }
-      plugins.add(chunk.chunkContent)
-    }
-    return chunk
-  }).filter(chunk => chunk !== undefined)
-}
 
 export function evaluateText() {
   return (dispatch, getState) => {

--- a/src/actions/jsmd-selection.js
+++ b/src/actions/jsmd-selection.js
@@ -1,0 +1,80 @@
+import { getChunkContainingLine } from './actions'
+import { jsmdParser } from './jsmd-parser'
+
+export function getAllSelections(doc) {
+  const selections = doc.getSelections()
+  const selectionLines = doc.listSelections()
+  const selectionSet = selections.map((sel, i) => {
+    // head & anchor depends on how you drag, so we have to sort by line+ch.
+    const startEnd = [selectionLines[i].anchor, selectionLines[i].head]
+    startEnd.sort((a, b) => {
+      if (a.line > b.line) return 1
+      else if (a.line < b.line) return 0
+      return a.ch > b.ch
+    })
+    return {
+      start: startEnd[0].line,
+      end: startEnd[1].line,
+      selectedText: sel,
+    }
+  })
+  return selectionSet
+}
+
+export function padOutFetchChunk(selectedChunkContent, fullChunkContent, lineNumber, side) {
+  const lineToReplace = fullChunkContent.split('\n')[lineNumber]
+  const content = selectedChunkContent.split('\n')
+  content[side === 'start' ? 0 : content.length - 1] = lineToReplace
+  return content.join('\n')
+}
+
+export function selectionToChunks(originalSelection, jsmdChunks) {
+  const {
+    start, end,
+  } = originalSelection
+  const { selectedText } = originalSelection
+  const startingChunk = getChunkContainingLine(jsmdChunks, start)
+  const endingChunk = getChunkContainingLine(jsmdChunks, end)
+
+  const selection = jsmdParser(selectedText)
+
+  if (selection[0].chunkType === '') {
+    selection[0].chunkType = startingChunk.chunkType
+  }
+  if (startingChunk.chunkType === 'fetch') {
+    selection[0].chunkContent = padOutFetchChunk(
+      selection[0].chunkContent,
+      startingChunk.chunkContent, start - startingChunk.startLine - 1, 'start',
+    )
+  }
+  if (endingChunk.chunkType === 'fetch') {
+    const lastSelectedChunk = selection[selection.length - 1]
+    lastSelectedChunk.chunkContent = padOutFetchChunk(
+      lastSelectedChunk.chunkContent, endingChunk.chunkContent,
+      end - endingChunk.startLine - 1,
+      'end',
+    )
+    selection[selection.length - 1] = lastSelectedChunk
+  }
+
+  if (startingChunk.chunkType === 'plugin') {
+    selection[0].chunkContent = startingChunk.chunkContent
+  }
+  if (endingChunk.chunkType === 'plugin') {
+    selection[selection.length - 1].chunkContent = endingChunk.chunkContent
+  }
+  return selection
+}
+
+export function removeDuplicatePluginChunksInSelectionSet() {
+  const plugins = new Set()
+  return selection => selection.map((chunk) => {
+    if (chunk.chunkType === 'plugin') {
+      if (plugins.has(chunk.chunkContent)) {
+        return undefined
+      }
+      plugins.add(chunk.chunkContent)
+    }
+    return chunk
+  }).filter(chunk => chunk !== undefined)
+}


### PR DESCRIPTION
Fixes #1160. This PR:

- [x] filters out md and css
- [x] allows multiple selections w/ CodeMirror's native stuff (`ctrl` and drag)
- [x] backs out the type from the first partially selected cell
- [x] automatically runs the entirety of a plugin cell even if it is partially highlighted
- [x] automatically runs the entirety of a highlighted _line_ from a fetch chunk (not the whole chunk, just the line)
- [x] test coverage for selection functionality