### PR TITLE
added onboarding layout (left col: editor; right: report and console); set this to be the initial view

### DIFF
--- a/src/components/pane-layout/layout-config-onboarding.js
+++ b/src/components/pane-layout/layout-config-onboarding.js
@@ -1,0 +1,39 @@
+import {
+  EditorPositioner,
+  ConsolePositioner,
+  ReportPositioner,
+  WorkspacePositioner,
+  AppInfoPositioner,
+} from './layout-config-content-items'
+
+export default {
+  settings: {
+    showPopoutIcon: false,
+    showCloseIcon: false,
+    showMaximiseIcon: false,
+  },
+  dimensions: {
+    dragProxyWidth: 300,
+    dragProxyHeight: 0,
+  },
+  content: [{
+    type: 'row',
+    content: [
+      EditorPositioner,
+      {
+        type: 'column',
+        content: [
+          ReportPositioner,
+          {
+            type: 'stack',
+            content: [
+              ConsolePositioner,
+              WorkspacePositioner,
+              AppInfoPositioner,
+            ],
+          },
+        ],
+      },
+    ],
+  }],
+}

--- a/src/components/pane-layout/layout-manager.jsx
+++ b/src/components/pane-layout/layout-manager.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import GoldenLayout from 'golden-layout'
 import { ResizeSensor } from 'css-element-queries'
 
-import intialLayoutConfig from './layout-config-explore'
+import intialLayoutConfig from './layout-config-onboarding'
 import {
   LAYOUT_MANAGER_IN_FRONT_ZINDEX,
   LAYOUT_MANAGER_IN_BACK_ZINDEX,


### PR DESCRIPTION
this just sets a new default view for notebooks so that users will be able to see the mapping between MD cells and the report and js cells and the console immediately without having to investigate and rearrange tabs

closes #1328

![image](https://user-images.githubusercontent.com/2380975/50857906-d774bf80-1343-11e9-82d9-e02ca791a63a.png)
