### PR TITLE
PROOF OF CONCEPT: Intercept console(.log | .warn | .error) and print to iodide console

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -127,7 +127,7 @@ function takeOverConsole(dispatch) {
       }
     };
   }
-  const methods = ["log", "warn", "error"];
+  const methods = ["info","log", "warn", "error"];
   for (let i = 0; i < methods.length; i++) intercept(methods[i]);
 }
 /* eslint-enable */

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -17,6 +17,10 @@ import { postMessageToEditor } from "../port-to-editor";
 const MD = MarkdownIt({ html: true });
 MD.use(MarkdownItKatex).use(MarkdownItAnchor);
 
+// NB: this is a POC, and should be made better than this.
+// takeOverConsole needs a dispatch. This can be done outside of actions,
+// but I guess I'll leave it here for now. Make sure to delete this note
+// if this PR goes somewhere.
 let takeOver = false;
 /* eslint-disable */
 function takeOverConsole(dispatch) {

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -17,8 +17,11 @@ import { postMessageToEditor } from "../port-to-editor";
 const MD = MarkdownIt({ html: true });
 MD.use(MarkdownItKatex).use(MarkdownItAnchor);
 
+let takeOver = false;
 /* eslint-disable */
 function takeOverConsole(dispatch) {
+  if (takeOver) return
+  if (!takeOver) takeOver = true
   const console = window.console;
   if (!console) return;
   function intercept(method) {
@@ -29,7 +32,7 @@ function takeOverConsole(dispatch) {
         method,
         arguments,
         {
-          historyType: "CONSOLE_EVAL"
+          historyType: "CONSOLE_MESSAGE"
         }
       ))
       if (original.apply) {

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -34,9 +34,10 @@ function takeOverConsole(dispatch) {
       dispatch(appendToEvalHistory(
         null,
         method,
-        arguments,
+        [...arguments],
         {
-          historyType: "CONSOLE_MESSAGE"
+          historyType: "CONSOLE_MESSAGE",
+          level: method
         }
       ))
       if (original.apply) {

--- a/src/eval-frame/components/panes/console-message.jsx
+++ b/src/eval-frame/components/panes/console-message.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "react-emotion";
+
+const ConsoleMessageIcon = styled("div")`
+  display: flex;
+  align-items: center;
+  align-self: center;
+  min-width: 17px;
+`;
+
+const ConsoleMessageContainer = styled("div")`
+  padding: 5px;
+  padding-left: 10px;
+  border-bottom: 0.5px solid gainsboro;
+  display: flex;
+  align-items: baseline;
+  background-color: ${props => props.levelColor};
+
+  div {
+    padding-right: 5px;
+  }
+
+  li div {
+    background-color: ${props => props.levelColor};
+  }
+`;
+
+export default class ConsoleMessage extends React.Component {
+  render() {
+    return (
+      <ConsoleMessageContainer levelColor={this.props.levelColor}>
+        <ConsoleMessageIcon>{this.props.icon}</ConsoleMessageIcon>
+        {this.props.children}
+      </ConsoleMessageContainer>
+    );
+  }
+}

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -15,6 +15,13 @@ import PaneContentButton from "./pane-content-button";
 import { postMessageToEditor } from "../../port-to-editor";
 import { EVALUATION_RESULTS } from "../../actions/actions";
 
+const ConsoleMessageIcon = styled("div")`
+  display: flex;
+  align-items: center;
+  align-self: center;
+  min-width: 17px;
+`;
+
 const ConsoleMessage = styled("div")`
   padding: 5px;
   padding-left: 10px;
@@ -24,7 +31,6 @@ const ConsoleMessage = styled("div")`
   background-color: ${props => props.levelColor};
 
   div {
-    padding-left: 5px;
     padding-right: 5px;
   }
 
@@ -70,7 +76,7 @@ export class HistoryItemUnconnected extends React.Component {
       case "CONSOLE_MESSAGE":
         return (
           <ConsoleMessage levelColor={this.props.levelColor}>
-            {this.props.levelIcon}
+            <ConsoleMessageIcon>{this.props.levelIcon}</ConsoleMessageIcon>
             {this.props.valueToRender.map(v => (
               <ValueRenderer
                 key={`out-${Math.random()}-${v.toString()}`}
@@ -137,6 +143,9 @@ export function mapStateToProps(state, ownProps) {
     const level = ownProps.historyItem.content;
     if (level !== undefined) {
       if (level === "log") {
+        levelColor = "white";
+        levelIcon = undefined;
+      } else if (level === "info") {
         levelColor = "white";
         levelIcon = (
           <Log

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -3,6 +3,10 @@ import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import styled from "react-emotion";
 
+import Log from "@material-ui/icons/InfoOutlined";
+import Warning from "@material-ui/icons/WarningOutlined";
+import Error from "@material-ui/icons/ErrorOutlined";
+
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import { ValueRenderer } from "../../../components/reps/value-renderer";
 import PreformattedTextItemsHandler from "../../../components/reps/preformatted-text-items-handler";
@@ -66,7 +70,7 @@ export class HistoryItemUnconnected extends React.Component {
       case "CONSOLE_MESSAGE":
         return (
           <ConsoleMessage levelColor={this.props.levelColor}>
-            {/* {this.props.valueToRender} <ValueRenderer render valueToRender={this.props.valueToRender} /> */}
+            {this.props.levelIcon}
             {this.props.valueToRender.map(v => (
               <ValueRenderer
                 key={`out-${Math.random()}-${v.toString()}`}
@@ -128,15 +132,46 @@ export class HistoryItemUnconnected extends React.Component {
 
 export function mapStateToProps(state, ownProps) {
   let levelColor;
+  let levelIcon;
   if (ownProps.historyItem) {
     const level = ownProps.historyItem.content;
     if (level !== undefined) {
       if (level === "log") {
         levelColor = "white";
+        levelIcon = (
+          <Log
+            style={{
+              paddingRight: "3px",
+              alignSelf: "center",
+              color: "rgb(74,74,79)"
+            }}
+            fontSize="inherit"
+          />
+        );
       } else if (level === "warn") {
         levelColor = "rgb(255,251,214)";
+        levelIcon = (
+          <Warning
+            style={{
+              paddingRight: "3px",
+              alignSelf: "center",
+              color: "rgb(190,155,0)"
+            }}
+            fontSize="inherit"
+          />
+        );
       } else if (level === "error") {
         levelColor = "rgb(253, 242, 245)";
+        levelIcon = (
+          <Error
+            style={{
+              paddingRight: "3px",
+              alignSelf: "center",
+              color: "rgb(215,0,34)"
+            }}
+            fontSize="inherit"
+          />
+        );
       }
     }
   }
@@ -147,7 +182,8 @@ export function mapStateToProps(state, ownProps) {
     historyType: ownProps.historyItem.historyType,
     lastRan: ownProps.historyItem.lastRan,
     valueToRender: EVALUATION_RESULTS[ownProps.historyItem.historyId],
-    levelColor
+    levelColor,
+    levelIcon
   };
 }
 

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import styled from "react-emotion";
 
 import Log from "@material-ui/icons/InfoOutlined";
 import Warning from "@material-ui/icons/WarningOutlined";
@@ -10,34 +9,11 @@ import Error from "@material-ui/icons/ErrorOutlined";
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import { ValueRenderer } from "../../../components/reps/value-renderer";
 import PreformattedTextItemsHandler from "../../../components/reps/preformatted-text-items-handler";
+import ConsoleMessage from "./console-message";
 
 import PaneContentButton from "./pane-content-button";
 import { postMessageToEditor } from "../../port-to-editor";
 import { EVALUATION_RESULTS } from "../../actions/actions";
-
-const ConsoleMessageIcon = styled("div")`
-  display: flex;
-  align-items: center;
-  align-self: center;
-  min-width: 17px;
-`;
-
-const ConsoleMessage = styled("div")`
-  padding: 5px;
-  padding-left: 10px;
-  border-bottom: 0.5px solid gainsboro;
-  display: flex;
-  align-items: baseline;
-  background-color: ${props => props.levelColor};
-
-  div {
-    padding-right: 5px;
-  }
-
-  li div {
-    background-color: ${props => props.levelColor};
-  }
-`;
 
 export class HistoryItemUnconnected extends React.Component {
   static propTypes = {
@@ -75,8 +51,10 @@ export class HistoryItemUnconnected extends React.Component {
         break;
       case "CONSOLE_MESSAGE":
         return (
-          <ConsoleMessage levelColor={this.props.levelColor}>
-            <ConsoleMessageIcon>{this.props.levelIcon}</ConsoleMessageIcon>
+          <ConsoleMessage
+            levelColor={this.props.levelColor}
+            icon={this.props.levelIcon}
+          >
             {this.props.valueToRender.map(v => (
               <ValueRenderer
                 key={`out-${Math.random()}-${v.toString()}`}

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -126,7 +126,6 @@ export function mapStateToProps(state, ownProps) {
       }
     }
   }
-  console.info(levelColor);
   return {
     content: ownProps.historyItem.content,
     cellId: ownProps.historyItem.cellId,

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -16,6 +16,10 @@ const ConsoleMessage = styled("div")`
   padding-left: 10px;
   border-bottom: 0.5px solid gainsboro;
   display: flex;
+  background-color: ${props => props.levelColor};
+  li div {
+    background-color: ${props => props.levelColor};
+  }
 `;
 
 export class HistoryItemUnconnected extends React.Component {
@@ -24,7 +28,8 @@ export class HistoryItemUnconnected extends React.Component {
     cellId: PropTypes.number,
     historyId: PropTypes.number.isRequired,
     historyType: PropTypes.string.isRequired,
-    lastRan: PropTypes.number.isRequired
+    lastRan: PropTypes.number.isRequired,
+    levelColor: PropTypes.string
   };
   constructor(props) {
     super(props);
@@ -53,7 +58,7 @@ export class HistoryItemUnconnected extends React.Component {
         break;
       case "CONSOLE_MESSAGE":
         return (
-          <ConsoleMessage level="log">
+          <ConsoleMessage levelColor={this.props.levelColor}>
             <ValueRenderer render valueToRender={this.props.valueToRender} />
           </ConsoleMessage>
         );
@@ -108,13 +113,28 @@ export class HistoryItemUnconnected extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
+  let levelColor;
+  if (ownProps.historyItem) {
+    const level = ownProps.historyItem.content;
+    if (level !== undefined) {
+      if (level === "log") {
+        levelColor = "white";
+      } else if (level === "warn") {
+        levelColor = "rgb(255,251,214)";
+      } else if (level === "error") {
+        levelColor = "rgb(253, 242, 245)";
+      }
+    }
+  }
+  console.info(levelColor);
   return {
     content: ownProps.historyItem.content,
     cellId: ownProps.historyItem.cellId,
     historyId: ownProps.historyItem.historyId,
     historyType: ownProps.historyItem.historyType,
     lastRan: ownProps.historyItem.lastRan,
-    valueToRender: EVALUATION_RESULTS[ownProps.historyItem.historyId]
+    valueToRender: EVALUATION_RESULTS[ownProps.historyItem.historyId],
+    levelColor
   };
 }
 

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -15,6 +15,7 @@ const ConsoleMessage = styled("div")`
   padding: 5px;
   padding-left: 10px;
   border-bottom: 0.5px solid gainsboro;
+  display: flex;
 `;
 
 export class HistoryItemUnconnected extends React.Component {

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -16,7 +16,14 @@ const ConsoleMessage = styled("div")`
   padding-left: 10px;
   border-bottom: 0.5px solid gainsboro;
   display: flex;
+  align-items: baseline;
   background-color: ${props => props.levelColor};
+
+  div {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+
   li div {
     background-color: ${props => props.levelColor};
   }
@@ -59,7 +66,14 @@ export class HistoryItemUnconnected extends React.Component {
       case "CONSOLE_MESSAGE":
         return (
           <ConsoleMessage levelColor={this.props.levelColor}>
-            <ValueRenderer render valueToRender={this.props.valueToRender} />
+            {/* {this.props.valueToRender} <ValueRenderer render valueToRender={this.props.valueToRender} /> */}
+            {this.props.valueToRender.map(v => (
+              <ValueRenderer
+                key={`out-${Math.random()}-${v.toString()}`}
+                render
+                valueToRender={v}
+              />
+            ))}
           </ConsoleMessage>
         );
       case "CONSOLE_EVAL":

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
+import styled from "react-emotion";
 
 import ArrowBack from "@material-ui/icons/ArrowBack";
 import { ValueRenderer } from "../../../components/reps/value-renderer";
@@ -9,6 +10,12 @@ import PreformattedTextItemsHandler from "../../../components/reps/preformatted-
 import PaneContentButton from "./pane-content-button";
 import { postMessageToEditor } from "../../port-to-editor";
 import { EVALUATION_RESULTS } from "../../actions/actions";
+
+const ConsoleMessage = styled("div")`
+  padding: 5px;
+  padding-left: 10px;
+  border-bottom: 0.5px solid gainsboro;
+`;
 
 export class HistoryItemUnconnected extends React.Component {
   static propTypes = {
@@ -43,6 +50,12 @@ export class HistoryItemUnconnected extends React.Component {
       case "CELL_EVAL_INFO":
         output = this.props.valueToRender;
         break;
+      case "CONSOLE_MESSAGE":
+        return (
+          <ConsoleMessage level="log">
+            <ValueRenderer render valueToRender={this.props.valueToRender} />
+          </ConsoleMessage>
+        );
       case "CONSOLE_EVAL":
         output = (
           <ValueRenderer render valueToRender={this.props.valueToRender} />

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -28,7 +28,8 @@ export const historySchema = {
         "SAVED_REP",
         "CONSOLE_EVAL",
         "SNIPPET_EVAL",
-        "FETCH_CELL_INFO"
+        "FETCH_CELL_INFO",
+        "CONSOLE_MESSAGE"
       ]
     },
     lastRan: { type: "integer" },


### PR DESCRIPTION
(@bcolloran @wlach would love your general thoughts on this approach as well, @mdboom had a look)

This PR is a basic console interception POC, which intercepts a few `console` functions and updates the iodide console before also going the regular route through the browser's dev tools. As I've mentioned before, this is somewhat blocked by #1107, which is itself the logical conclusion of moving away from cells, but not strictly speaking.

This functionality will also allow iodide-ready language stacks like Pyodide and Julide to use their native print functionality within the iodide context a bit more fluently.

A few takeaways:

- this only intercepts `info`, `log`, `warn`, and `error`. We could add others but I think these are the most important ones.
- by decoupling the outputs from the input (I do this by side-stepping most of the cruft in the `HistoryItem` component), `setInterval` and other async message dispatches fire similarly to how they would on the devtools console.
- right now, the default render for what is passed into `console` is just an array of args sent to `ValueRenderer`. We should make it match what happens on the devtools console.
- any extraneous `console` calls within iodide or other libraries will be visible in the console. This will especially be the case w/ pyodide. On that front, I think pyodide should probably default to `console.debug` for those types of messages. Alternatively, we could default send to the console _all_ of the pyodide status messages this way.

<img width="1142" alt="screen shot 2019-01-22 at 8 40 04 pm" src="https://user-images.githubusercontent.com/95735/51583541-f0be5580-1e85-11e9-98c9-95f7f544986f.png">
