### PR TITLE
add circular dep warning during build and fix lint in webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2532,6 +2532,12 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "circular-dependency-plugin": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.0.2.tgz",
+      "integrity": "sha512-oC7/DVAyfcY3UWKm0sN/oVoDedQDQiw/vIiAnuTWTpE5s0zWf7l3WY417Xw/Fbi/QbAjctAkxgMiS9P0s3zkmA==",
+      "dev": true
+    },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "8.0.4",
     "babel-plugin-lodash": "3.3.4",
+    "circular-dependency-plugin": "5.0.2",
     "create-file-webpack": "1.0.2",
     "css-loader": "2.1.0",
     "dotenv": "6.2.0",


### PR DESCRIPTION
@wlach @mdboom @hamilton just fyi -- i was experimenting with this circular dependency checker the other day... we have a ton of circular deps, and they actually cause a bunch of headaches in a few places.

Right now this is set to warn not error during the webpack build, but i intend to keep working on these. I think ideally, if we can eliminate the circularities we have and not add any new ones, we should set this to error. No action is required ATM, this is just a heads up. I'll go ahead and merge when this passes CI, no need to review (tho of course you're welcome to look and add suggestions!).