### PR TITLE
Have server shells run inside *existing* containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ build:
 	docker build -t app:build .
 
 root-shell:
-	docker-compose run -u 0 server bash
+	docker-compose exec -u 0 server bash
 
 shell:
-	docker-compose run server bash
+	docker-compose exec server bash
 
 up:
 	docker-compose up

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -41,7 +41,7 @@ Additionally, if you are working on client code, you can run `npm run start` in 
 
 Sometimes, for debugging purposes, it is useful to have a shell session inside the "app" docker container. You
 can use either the `make shell` command (creates a shell session with the "app" user) or the `make root-shell`
-commands (creates a shell session logged in as root, useful for experimenting with new python packages).
+commands (creates a shell session logged in as root, useful for experimenting with new python packages). Note that the iodide server environment must already be running for this to work.
 
 ### Building the docs
 


### PR DESCRIPTION
This ensures changes made (e.g. installing new packages) will be
visible to other processes running inside the same container.