### PR TITLE
fetch cells no longer mysteriously block on error

### DIFF
--- a/src/components/codemirror-jsmd-mode.js
+++ b/src/components/codemirror-jsmd-mode.js
@@ -70,7 +70,6 @@ CodeMirror.defineMode("jsmd", () => ({
       const indent = state.localMode.indent(state.localState, textAfter, line);
       return indent;
     }
-    console.log("no local indent available");
     return CodeMirror.Pass;
   },
 

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -112,6 +112,7 @@ export function evaluateFetchText(fetchText, evalId) {
           { historyId, historyType: "FETCH_CELL_INFO" }
         )
       );
+      sendStatusResponseToEditor("ERROR", evalId);
       return Promise.resolve();
     }
 

--- a/src/eval-frame/reducers/reducer.js
+++ b/src/eval-frame/reducers/reducer.js
@@ -21,7 +21,7 @@ const actionForwarder = (state, action) => {
   try {
     if (action.type !== "REPLACE_STATE") postActionToEditor(action);
   } catch (error) {
-    console.log("EVAL FRAME ACTION POST TO EDITOR FAILED");
+    console.error("EVAL FRAME ACTION POST TO EDITOR FAILED");
   }
   return state;
 };

--- a/src/eval-frame/reducers/reducer.js
+++ b/src/eval-frame/reducers/reducer.js
@@ -21,7 +21,7 @@ const actionForwarder = (state, action) => {
   try {
     if (action.type !== "REPLACE_STATE") postActionToEditor(action);
   } catch (error) {
-    console.error("EVAL FRAME ACTION POST TO EDITOR FAILED");
+    console.log("EVAL FRAME ACTION POST TO EDITOR FAILED");
   }
   return state;
 };


### PR DESCRIPTION
fixes #1372. Not sure how this was introduced as a bug, but something was preventing sending the evaluation response on syntax errors in fetch chunks.