### PR TITLE
jsmd editing: fixes side effect DOM element fail on fetch / plugin chunks

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -211,8 +211,13 @@ export function evaluateText(
   return (dispatch, getState) => {
     // exit if there is no code to eval or no eval type
     // if (!evalText || !evalType) { return undefined }
+    // FIXME: we need to deprecate side effects ASAP. They don't serve a purpose
+    // in the direct jsmd editing paradigm.
     MOST_RECENT_CHUNK_ID.set(chunkId)
-    document.getElementById(`side-effect-target-${MOST_RECENT_CHUNK_ID.get()}`).innerText = null
+    const sideEffect = document.getElementById(`side-effect-target-${MOST_RECENT_CHUNK_ID.get()}`)
+    if (sideEffect) {
+      sideEffect.innerText = null
+    }
     const state = getState()
     if (evalType === 'fetch') {
       evaluationQueue = evaluationQueue.then(() => dispatch(evaluateFetchText(evalText)))


### PR DESCRIPTION
A recent PR fixing `iodide.output` appears to have caused a new bug in the fetch chunk which I unfortunately did not catch in my manual QA. This PR fixes this for now.