### PR TITLE
Add language drop down for the console

### DIFF
--- a/src/eval-frame/components/panes/console-input.js
+++ b/src/eval-frame/components/panes/console-input.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import DoubleChevronIcon from './double-chevron-icon'
 
 import { updateConsoleText, consoleHistoryStepBack } from '../../actions/actions'
+import ConsoleLanguageMenu from './console-language-menu'
 
 export class ConsoleInputUnconnected extends React.Component {
   static propTypes = {
@@ -82,6 +83,7 @@ export class ConsoleInputUnconnected extends React.Component {
             value={this.props.consoleText}
           />
         </div>
+        <ConsoleLanguageMenu />
       </div>
     )
   }

--- a/src/eval-frame/components/panes/console-language-menu.jsx
+++ b/src/eval-frame/components/panes/console-language-menu.jsx
@@ -22,14 +22,14 @@ export class ConsoleLanguageMenuUnconnected extends React.Component {
       anchorElement: null,
     }
     this.handleClick = this.handleClick.bind(this)
-    this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
+    this.handleClose = this.handleClose.bind(this)
   }
 
   handleClick(event) {
     this.setState({ anchorElement: event.currentTarget })
   }
 
-  handleIconButtonClose() {
+  handleClose() {
     this.setState({ anchorElement: null })
   }
 
@@ -37,7 +37,7 @@ export class ConsoleLanguageMenuUnconnected extends React.Component {
     const { anchorElement } = this.state
 
     return (
-      <div className="cell-menu-container">
+      <div>
         <Tooltip
           classes={{ tooltip: 'iodide-tooltip' }}
           placement="bottom"
@@ -45,30 +45,29 @@ export class ConsoleLanguageMenuUnconnected extends React.Component {
         >
           <div>
             <Menu
-              id="cell-menu"
+              id="console-language-menu"
               open={Boolean(anchorElement)}
-              onClose={this.handleIconButtonClose}
+              onClose={this.handleClose}
               transitionDuration={70}
               getContentAnchorEl={null}
+              anchorEl={anchorElement}
               anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
               transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
-              <div className="cell-menu-items-container">
+              <div>
                 {Object.values(this.props.availableLanguages).map(language => (
                   <MenuItem
                     classes={{ root: 'iodide-menu-item' }}
                     key={language.languageId}
                     onClick={() => {
                       this.props.setConsoleLanguage(language.languageId)
-                      this.handleIconButtonClose()
+                      this.handleClose()
                     }}
                   >
                     <ListItemText
-                      classes={{ root: 'primary-menu-item' }}
                       primary={language.languageId}
                     />
                     <ListItemText
-                      classes={{ root: 'primary-menu-item' }}
                       primary={language.displayName}
                     />
                   </MenuItem>
@@ -76,7 +75,7 @@ export class ConsoleLanguageMenuUnconnected extends React.Component {
               </div>
             </Menu>
             <div
-              className="cell-type-label"
+              aria-owns={anchorElement ? 'simple-menu' : undefined}
               aria-haspopup="true"
               onClick={this.handleClick}
             >

--- a/src/eval-frame/components/panes/console-language-menu.jsx
+++ b/src/eval-frame/components/panes/console-language-menu.jsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import Tooltip from '@material-ui/core/Tooltip'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import ListItemText from '@material-ui/core/ListItemText'
+import ArrowDropUp from '@material-ui/icons/ArrowDropUp'
+
+import { setConsoleLanguage } from '../../actions/actions'
+
+
+export class ConsoleLanguageMenuUnconnected extends React.Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    availableLanguages: PropTypes.object.isRequired,
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      anchorElement: null,
+    }
+    this.handleClick = this.handleClick.bind(this)
+    this.handleIconButtonClose = this.handleIconButtonClose.bind(this)
+  }
+
+  handleClick(event) {
+    this.setState({ anchorElement: event.currentTarget })
+  }
+
+  handleIconButtonClose() {
+    this.setState({ anchorElement: null })
+  }
+
+  render() {
+    const { anchorElement } = this.state
+
+    return (
+      <div className="cell-menu-container">
+        <Tooltip
+          classes={{ tooltip: 'iodide-tooltip' }}
+          placement="bottom"
+          title="Current language"
+        >
+          <div>
+            <Menu
+              id="cell-menu"
+              open={Boolean(anchorElement)}
+              onClose={this.handleIconButtonClose}
+              transitionDuration={70}
+              getContentAnchorEl={null}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            >
+              <div className="cell-menu-items-container">
+                {Object.values(this.props.availableLanguages).map(language => (
+                  <MenuItem
+                    classes={{ root: 'iodide-menu-item' }}
+                    key={language.languageId}
+                    onClick={() => {
+                      this.props.setConsoleLanguage(language.languageId)
+                      this.handleIconButtonClose()
+                    }}
+                  >
+                    <ListItemText
+                      classes={{ root: 'primary-menu-item' }}
+                      primary={language.languageId}
+                    />
+                    <ListItemText
+                      classes={{ root: 'primary-menu-item' }}
+                      primary={language.displayName}
+                    />
+                  </MenuItem>
+                ))}
+              </div>
+            </Menu>
+            <div
+              className="cell-type-label"
+              aria-haspopup="true"
+              onClick={this.handleClick}
+            >
+              {this.props.label}
+              <ArrowDropUp style={{ fontSize: 20 }} />
+            </div>
+          </div>
+        </Tooltip>
+      </div>
+    )
+  }
+}
+
+
+function mapStateToProps(state) {
+  const availableLanguages = Object.assign({}, state.languageDefinitions, state.loadedLanguages)
+  return {
+    label: state.languageLastUsed,
+    availableLanguages,
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    setConsoleLanguage: (language) => {
+      dispatch(setConsoleLanguage(language))
+    },
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConsoleLanguageMenuUnconnected)

--- a/src/eval-frame/reducers/eval-frame-reducer.js
+++ b/src/eval-frame/reducers/eval-frame-reducer.js
@@ -168,6 +168,10 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { panePositions: action.panePositions })
     }
 
+    case 'SET_CONSOLE_LANGUAGE': {
+      return Object.assign({}, state, { languageLastUsed: action.language })
+    }
+
     default: {
       return state
     }


### PR DESCRIPTION
Fixes #1088.

Adds a drop down to the console input line to select a language.  It automatically updates based on the last language evaluated from the JSMD editor as well (this used to work in the cell-based days, but looks like it got disconnected in the JSMD refactor).

It also supports automatically loading the language if it hasn't already been loaded.