### PR TITLE
Upgrade pyodide to 0.7.0.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ let { EVAL_FRAME_ORIGIN } = process.env;
 const { USE_OPENIDC_AUTH } = process.env;
 const { IODIDE_PUBLIC } = process.env || false;
 
-const PYODIDE_VERSION = process.env.PYODIDE_VERSION || "0.5.0";
+const PYODIDE_VERSION = process.env.PYODIDE_VERSION || "0.7.0";
 process.env.PYODIDE_VERSION = PYODIDE_VERSION;
 
 const APP_VERSION_STRING = process.env.APP_VERSION_STRING || "dev";


### PR DESCRIPTION
This has the bugfix for empty code.

Also @madhur-tandon's ABI and styling changes.

It also compiles with a new version of emscripten (slightly smaller and more efficient binaries).