### PR TITLE
Fix #641: Add link to docs in help pane

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,6 @@
 **[API docs](api.md)**: Documents special Javascript functions available to
 Iodide notebooks.
 
-**[Keybindings](keybindings.md)**: The keybindings and shortcuts.
-
 ## Developer documentation
 
 **[Developer docs](developer.md)**: Information about contributing to Iodide.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -1,3 +1,0 @@
-# Keybindings
-
-TODO

--- a/src/components/modals/help-modal.jsx
+++ b/src/components/modals/help-modal.jsx
@@ -26,7 +26,12 @@ function AboutIodide() {
 }
 
 function MoreResources() {
-  return (<div className="help-modal-contents">Coming soon...</div>);
+  return (
+    <div className="help-modal-contents">
+      <h2>Documentation</h2>
+      <p>Visit the <a href="https://iodide.io/docs">Iodide Documentation</a>.</p>
+    </div>
+  )
 }
 
 export default class HelpModal extends React.Component {


### PR DESCRIPTION
Additionally, this remove the keybindings from the docs (which were empty anyway), since it seems less clunky to have those only in the interface.