### PR TITLE
Fix #1286: Add in-tree documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,24 @@ jobs:
             - Dockerfile
             - docker-compose.yml
 
+  docs:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: sudo pip install mkdocs markdown-include
+      - run:
+          name: Build docs
+          command: mkdocs build
+      - deploy:
+          name: Deploy
+          command: |
+            if [ $CIRCLE_BRANCH == "master" ]; then
+              mkdocs gh-deploy
+            fi
+
   test-server:
     machine:
       enable: true
@@ -141,6 +159,10 @@ workflows:
             tags:
               only: /.*/
       - build:
+          filters:
+            tags:
+              only: /.*/
+      - docs:
           filters:
             tags:
               only: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ ext_resources/
 # vscode configs
 .vscode/
 wallaby.js
+
+# mkdocs
+site

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,11 @@ If you’d like to fix a currently-filed issue, please take a look at the commen
 We use [Jest](https://facebook.github.io/jest/) as our testing framework. Every PR will automatically run through our tests, and our test framework will alert you on Github if your PR doesn’t pass all of them. If your PR fails a test, try to figure out whether or not you can update your code to make the test pass again, or ask for help. As a policy we will not accept a PR that fails any of our tests, and will likely ask you to add tests if your PR adds new functionality. Writing tests can be scary, but they make open-source contributions easier for everyone to assess. Take a moment and look through how we’ve written our tests, and try to make your tests match. If you are having trouble, we can help you get started on your test-writing journey.
 
 We've found the following articles to be particularly useful, and we suggest reading them:
-- https://medium.freecodecamp.org/the-right-way-to-test-react-components-548a4736ab22
-- https://hackernoon.com/front-end-react-snapshot-testing-with-jest-what-is-it-for-7788f7bd5a2e
-- http://muness.blogspot.com/2008/04/testing-declarative-code.html
-- https://hackernoon.com/unit-testing-redux-connected-components-692fa3c4441c
+
+- [The right way to test React components](https://medium.freecodecamp.org/the-right-way-to-test-react-components-548a4736ab22)
+- [Frontend React snapshot testing with Jest](https://hackernoon.com/front-end-react-snapshot-testing-with-jest-what-is-it-for-7788f7bd5a2e)
+- [Testing declarative code](http://muness.blogspot.com/2008/04/testing-declarative-code.html)
+- [Unit-testing Redux connection components](https://hackernoon.com/unit-testing-redux-connected-components-692fa3c4441c)
 
 Some guidelines that we tend to follow:
 - we don't use snapshots for testing

--- a/README.md
+++ b/README.md
@@ -38,48 +38,9 @@ Please feel free to join our [Google group](https://groups.google.com/forum/#!fo
 
 You can also [chat with us on Gitter](https://gitter.im/iodide-project/iodide).
 
-# Setup
+# Learn more about it
 
-Run `npm install` after cloning this repository.
-
-## Running/Building
-
-### Client-only mode
-
-If you're only working on client code and don't need to use/test any of the server functionality described below. You can use `npm run start-and-serve` to write development versions of the Iodide client-side app resources to `dev/` and to serve the files in that folder at `http://localhost:8000`. You can open `http://localhost:8000/iodide.dev.html` in your browser to get started with a blank notebook, or open `http://localhost:8000` to see the list of files saved in `dev/` (in case you have exported other test notebooks in that folder)
-
-The command `npm run start-and-serve` runs in watch mode, so changes to files will be detected and bundled into `dev/` automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
-
-If you require verbose Redux logging, you can use the command `npm run start-and-serve -- reduxVerbose`
-
-#### Exporting from client-only dev mode
-
-In this mode, resource paths are set to be relative to the `dev/` directory. Thus, if you export a bundled notebook from a dev notebook, you need to be sure save the exported HTML file in the `dev/` folder for the relative paths to correctly resolve the required js, css, and font files (and if you want to share a notebook that you created in a dev environment, you'll need to update the paths to point to the web-accessible resources at `iodide.io` and `iodide.app`).
-
-
-### Server mode
-
-We have been building an experimental iodide server based on Python and Django. Currently the main features
-it supports are login/identity (via the github API). To test/run it locally, follow this set of steps:
-
-* Register a [github oauth token](https://github.com/settings/applications/new). Set the homepage URL to be
-"http://localhost:8000" and the authentication callback URL to be "http://localhost:8000/oauth/complete/github/".
-* Copy `.env-dist` to `.env` and set the `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to the values provided above.
-* Make sure you have [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) installed and working correctly
-* Run `make build && make up`
-* You should now be able to navigate to a test server instance at http://localhost:8000
-
-On subsequent runs, you only need to run `make up`.
-
-Additionally, if you are working on client code, you can run `npm run start` in a separate terminal to run webpack in watch mode (which will make your client code changes visible on page reload). If you require verbose Redux logging, you can set the environment variable `REDUX_LOGGING=VERBOSE` with the command `REDUX_LOGGING=VERBOSE npm run start`
-
-Sometimes, for debugging purposes, it is useful to have a shell session inside the "app" docker container. You
-can use either the `make shell` command (creates a shell session with the "app" user) or the `make root-shell`
-commands (creates a shell session logged in as root, useful for experimenting with new python packages).
-
-## Testing
-
-Run `npm test` to run the test suite once, or `npm test --watch` to run the suite in watch mode, which will automatically re-run the tests when the source or tests have changed.
+Please visit our [documentation](https://iodide-project.github.io/iodide/).
 
 # Using the notebook
 
@@ -87,11 +48,12 @@ Visit our examples repo at https://github.com/iodide-project/iodide-examples to 
 
 For now, work can be saved to local storage using the "Save Notebook <ctrl-s>" menu item, or exported with "Export Notebook <ctrl-e>", which allows you to download your work as HTML file that will run anywhere (for the time being, we advise periodically exporting any code you care about).
 
-We've modeled much of the experience on Jupyter as our jumping-off point, with a few additions. Check out our milestones & issues to see the direction we're going.
-
 # Contributing
 
-Please join us! The notebook is written using React+Redux, which, if you haven't used them, are pretty delightful -- there's some learning curve, but even for non-professional webdevs the curve is not too steep, and the mental model is clean and powerful.
+Please join us! The notebook is written using React+Redux, which, if you haven't
+used them, are pretty delightful -- there's some learning curve, but even for
+non-professional webdevs the curve is not too steep, and the mental model is
+clean and powerful.
 
 See our ["How to Contribute" page](CONTRIBUTING.md) for more information.
 
@@ -100,47 +62,31 @@ We especially need help with:
 - test coverage for everything in our system.
 - demos, tutorials, and documentation. The more we have, and the better organized it is, the better.
 
-# Our core principles
+# Design principles
+
+## Our core principles
+
 - Human factors come before everything else
 - Scientific computing and computational inquiry implies different needs than typical software development
 - We want to make the advantages of web tech available to scientists without requiring them to become fully fledged web devs
 
 ## Secondary principles
 Flowing from those core principles, we have a number of secondary principles/objectives that revolve around the notion of reduce friction for people that want out the platform.
+
 - Portability is key -- users should be able to get up and running immediately and be able to start doing real work entirely within the browser. 
+
     - Allowing the notebook to work with other client and/or server-side programs/components/tools (e.g. external editors, external compute kernels (other languages or big data thingies)) might be something cool to work on down the road, but is not an objective at the moment
     - Addons to do things that the browser restricts or can’t do for some reason (file system access, halting hung scripts) could potentially be ok for power users, but cannot be a requirement to get going with a satisfactory experience.
+
 - No magic APIs -- users should (within reason) not have to learn about a ton of idiosyncrasies of the notebook to get up and running.
+
     - Users need to be able to build off of existing work/examples/resources. Users need to be able to pull examples from bl.ocks.org or JSfiddle or Stackoverflow and have them run in the notebook without modification (within reason). This means, among other things, seamless access to all browser APIs is a hard requirement.
     - Helper libraries are desirable, but they should just act like regular JS libraries and not require users to contort their mental model of how vanilla JS works, or pollute the regular JS environment. (Ex: it would be preferable to add a single namespaced helper lib than to dump a bunch of utility functions into the global scope).
     - We want to support syntax extensions for mathematics, but we want them to be opt in, not something that a user will have to learn to be able to use a notebook.
 - Don’t innovate too much -- at least initially, we want to follow existing, familiar paradigms that will enable people to dive right in.
 
-You can read more about how these priciples have shaped the choices we've made so far [in our FAQ]( ../../wiki/FAQ )
-
 ## Initial use case
 In building this tool, we will keep our eyes on a broad swath of computational inquiry use cases, and we’ll strive to avoid making decisions that limit the tools use to a specific domain. We're initially be targeting small to medium _N_ data science workflows, since these often come up at Mozilla and we're very familiar with them, but if your use case requires something that we haven't addressed yet, please leave us a message at our [Google group](https://groups.google.com/forum/#!forum/iodide-dev).
-
-
-## Roadmap
-
-There are a bunch of features that we know we want to build to make this compelling. Here are a few in rough order of priority:
-
-- Export improvements
-    - Option to Inline bundle.js (rather than load from URL)
-    - Options to inline external libs in a saved snapshot
-    - Saving an “environment” (a la R and R Studio) with selected variables that were computed during a session
-        - serializing/compressing data inline (needed for bigger datasets),
-        - Estimate of total bundled size with all scripts and environment vars
-    - Export/import to gists, g-drive, dropbox, and other external repos
-- r-studio mode (direct editing of jsmd)
-- editor improvements
-    - Code editor
-        - Special character insertion (greek, special operators, etc)
-    - Latex editor
-        - hints, autocomplete (for latex, this includes special character insertion)
-        - Lyx-like wysiwyg preview for equation editing
-- UI for importing local data from file (with drag and drop? Needed for XSS reasons, lack of filesystem access reasons)
 
 # License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,188 @@
+# API docs
+
+These functions, available within any code cell, aim to improve workflows and
+challenges presented by Javascript and web browsers.
+
+Please direct clarifications or observations of innacuracy to [our issue
+tracker](https://github.com/iodide-project/docs/issues/new).
+
+## `iodide.environment`
+
+Functions for saving the state of variables and exporting data with your notebook.
+
+### `iodide.environment.freeze(obj)`
+
+Serializes as JSON then compresses the state of an object. `obj` will freeze the
+value under the namespace of the key. Once the notebook is exported, the state
+will be added to the embedded JSMD in the html document. Freezing is
+_additive_ - every call to `iodide.environment.freeze` will either update or add
+a new bit of state, but will not overwrite key-value pairs not explicitly
+updated.
+
+```javascript
+var x = [{a: 10000, b: 20000}, {a: 1043, b: 29343}]
+var y = 'iodide'
+iodide.environment.freeze({x, y})
+```
+
+### `iodide.environment.freezeRawString`
+
+Same as `iodide.environment.freeze`, but will not compress the value.
+
+### `iodide.environment.get(key)`
+
+Retrieves the serialized data.
+
+```javascript
+let xData = iodide.environment.get('x')
+```
+
+### `iodide.environment.list`
+
+Returns an array of keys of the set of currently frozen variables.
+
+```javascript
+var x = [{a: 10000, b: 20000}, {a: 1043, b: 29343}]
+var y = 'iodide'
+iodide.environment.freeze({x, y})
+
+iodide.environment.list()
+> ['x', 'y']
+```
+
+### `iodide.environment.clear`
+
+Removes all frozen variables from the environment.
+
+```javascript
+iodide.environment.clear()
+iodide.environment.list()
+> []
+```
+
+## `iodide.evalQueue`
+
+Functions for pausing and resuming the cell evaluation queue. Useful for
+awaiting the end of an asynchronous call or process of some sort before
+continuing onto the next cell.
+
+### `iodide.evalQueue.await(arrayOfPromises)`
+
+Works similarly to `Promise.all`. Once all the Promises contained in
+`arrayOfPromises` resolve (or reject), iodide is allowed to evaluate other
+cells.
+
+This is the easiest way to fetch a number of data sources, delaying other cells
+from being evaluated until you have the data you need.
+
+```javascript
+var data1
+var data2
+
+iodide.evalQueue.await([
+  fetch('whatever.com/data1.json').then(d=>d.json()).then(d => data1=d),
+  fetch('whatever.com/someComplicatedData2.json').then(d => d.json()).then(d => data2=d),
+])
+```
+
+### `iodide.evalQueue.requireExplicitContinuation()`
+
+This function explicitly sets a flag to delay any further cell evaluation until
+the user has encountered `iodide.evalQueue.continue()`.
+
+It is vital that when using `iodide.evalQueue` functions that you properly build
+in error catching.
+
+### `iodide.evalQueue.continue()`
+
+This function sets a flag to move on to the next cell execution after the block
+in which it is executed has completed.
+
+By way of an example, this code block will await the resolution of a `Promise`
+before moving to the next cell.
+
+```javascript
+iodide.evalQueue.requireExplicitContinuation()
+var url = 'https://gist.githubusercontent.com/hamilton/67d7904af5cd696ec2b12450b69bd657/raw/15d83f7f281c3e5de2ca3359529ef041b47fcbf6/css'
+
+fetch(url).then(d=>d.text())
+  .then(data=>{
+ 	 return data.split('\n').map(d=>d.split(","))
+  })
+  .then(data=>{
+    let header = data[0]
+    let body = data.slice(1)
+    return body.map(di=>{
+      let out = {}
+      header.forEach((h,i)=>{
+        out[h] = di[i]
+      })
+      return out
+    })
+  })
+  .then(data=>{
+  // format data a bit more nicely!
+  iodide.evalQueue.continue()
+  return data.map(d=>{
+      d.neighborhood = d.nbrhd
+      delete d.nbrhd
+      d.evictionNotices = d.count
+      delete d.count
+      d.date = new Date(d.date)
+      return d
+    })
+})
+```
+
+Here is another example to further clarify, using a Promise directly.
+
+```javascript
+iodide.evalQueue.requireExplicitContinuation()
+
+let dataSet = new Promise((resolve, reject) => {
+    let counter = 0
+    let timer = setInterval(() => {
+        counter += 1
+        if (counter > 10) {
+            iodide.evalQueue.continue()
+            resolve('finished!') // resolve the promise
+            clearInterval(timer)
+        }
+    }, 300)
+})
+```
+
+## `iodide.addOutputHandler(handler)`
+
+Adds a custom output handler to Iodide. Check out [this example
+notebook](https://iodide.io/iodide-examples/output-handling.html).
+
+An output handler is an object or function that has two functions:
+`shouldHandle` and `render`. `shouldHandle` is a function that takes a value,
+inspects it in some way, and then returns `true` if this handler should handle
+it, and `false` otherwise. `iodide.addOutputHandler` takes the handler and adds
+it to the chain of handlers checked whenever a user outputs a return value in a
+cell.
+
+By way of example, this handler will inspect a value for `lat` and `lon` keys,
+and if they exist, outputs a map centered on the coordinates.
+
+```javascript
+const GeoLocationOutputHandler = {
+    shouldHandle: function(value) {
+        return (typeof value === 'object') && 'lat' in value && 'lon' in value
+    },
+
+    render: function(value, inContainer) {
+        // return a HTMLElement, as created by document.createElement
+        let img = document.createElement('img')
+        let size = inContainer ? "150x100" : "600x300"
+        img.src = 'http://staticmap.openstreetmap.de/staticmap.php?center=' + value.lat + ',' + value.lon +
+          '&zoom=17&size=' + size + '&maptype=mapnik'
+        return img
+    }
+}
+
+iodide.addOutputHandler(GeoLocationOutputHandler)
+
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+{!CONTRIBUTING.md!}

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,81 @@
+# Developer documentation
+
+This document describes how to get up and running with Iodide development to
+contribute to the project. Most users of Iodide shouldn't need this information.
+
+## Setting up a local development environment
+
+### Installing dependencies
+
+Run `npm install` after cloning this repository.
+
+### Running/Building
+
+#### Client-only mode
+
+If you're only working on client code and don't need to use/test any of the server functionality described below. You can use `npm run start-and-serve` to write development versions of the Iodide client-side app resources to `dev/` and to serve the files in that folder at `http://localhost:8000`. You can open `http://localhost:8000/iodide.dev.html` in your browser to get started with a blank notebook, or open `http://localhost:8000` to see the list of files saved in `dev/` (in case you have exported other test notebooks in that folder)
+
+The command `npm run start-and-serve` runs in watch mode, so changes to files will be detected and bundled into `dev/` automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
+
+If you require verbose Redux logging, you can use the command `npm run start-and-serve -- reduxVerbose`
+
+##### Exporting from client-only dev mode
+
+In this mode, resource paths are set to be relative to the `dev/` directory. Thus, if you export a bundled notebook from a dev notebook, you need to be sure save the exported HTML file in the `dev/` folder for the relative paths to correctly resolve the required js, css, and font files (and if you want to share a notebook that you created in a dev environment, you'll need to update the paths to point to the web-accessible resources at `iodide.io` and `iodide.app`).
+
+#### Server mode
+
+We have been building an experimental iodide server based on Python and Django. Currently the main features
+it supports are login/identity (via the github API). To test/run it locally, follow this set of steps:
+
+* Register a [github oauth token](https://github.com/settings/applications/new). Set the homepage URL to be
+"http://localhost:8000" and the authentication callback URL to be "http://localhost:8000/oauth/complete/github/".
+* Copy `.env-dist` to `.env` and set the `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to the values provided above.
+* Make sure you have [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) installed and working correctly
+* Run `make build && make up`
+* You should now be able to navigate to a test server instance at http://localhost:8000
+
+On subsequent runs, you only need to run `make up`.
+
+Additionally, if you are working on client code, you can run `npm run start` in a separate terminal to run webpack in watch mode (which will make your client code changes visible on page reload). If you require verbose Redux logging, you can set the environment variable `REDUX_LOGGING=VERBOSE` with the command `REDUX_LOGGING=VERBOSE npm run start`
+
+Sometimes, for debugging purposes, it is useful to have a shell session inside the "app" docker container. You
+can use either the `make shell` command (creates a shell session with the "app" user) or the `make root-shell`
+commands (creates a shell session logged in as root, useful for experimenting with new python packages).
+
+### Building the docs
+
+The documentation is written in markdown, and uses
+[mkdocs](https://www.mkdocs.org/) to generate a static website.
+
+To test changes to the docs locally, you'll need to install `mkdocs` and
+`markdown-include`. This is completely independent of the server's Docker image
+described above. If you have `pip` and `python` installed on your system, you
+can install these packages using the command:
+
+```
+pip install mkdocs markdown-include
+```
+
+If that doesn't work, consult the [mkdocs installation
+instructions](https://www.mkdocs.org/#installing-mkdocs).
+
+Then you can run:
+
+```
+mkdocs serve
+```
+
+to preview the docs during development.
+
+To build a local, static copy of the docs, run:
+
+```
+mkdocs build
+```
+
+### Testing
+
+Run `npm test` to run the test suite once, or `npm test --watch` to run the suite in watch mode, which will automatically re-run the tests when the source or tests have changed.
+
+

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,26 @@
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,500|Zilla+Slab');
+
+body::before {
+  background-image: none;
+  background-color: white;
+}
+
+.navbar {
+  background-image: none;
+  background-color: black;
+  border-bottom: none;
+}
+
+.navbar-brand {
+  font-family: 'Zilla Slab', serif;
+}
+
+h1, h2, h3, h4, h5 {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 300;
+}
+
+body {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 400;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Iodide Documentation 
+
+## User documentation
+
+**[JSMD format](jsmd.md)**: The simple file format used to write Iodide notebooks.
+
+**[API docs](api.md)**: Documents special Javascript functions available to
+Iodide notebooks.
+
+**[Keybindings](keybindings.md)**: The keybindings and shortcuts.
+
+## Developer documentation
+
+**[Developer docs](developer.md)**: Information about contributing to Iodide.

--- a/docs/jsmd.md
+++ b/docs/jsmd.md
@@ -1,0 +1,35 @@
+# JSMD format 
+
+## What is JSMD?
+
+JSMD, short for **J**ava**S**cript **M**ark**D**own, is the file format that
+Iodide notebooks are written in. It provides a way to interleave the narrative
+parts of your notebook, written in Markdown, with the computational parts, written
+in Javascript, or through the use of language plugins, in other languages such
+as Python or OCaml.
+
+It is simply a collection of contents in different languages,
+separated by lines that start with `%%` and indicate the language of the chunk
+below.  For example, JSMD supports the following delimiters:
+
+- `%% md` for Markdown
+- `%% js` for Javascript
+- `%% css` for CSS
+- `%% py` for Python
+
+and so on.
+
+So, why aren't we just exporting big JSON files like Jupyter and calling it a
+day? Importantly, a flat file is easy for both humans and computers to
+understand. For example, it works out of the box with standard software
+development tools like ``diff`` and Github pull requests. The simplicity of this
+format is inspired by [`.Rmd`](https://rmarkdown.rstudio.com/r_notebooks.html)
+(RMarkdown notebook) files.
+
+Additionally, since the point of Iodide is to give you a living, breathing
+notebook evaluation environment, this means we have a lot less state to export,
+so are requirements are much simpler than Jupyter's. Markdown chunks get
+rendered when a page loads, libraries get requested from cdns, data gets pulled,
+and so on. So you don't need to save the kinds of state you do in a Jupyter
+notebook.
+

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,0 +1,3 @@
+# Keybindings
+
+TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Iodide Documentation
+site_url: https://iodide-project.github.io/iodide/
+repo_url: https://github.com/iodide-project/iodide/
+theme: mkdocs
+extra_css: [extra.css]
+nav:
+  - Index: index.md
+markdown_extensions:
+  - markdown_include.include
+


### PR DESCRIPTION
This adds a in-tree documentation.

I'm using `mkdocs` for this.  While that adds a build-time Python dependency, hopefully that's not too onerous.  The leading Javascript-based tool, GitBook, is no longer supported.  Overall, I've been pleased with mkdocs -- it was pretty easy to get it to do the simple things we need it to do.

A lot of the content is repurposed from the `docs` repo, but a lot of that is kind of out-of-date.  This all probably needs refleshing of details.  I didn't tackle the `fetch` cell, because I don't really know how it works... :)

This also reorganizes the `README`, moving some of the more low-level technical content into the docs.