### PR TITLE
Fix #1453: Rename iodide.io/docs -> docs.iodide.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can also [chat with us on Gitter](https://gitter.im/iodide-project/iodide).
 
 # Learn more about it
 
-Please visit our [documentation](https://iodide.io/docs/).
+Please visit our [documentation](https://docs.iodide.io/).
 
 # Using the notebook
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Iodide Documentation
-site_url: https://iodide.io/docs/
+site_url: https://docs.iodide.io/
 repo_url: https://github.com/iodide-project/iodide/
 theme: mkdocs
 extra_css: [extra.css]

--- a/src/components/modals/help-modal.jsx
+++ b/src/components/modals/help-modal.jsx
@@ -38,7 +38,7 @@ const MoreResources = () => (
   <HelpModalContent>
     <h2>Documentation</h2>
     <p>
-      Visit the <a href="https://iodide.io/docs">Iodide Documentation</a>.
+      Visit the <a href="https://docs.iodide.io/">Iodide Documentation</a>.
     </p>
   </HelpModalContent>
 );

--- a/src/eval-frame/components/panes/onboarding-content.jsx
+++ b/src/eval-frame/components/panes/onboarding-content.jsx
@@ -114,10 +114,10 @@ export default class OnboardingContent extends React.Component {
           <Element key="docs">
             <ElementTitle>Check the Docs</ElementTitle>
             <ElementBody>
-              <ElementBlockLink href="https://iodide.io/docs/jsmd/">
+              <ElementBlockLink href="https://docs.iodide.io/jsmd/">
                 JSMD format
               </ElementBlockLink>
-              <ElementBlockLink href="https://iodide.io/docs/api/">
+              <ElementBlockLink href="https://docs.iodide.io/api/">
                 Iodide API
               </ElementBlockLink>
               <ElementBlockLink href="https://github.com/iodide-project/pyodide/tree/master/docs">

--- a/src/server/components/docs-button.jsx
+++ b/src/server/components/docs-button.jsx
@@ -2,5 +2,5 @@ import React from "react";
 import { OutlineButton } from "../../shared/components/buttons";
 
 export default () => (
-  <OutlineButton href="https://iodide.io/docs/">Docs</OutlineButton>
+  <OutlineButton href="https://docs.iodide.io/">Docs</OutlineButton>
 );

--- a/src/shared/user-menu.jsx
+++ b/src/shared/user-menu.jsx
@@ -47,7 +47,7 @@ export default class UserMenu extends React.Component {
   }
 
   goToDocs() {
-    window.open("https://iodide.io/docs");
+    window.open("https://docs.iodide.io/");
     this.handleMenuClose();
   }
 


### PR DESCRIPTION
The domain is already updated on Google Domains.  This just fixes the links to the docs from within Iodide.