### PR TITLE
sets default font family to be the one shared in THEME.mainFontFamily

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,7 +13,7 @@ import "golden-layout/src/css/goldenlayout-light-theme.css";
 
 // iodide styles
 import "./shared/style/base";
-import "./style/top-level-container-styles.css";
+import "./style/top-level-container-styles";
 import "./style/side-panes.css";
 import "./style/menu-and-button-and-ui-styles.css";
 import "./style/codemirror-styles.css";

--- a/src/server/style/base.jsx
+++ b/src/server/style/base.jsx
@@ -1,4 +1,5 @@
 import { css, injectGlobal } from "emotion";
+import THEME from "../../shared/theme";
 
 /*
 This is a baseline css reset, mostly based off
@@ -20,8 +21,7 @@ export const sharedProperties = {
 
 const baseCSS = css`
   body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-      sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family: ${THEME.mainFontFamily};
   }
 `;
 

--- a/src/shared/theme.js
+++ b/src/shared/theme.js
@@ -1,5 +1,7 @@
 const THEME = {};
 
+THEME.mainFontFamily = `-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";`;
+
 THEME.logo = {};
 THEME.logo.darkColor = "#4f3554";
 

--- a/src/style/top-level-container-styles.js
+++ b/src/style/top-level-container-styles.js
@@ -1,5 +1,8 @@
-html, body {
-  font-family: 'Open Sans', sans-serif;
+import { injectGlobal } from "emotion";
+import THEME from "../shared/theme";
+
+export default injectGlobal`html, body {
+  font-family: ${THEME.mainFontFamily};
   height: 100%;
   margin: 0;
   padding: 0;
@@ -33,3 +36,4 @@ iframe#eval-frame {
     height: 100%;
     z-index: 0;
 }
+`;


### PR DESCRIPTION
This resets the default font for the client UX elements (stuff in the notebook header, primarily) to be whatever is set in `THEME.mainFontFamily`, which for now is the system font stack we're using on the server pages.

Address will's comment in #1422, but not the central thrust of that issue.