### PR TITLE
WIP: throw error if evalType isn't loaded

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -230,10 +230,12 @@ export function evaluateText(
         dispatch(evaluateCode(evalText, evalType, state)))
     } else {
       evaluationQueue = evaluationQueue.then(() => {
-        const error = new Error(`eval type ${evalType} is not defined`)
-        dispatch(appendToEvalHistory(null, evalText, error, {
-          historyType: 'CONSOLE_EVAL',
-        }))
+        dispatch(appendToEvalHistory(
+          null, evalText,
+          new Error(`eval type ${evalType} is not defined`), {
+            historyType: 'CONSOLE_EVAL',
+          },
+        ))
       })
     }
     return evaluationQueue

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -228,7 +228,7 @@ export function evaluateText(
       Object.keys(state.languageDefinitions).includes(evalType)) {
       evaluationQueue = evaluationQueue.then(() =>
         dispatch(evaluateCode(evalText, evalType, state)))
-    } else {
+    } else if (!['css', 'md', 'meta', 'raw'].includes(evalType)) {
       evaluationQueue = evaluationQueue.then(() => {
         dispatch(appendToEvalHistory(
           null, evalText,

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -2,7 +2,9 @@ import MarkdownIt from 'markdown-it'
 import MarkdownItKatex from 'markdown-it-katex'
 import MarkdownItAnchor from 'markdown-it-anchor'
 
-// import { waitForExplicitContinuationStatusResolution } from '../iodide-api/evalQueue'
+import {
+  NONCODE_EVAL_TYPES,
+} from '../../state-schemas/editor-only-state-schemas'
 
 import {
   // evaluateLanguagePluginCell,
@@ -228,7 +230,7 @@ export function evaluateText(
       Object.keys(state.languageDefinitions).includes(evalType)) {
       evaluationQueue = evaluationQueue.then(() =>
         dispatch(evaluateCode(evalText, evalType, state)))
-    } else if (!['css', 'md', 'meta', 'raw'].includes(evalType)) {
+    } else if (!NONCODE_EVAL_TYPES.includes(evalType)) {
       evaluationQueue = evaluationQueue.then(() => {
         dispatch(appendToEvalHistory(
           null, evalText,

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -228,6 +228,13 @@ export function evaluateText(
       Object.keys(state.languageDefinitions).includes(evalType)) {
       evaluationQueue = evaluationQueue.then(() =>
         dispatch(evaluateCode(evalText, evalType, state)))
+    } else {
+      evaluationQueue = evaluationQueue.then(() => {
+        const error = new Error(`eval type ${evalType} is not defined`)
+        dispatch(appendToEvalHistory(null, evalText, error, {
+          historyType: 'CONSOLE_EVAL',
+        }))
+      })
     }
     return evaluationQueue
   }

--- a/src/state-schemas/editor-only-state-schemas.js
+++ b/src/state-schemas/editor-only-state-schemas.js
@@ -11,6 +11,8 @@ export const editorOnlyCellProperties = {
   },
 }
 
+export const NONCODE_EVAL_TYPES = ['css', 'md', 'meta', 'raw']
+
 export const editorCellSchema = {
   type: 'object',
   properties:


### PR DESCRIPTION
Fixes #1161. As of filing we are still showing one line of the stack trace. It's possible that @mdboom's PR mentioned on gitter will possibly fix this, so instead of fixing it myself I'll wait for that one.