### PR TITLE
Set Python indent to 4 in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
Most, if not all, Python source files already use an indent of 4. Will
confirms that this is the intended indent size for Python files.