### PR TITLE
Make iodide link in menu bar open in new tab

### DIFF
--- a/src/shared/iodide-logo.jsx
+++ b/src/shared/iodide-logo.jsx
@@ -13,7 +13,8 @@ export default class IodideLogo extends React.Component {
       >
         <a
           href={this.props.backLink}
-          target="_self"
+          rel="noopener noreferrer"
+          target="_blank"
           className={css`
             color: white;
             text-decoration: none;`}


### PR DESCRIPTION
Fixes #1268 

@bcolloran Please see if this is the correct fix. It is working for me.