### PR TITLE
Use pointer cursor type when hovering over menus

### DIFF
--- a/src/shared/components/menu-item.jsx
+++ b/src/shared/components/menu-item.jsx
@@ -15,6 +15,7 @@ const MenuItemContainer = styled("li")`
 
   :hover {
     background-color: ${MAIN_GRAY};
+    cursor: pointer;
   }
 `;
 


### PR DESCRIPTION
Right now it alternated between the caret (when hovering over the text)
and the default cursor, both of which looked subtly wrong.