### PR TITLE
restores iodide.output. also fixed a bug in chunk id (hash) generation

### DIFF
--- a/src/actions/__tests__/jsmd-parser-test.js
+++ b/src/actions/__tests__/jsmd-parser-test.js
@@ -210,6 +210,22 @@ js`
   })
 })
 
+describe('jsmd hashes are distinct for empty cells', () => {
+  const jsmdSample = `%% js
+%% js
+%% js
+%% js`
+
+  it('length of set of hashes is correct', () => {
+    expect(new Set(jsmdParser(jsmdSample).map(c => c.chunkId)).size)
+      .toEqual(4)
+  })
+
+  it('hashes of identical content have correct suffixes', () => {
+    expect(jsmdParser(jsmdSample).map(c => c.chunkId.split('_')[1]))
+      .toEqual(['0', '1', '2', '3'])
+  })
+})
 
 describe('correct chunk types in tricky cases', () => {
   const jsmdSample = `%% chunk1

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -207,6 +207,7 @@ export function evaluateText(chunk = undefined) {
         evalText: chunk.chunkContent,
         evalType: chunk.chunkType,
         evalFlags: chunk.evalFlags,
+        chunkId: chunk.chunkId,
       }
     } else if (!doc.somethingSelected()) {
       const { line } = doc.getCursor()
@@ -217,6 +218,7 @@ export function evaluateText(chunk = undefined) {
         evalText: activeChunk.chunkContent,
         evalType: activeChunk.chunkType,
         evalFlags: activeChunk.evalFlags,
+        chunkId: activeChunk.chunkId,
       })
     } else {
       // FIXME handle case of code selected

--- a/src/actions/jsmd-parser.js
+++ b/src/actions/jsmd-parser.js
@@ -3,11 +3,12 @@ function hashCode(str) {
   // https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
   let hash = 0
   let chr
-  if (str.length === 0) return hash;
-  for (let i = 0; i < str.length; i++) {
-    chr = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + chr // eslint-disable-line
-    hash |= 0 // eslint-disable-line
+  if (str.length !== 0) {
+    for (let i = 0; i < str.length; i++) {
+      chr = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr // eslint-disable-line
+      hash |= 0 // eslint-disable-line
+    }
   }
   return hash.toString()
 }

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -41,6 +41,26 @@ function IdFactory() {
 
 export const historyIdGen = new IdFactory()
 
+class Singleton {
+  constructor() {
+    this.data = null
+  }
+  set(data) {
+    this.data = data
+  }
+  get() {
+    return this.data
+  }
+}
+
+const MOST_RECENT_CHUNK_ID = new Singleton()
+
+export { MOST_RECENT_CHUNK_ID }
+
+
+// ////////////// actual actions
+
+
 export function resetNotebook() {
   // we still need this for some tests to work, even though it's not really used
   return {
@@ -184,12 +204,15 @@ export function evaluateText(
   evalText,
   evalType,
   evalFlags, // eslint-disable-line
+  chunkId = null,
 ) {
   // allowed types:
   // md
   return (dispatch, getState) => {
     // exit if there is no code to eval or no eval type
     // if (!evalText || !evalType) { return undefined }
+    MOST_RECENT_CHUNK_ID.set(chunkId)
+    document.getElementById(`side-effect-target-${MOST_RECENT_CHUNK_ID.get()}`).innerText = null
     const state = getState()
     if (evalType === 'fetch') {
       evaluationQueue = evaluationQueue.then(() => dispatch(evaluateFetchText(evalText)))

--- a/src/eval-frame/components/panes/report-pane.js
+++ b/src/eval-frame/components/panes/report-pane.js
@@ -32,6 +32,7 @@ export class ReportPaneUnconnected extends React.Component {
     const mdComponents = this.props.reportChunks.map((chunk) => {
       const key = chunk.chunkId
       let contents
+      let htmlId
       switch (chunk.chunkType) {
         case 'md':
         case 'html':
@@ -46,9 +47,10 @@ export class ReportPaneUnconnected extends React.Component {
         default:
           // in the case of code and other cell types,
           // just want an empty div; `contents` can remain undefined
+          htmlId = `side-effect-target-${key}`
           break
       }
-      return (<div key={key}>{contents}</div>)
+      return (<div key={key} id={htmlId}>{contents}</div>)
     })
 
     return (

--- a/src/eval-frame/iodide-api/output.js
+++ b/src/eval-frame/iodide-api/output.js
@@ -1,4 +1,4 @@
-import { store } from '../store'
+import { MOST_RECENT_CHUNK_ID } from '../actions/actions'
 
 /*
 These functions operate outside of the normal React/redux update cycle
@@ -14,12 +14,12 @@ things out.
 
 function sideEffectDiv(sideEffectClass, reportSideEffect) {
   // appends a side effect div to the side effect area
-  const cellId = store.getState().runningCellID
-  store.dispatch({ type: 'CELL_SIDE_EFFECT_STATUS', cellId, hasSideEffect: true })
+  // const cellId = store.getState().runningCellID
+  // store.dispatch({ type: 'CELL_SIDE_EFFECT_STATUS', cellId, hasSideEffect: true })
   const div = document.createElement('div')
   div.setAttribute('class', sideEffectClass)
   if (reportSideEffect === false) { div.setAttribute('style', 'display:') }
-  document.getElementById(`cell-${cellId}-side-effect-target`).append(div)
+  document.getElementById(`side-effect-target-${MOST_RECENT_CHUNK_ID.get()}`).append(div)
   return div
 }
 

--- a/src/eval-frame/iodide-api/output.js
+++ b/src/eval-frame/iodide-api/output.js
@@ -14,8 +14,6 @@ things out.
 
 function sideEffectDiv(sideEffectClass, reportSideEffect) {
   // appends a side effect div to the side effect area
-  // const cellId = store.getState().runningCellID
-  // store.dispatch({ type: 'CELL_SIDE_EFFECT_STATUS', cellId, hasSideEffect: true })
   const div = document.createElement('div')
   div.setAttribute('class', sideEffectClass)
   if (reportSideEffect === false) { div.setAttribute('style', 'display:') }

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -47,6 +47,7 @@ function receiveMessage(event) {
             message.evalText,
             message.evalType,
             message.evalFlags,
+            message.chunkId,
           ))
         } else if (message.type === 'UPDATE_EVAL_FRAME_FROM_INITIAL_JSMD') {
           // in this case, we need to update the declared variables


### PR DESCRIPTION
here's some sample content to test:
```
%% md
# a header

%% js
[1,2,3,4].forEach((i) => iodide.output.text(`scripted text ${i}`))

%%md
# another header

%% md
## Using numpy and matplotlib

%% py
import numpy as np
x = np.linspace(0, 2.0 * np.pi, 100)
y = np.sin(x)
y

%% py
z = np.exp(np.sin(x))
z

%% py
from matplotlib import pyplot as plt
plt.figure()
plt.plot(x, y)
plt.show()
```


IMPORTANT CAVEAT (which is basically a reminder of the caveat we discussed in toronto):

because we don't have actual cell objects with stable, persistent ids, and because the list of chunks can be mutated in arbitrarily weird ways via cut and paste, typing, etc, there is not a great way of linking text chunks to divs in the report that allows a stable mapping to be preserved when a chunk is edited (without doing a ton of extra work using eg diffs of operative transforms or something).

as a consequence, when you eval a chunk that uses `iodide.output`, it renders to the div corresponding to that chunk; but as soon as you edit that chunk, the mapping is broken (b/c without doing heavy sorcery, we can't know if you deleted the whole chunk, pasted new code over it, etc) so the output goes away _immediately_; and thus you have to eval the chunk again to see the new output.

this PR still gets us to close to parity with where we are on master in terms of being able to use iodide.output to put stuff in the report, so i don't want to over-rotate on this. in general, i'm less and less sure that `iodide.output` is a good idea in the jsmd context, and i'd rather provide it "as-is" with documentation about it's foibles and a warning that it's a convenience function and that for robust control over positioning etc it's better to target a div. (also recall that, as @hamilton noted, there is actually not a way to make this convenience function target the correct report div when async evals are involved (i think there is not a way to make it work at all, and there is certainly not away to do it without more deep sorcery))