### PR TITLE
Add basic admin view for notebooks

### DIFF
--- a/server/notebooks/admin.py
+++ b/server/notebooks/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+from .models import Notebook
+
+
+class NotebookAdmin(admin.ModelAdmin):
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser or request.user.is_staff
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.is_superuser or request.user.is_staff
+
+    def has_module_permission(self, request):
+        return request.user.is_superuser or request.user.is_staff
+
+
+admin.site.register(Notebook, NotebookAdmin)


### PR DESCRIPTION
This lets users designated as admins modify or delete existing notebooks
on the server. It might be useful, for example, for designating
certain notebooks as "featured" (#1229).