### PR TITLE
Add support for emoji in markdown view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8689,6 +8689,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
       "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
     },
+    "markdown-it-emoji": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
+      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
+    },
     "markdown-it-katex": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lz-string": "1.4.4",
     "markdown-it": "8.4.2",
     "markdown-it-anchor": "5.0.2",
+    "markdown-it-emoji": "1.4.0",
     "markdown-it-katex": "2.0.3",
     "mousetrap": "1.6.2",
     "numeral": "2.0.6",

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -1,6 +1,7 @@
 import MarkdownIt from "markdown-it";
 import MarkdownItKatex from "markdown-it-katex";
 import MarkdownItAnchor from "markdown-it-anchor";
+import MarkdownItEmoji from "markdown-it-emoji";
 
 import { NONCODE_EVAL_TYPES } from "../../state-schemas/state-schema";
 
@@ -15,9 +16,11 @@ import { evaluateFetchText } from "./fetch-cell-eval-actions";
 import { postMessageToEditor } from "../port-to-editor";
 
 const MD = MarkdownIt({ html: true });
-MD.use(MarkdownItKatex).use(MarkdownItAnchor);
+MD.use(MarkdownItKatex)
+  .use(MarkdownItAnchor)
+  .use(MarkdownItEmoji);
 
-const CodeMirror = require('codemirror') // eslint-disable-line
+const CodeMirror = require("codemirror"); // eslint-disable-line
 
 const initialVariables = new Set(Object.keys(window)); // gives all global variables
 initialVariables.add("__core-js_shared__");

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -1,8 +1,3 @@
-import MarkdownIt from "markdown-it";
-import MarkdownItKatex from "markdown-it-katex";
-import MarkdownItAnchor from "markdown-it-anchor";
-import MarkdownItEmoji from "markdown-it-emoji";
-
 import { NONCODE_EVAL_TYPES } from "../../state-schemas/state-schema";
 
 import {
@@ -14,11 +9,6 @@ import {
 
 import { evaluateFetchText } from "./fetch-cell-eval-actions";
 import { postMessageToEditor } from "../port-to-editor";
-
-const MD = MarkdownIt({ html: true });
-MD.use(MarkdownItKatex)
-  .use(MarkdownItAnchor)
-  .use(MarkdownItEmoji);
 
 const CodeMirror = require("codemirror"); // eslint-disable-line
 

--- a/src/eval-frame/components/panes/report-pane.js
+++ b/src/eval-frame/components/panes/report-pane.js
@@ -5,9 +5,13 @@ import { connect } from "react-redux";
 import MarkdownIt from "markdown-it";
 import MarkdownItKatex from "markdown-it-katex";
 import MarkdownItAnchor from "markdown-it-anchor";
+import MarkdownItEmoji from "markdown-it-emoji";
 
 const mdIt = MarkdownIt({ html: true });
-mdIt.use(MarkdownItKatex).use(MarkdownItAnchor);
+mdIt
+  .use(MarkdownItKatex)
+  .use(MarkdownItAnchor)
+  .use(MarkdownItEmoji);
 
 const mdDiv = html => (
   <div


### PR DESCRIPTION
To capture the support of the elusive millenial/slack demographic,
we clearly need emoji support in markdown view to keep things :100:.