### PR TITLE
Add redirects

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -36,6 +36,11 @@ ALLOWED_HOSTS = [SITE_HOSTNAME]
 APP_VERSION_STRING = env.str('APP_VERSION_STRING', 'dev')
 EVAL_FRAME_ORIGIN = env.str('EVAL_FRAME_ORIGIN', SITE_URL)
 
+# Define URI redirects.
+# Is a ;-delimited list of redirects, where each section is of the form
+# $prefix=$destination
+IODIDE_REDIRECTS = env("IODIDE_REDIRECTS", default="")
+
 # Dockerflow
 DOCKERFLOW_ENABLED = env.bool("DOCKERFLOW_ENABLED", default=False)
 

--- a/server/tests/test_settings.py
+++ b/server/tests/test_settings.py
@@ -1,0 +1,17 @@
+from server.urls import parse_redirects
+
+
+def test_parse_redirects():
+    content = \
+        'docs/= http://iodide-project.github.io/docs/;dist/=http://google.com'
+    redirects = list(parse_redirects(content))
+
+    docs, dist = redirects
+
+    assert docs.pattern._regex == '^docs/.*'
+    assert docs.callback.view_initkwargs['url'] == \
+        'http://iodide-project.github.io/docs/'
+
+    assert dist.pattern._regex == '^dist/.*'
+    assert dist.callback.view_initkwargs['url'] == \
+        'http://google.com'


### PR DESCRIPTION
This adds redirects on the server that go to GH pages, only when installed on `iodide.io` for the following:

- `dist/`: The old released versions of standalone (serverless) iodide, so as to not break existing notebooks on the internet
- `docs/`: This is location of the new markdown-based docs
- `pyodide-demo/`: Not strictly necessary, but it buys me some time to update links from blog posts and presentations

I'm not sure if the `SITE_URL` value is exactly correct, as I couldn't find where the configuration for our Heroku deployment is...  I did test it in a local server and changing it to `http://localhost:8000/` makes it work locally.