### PR TITLE
Fix #1308: Ignore mkdocs version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             if [ $CIRCLE_BRANCH == "master" ]; then
               git remote add docs git@github.com:iodide-project/docs.git
-              mkdocs gh-deploy --force --remote-name=docs --remote-branch=master
+              mkdocs gh-deploy --force --remote-name=docs --remote-branch=master --ignore-version
             fi
 
   test-server:


### PR DESCRIPTION
This just turns off the broken version check when deploying mkdocs.  I'm not terribly sure what the value of the version check is in the first place...