### PR TITLE
Add a "try it out" mode to iodide (fixes #1330)

### DIFF
--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -111,3 +111,26 @@ def new_notebook_view(request):
             title='Untitled notebook'
         )
     return redirect(notebook)
+
+
+@ensure_csrf_cookie
+def tryit_view(request):
+    '''
+    A way to let new users experiment with iodide without logging in
+
+    If user is logged in, redirect to `/new/`
+    '''
+    if request.user.is_authenticated:
+        return redirect(new_notebook_view)
+    # create a new notebook and redirect to its view
+    new_notebook_content_template = get_template('new_notebook_content.jsmd')
+    return render(request, 'notebook.html', {
+        'user_info': {},
+        'notebook_info': {
+            'connectionMode': 'SERVER',
+            'tryItMode': True,
+            'title': 'Untitled notebook'
+        },
+        'jsmd': new_notebook_content_template.render(),
+        'iframe_src': _get_iframe_src()
+    })

--- a/server/tests/test_notebook_view.py
+++ b/server/tests/test_notebook_view.py
@@ -29,3 +29,24 @@ def test_new_notebook_view(client, fake_user, logged_in):
         assert NotebookRevision.objects.count() == 0
         assert Notebook.objects.count() == 0
         assert last_url == reverse('login') + '?next=/new'
+
+
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_tryit_view(client, fake_user, logged_in):
+    if logged_in:
+        client.force_login(fake_user)
+    response = client.get(reverse('try-it'), follow=True)
+
+    if logged_in:
+        # if we are logged in, this view should redirect to /new`
+        assert NotebookRevision.objects.count() == 1
+        assert Notebook.objects.count() == 1
+        assert len(response.redirect_chain) == 2
+        (last_url, _) = response.redirect_chain[-1]
+        assert last_url == Notebook.objects.all()[0].get_absolute_url()
+    else:
+        # if we are not logged in, all the action should happen on the
+        # client
+        assert NotebookRevision.objects.count() == 0
+        assert Notebook.objects.count() == 0
+        assert len(response.redirect_chain) == 0

--- a/server/urls.py
+++ b/server/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
     url(r'^notebooks/', include('server.notebooks.urls')),
     url(r'^new/?', server.notebooks.views.new_notebook_view,
         name='new-notebook'),
+    url(r'^tryit/?', server.notebooks.views.tryit_view,
+        name='try-it'),
 
     # various views to help with the authentication pipeline
     url(r'^oauth/', include('social_django.urls', namespace='social')),

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -74,8 +74,8 @@ export class HeaderMessagesUnconnected extends React.Component {
       case "NEED_TO_LOGIN":
         content = (
           <span>
-            To save to this server, you need to&nbsp;
-            <a onClick={this.showLoginModal}>login</a>.
+            You can modify and experiment with this notebook freely. To save to
+            this server, you need to <a onClick={this.showLoginModal}>login</a>.
           </span>
         );
         break;

--- a/src/server/components/splash/marketing-copy-splash.jsx
+++ b/src/server/components/splash/marketing-copy-splash.jsx
@@ -75,9 +75,7 @@ export default class MarketingCopySplash extends React.Component {
         </SplashCopy>
         <ButtonGroup>
           <ContainedButton href="/login">Sign Up For Free</ContainedButton>
-          <OutlineButton href="https://extremely-alpha.iodide.io/notebooks/154/">
-            Try It Out
-          </OutlineButton>
+          <OutlineButton href="/tryit/">Try It Out</OutlineButton>
           <DocsButton />
         </ButtonGroup>
         <ThreePointsContainer>

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -190,7 +190,8 @@ export const stateProperties = {
       connectionMode: {
         type: "string",
         enum: ["SERVER", "STANDALONE"]
-      }
+      },
+      tryItMode: { type: "boolean" }
     },
     default: {
       notebook_id: undefined,

--- a/src/tools/server-tools.js
+++ b/src/tools/server-tools.js
@@ -28,6 +28,10 @@ export function connectionModeIsServer(state) {
   return getConnectionMode(state) === "SERVER";
 }
 
+export function notebookIsATrial(state) {
+  return state.notebookInfo.tryItMode;
+}
+
 export function getNotebookID(state) {
   if (!connectionModeIsServer(state)) return undefined;
   const notebookID = state.notebookInfo.notebook_id;


### PR DESCRIPTION
This is similar in behaviour to the `/new/` endpoint, except it doesn't
save the notebook. If the user later decides to log in, their changes
will automatically be saved to their account.

If a logged in user visits this endpoint, they will be redirected to
`/new/`.