### PR TITLE
separate out must-have onload css from theme setting in client

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,12 +13,15 @@ import "golden-layout/src/css/goldenlayout-light-theme.css";
 
 // iodide styles
 import "./shared/style/base";
-import "./style/top-level-container-styles";
+import "./style/top-level-container-styles.css";
 import "./style/side-panes.css";
 import "./style/menu-and-button-and-ui-styles.css";
 import "./style/codemirror-styles.css";
 import "./style/help-modal-styles.css";
 import "./style/golden-layout-style-overrides.css";
+
+// theme settings
+import "./style/client-style-defaults";
 
 import NotebookHeader from "./components/menu/notebook-header";
 import EditorPaneContainer from "./components/editor-pane-container";

--- a/src/style/client-style-defaults.js
+++ b/src/style/client-style-defaults.js
@@ -1,0 +1,8 @@
+import { injectGlobal } from "emotion";
+import THEME from "../shared/theme";
+
+export default injectGlobal`
+html, body {
+    font-family: ${THEME.mainFontFamily};
+}
+`;

--- a/src/style/top-level-container-styles.css
+++ b/src/style/top-level-container-styles.css
@@ -1,8 +1,5 @@
-import { injectGlobal } from "emotion";
-import THEME from "../shared/theme";
-
-export default injectGlobal`html, body {
-  font-family: ${THEME.mainFontFamily};
+html, body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   height: 100%;
   margin: 0;
   padding: 0;
@@ -36,4 +33,3 @@ iframe#eval-frame {
     height: 100%;
     z-index: 0;
 }
-`;


### PR DESCRIPTION
parsed out some top level must-have styles before the JS is loaded and kept the non-vital theme elements in injectSGlobal.