### PR TITLE
get rid of the history id generation in favor of random string, generic createHistoryItem function + tests

### DIFF
--- a/src/actions/__tests__/eval-frame-action-validator.test.js
+++ b/src/actions/__tests__/eval-frame-action-validator.test.js
@@ -28,7 +28,7 @@ describe("validateActionFromEvalFrame should throw errors as expected", () => {
     expect(() =>
       validateActionFromEvalFrame({
         type: "UPDATE_VALUE_IN_HISTORY",
-        historyId: "this should be an int"
+        historyId: 12424242
       })
     ).toThrowError(ActionSchemaValidationError);
   });
@@ -55,7 +55,7 @@ describe("validateActionFromEvalFrame should return true it action is valid", ()
     expect(
       validateActionFromEvalFrame({
         type: "UPDATE_VALUE_IN_HISTORY",
-        historyId: 42
+        historyId: "a92nf9snf9s"
       })
     ).toEqual(true);
   });

--- a/src/actions/eval-frame-action-validator.js
+++ b/src/actions/eval-frame-action-validator.js
@@ -80,7 +80,7 @@ const schemas = {
     additionalProperties: false,
     properties: {
       type: { type: "string" },
-      historyId: { type: "integer" }
+      historyId: { type: "string" }
     },
     required: ["type", "historyId"]
   }

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -11,6 +11,8 @@ import {
 import { evaluateFetchText } from "./fetch-cell-eval-actions";
 import messagePasser from "../../redux-to-port-message-passer";
 
+import createHistoryItem from "../../tools/create-history-item";
+
 const CodeMirror = require("codemirror"); // eslint-disable-line
 
 const initialVariables = new Set(Object.keys(window)); // gives all global variables
@@ -57,23 +59,23 @@ export function appendToEvalHistory(
   value,
   historyOptions = {}
 ) {
-  const { historyId } = historyOptions;
   const historyType =
     historyOptions.historyType === undefined
       ? "CELL_EVAL_VALUE"
       : historyOptions.historyType;
 
-  EVALUATION_RESULTS[historyId] = value;
-
-  // returned obj must match history schema
-  return {
-    type: "APPEND_TO_EVAL_HISTORY",
-    cellId,
+  const historyAction = createHistoryItem({
     content,
-    historyId,
+    value,
     historyType,
-    lastRan: Date.now()
-  };
+    historyId: historyOptions.historyId,
+    lastRan: historyOptions.lastRan
+  });
+  historyAction.type = "APPEND_TO_EVAL_HISTORY";
+
+  EVALUATION_RESULTS[historyAction.historyId] = value;
+
+  return historyAction;
 }
 
 export function updateValueInHistory(historyId, value) {

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -131,7 +131,6 @@ export function evalConsoleInput(consoleText) {
 function evaluateCode(code, language, state, evalId) {
   return dispatch => {
     const historyId = generateRandomId();
-    console.log("evaluateCode", historyId);
     const updateCellAfterEvaluation = (output, evalStatus) => {
       const cellProperties = { rendered: true };
       if (evalStatus === "ERROR") {
@@ -146,7 +145,6 @@ function evaluateCode(code, language, state, evalId) {
 
     const messageCallback = msg => {
       const messageHistoryId = generateRandomId();
-      console.log("messageCallback", messageHistoryId);
       dispatch(
         appendToEvalHistory(null, msg, undefined, {
           historyType: "CELL_EVAL_INFO",

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -1,6 +1,6 @@
 import { NONCODE_EVAL_TYPES } from "../../state-schemas/state-schema";
 
-import generateNextIdFromHistory from "../../tools/generate-next-id-from-history";
+import generateRandomId from "../../tools/generate-random-id";
 
 import {
   evaluateLanguagePlugin,
@@ -129,9 +129,9 @@ export function evalConsoleInput(consoleText) {
 }
 
 function evaluateCode(code, language, state, evalId) {
-  return (dispatch, getState) => {
-    const historyId = generateNextIdFromHistory(getState().history);
-
+  return dispatch => {
+    const historyId = generateRandomId();
+    console.log("evaluateCode", historyId);
     const updateCellAfterEvaluation = (output, evalStatus) => {
       const cellProperties = { rendered: true };
       if (evalStatus === "ERROR") {
@@ -145,10 +145,12 @@ function evaluateCode(code, language, state, evalId) {
     };
 
     const messageCallback = msg => {
+      const messageHistoryId = generateRandomId();
+      console.log("messageCallback", messageHistoryId);
       dispatch(
         appendToEvalHistory(null, msg, undefined, {
           historyType: "CELL_EVAL_INFO",
-          historyId
+          historyId: messageHistoryId
         })
       );
     };
@@ -179,7 +181,7 @@ export function evaluateText(
     // if (!evalText || !evalType) { return undefined }
     // FIXME: we need to deprecate side effects ASAP. They don't serve a purpose
     // in the direct jsmd editing paradigm.
-    const historyId = generateNextIdFromHistory(getState().history);
+    const historyId = generateRandomId();
 
     MOST_RECENT_CHUNK_ID.set(chunkId);
     const sideEffect = document.getElementById(

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -66,7 +66,6 @@ export function appendToEvalHistory(
 
   const historyAction = createHistoryItem({
     content,
-    value,
     historyType,
     historyId: historyOptions.historyId,
     lastRan: historyOptions.lastRan

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -14,7 +14,7 @@ import {
 } from "../../tools/fetch-tools";
 
 import fetchFileFromParentContext from "../tools/fetch-file-from-parent-context";
-import generateNextIdFromHistory from "../../tools/generate-next-id-from-history";
+import generateRandomId from "../../tools/generate-random-id";
 
 export function fetchProgressInitialStrings(fetchInfo) {
   let text;
@@ -99,8 +99,8 @@ export async function handleFetch(fetchInfo) {
 }
 
 export function evaluateFetchText(fetchText, evalId) {
-  return (dispatch, getState) => {
-    const historyId = generateNextIdFromHistory(getState().history);
+  return dispatch => {
+    const historyId = generateRandomId();
     const fetches = parseFetchCell(fetchText);
     const syntaxErrors = fetches.filter(fetchInfo => fetchInfo.parsed.error);
     if (syntaxErrors.length) {

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -2,7 +2,6 @@ import parseFetchCell from "./fetch-cell-parser";
 import {
   appendToEvalHistory,
   updateValueInHistory,
-  historyIdGen,
   updateUserVariables,
   sendStatusResponseToEditor
 } from "./actions";
@@ -15,6 +14,7 @@ import {
 } from "../../tools/fetch-tools";
 
 import fetchFileFromParentContext from "../tools/fetch-file-from-parent-context";
+import generateNextIdFromHistory from "../../tools/generate-next-id-from-history";
 
 export function fetchProgressInitialStrings(fetchInfo) {
   let text;
@@ -99,8 +99,8 @@ export async function handleFetch(fetchInfo) {
 }
 
 export function evaluateFetchText(fetchText, evalId) {
-  return dispatch => {
-    const historyId = historyIdGen.nextId();
+  return (dispatch, getState) => {
+    const historyId = generateNextIdFromHistory(getState().history);
     const fetches = parseFetchCell(fetchText);
     const syntaxErrors = fetches.filter(fetchInfo => fetchInfo.parsed.error);
     if (syntaxErrors.length) {

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -72,9 +72,8 @@ function loadLanguagePlugin(pluginData, historyId, dispatch) {
 }
 
 export function evaluateLanguagePlugin(pluginText, evalId) {
-  return (dispatch, getState) => {
-    const historyId = generateRandomId(getState().history);
-    console.log("evaluateLanguagePlugin", historyId);
+  return dispatch => {
+    const historyId = generateRandomId();
     dispatch(
       appendToEvalHistory(null, pluginText, undefined, {
         historyId,
@@ -110,7 +109,6 @@ export function ensureLanguageAvailable(languageId, state, dispatch) {
     Object.prototype.hasOwnProperty.call(state.languageDefinitions, languageId)
   ) {
     const historyId = generateRandomId();
-    console.log("ensureLanguageAvailable", historyId);
     dispatch(
       appendToEvalHistory(
         null,

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -4,7 +4,7 @@ import {
   updateValueInHistory,
   sendStatusResponseToEditor
 } from "./actions";
-import generateNextIdFromHistory from "../../tools/generate-next-id-from-history";
+import generateRandomId from "../../tools/generate-random-id";
 
 export function addLanguage(languageDefinition) {
   return {
@@ -73,7 +73,8 @@ function loadLanguagePlugin(pluginData, historyId, dispatch) {
 
 export function evaluateLanguagePlugin(pluginText, evalId) {
   return (dispatch, getState) => {
-    const historyId = generateNextIdFromHistory(getState().history);
+    const historyId = generateRandomId(getState().history);
+    console.log("evaluateLanguagePlugin", historyId);
     dispatch(
       appendToEvalHistory(null, pluginText, undefined, {
         historyId,
@@ -108,7 +109,8 @@ export function ensureLanguageAvailable(languageId, state, dispatch) {
   if (
     Object.prototype.hasOwnProperty.call(state.languageDefinitions, languageId)
   ) {
-    const historyId = generateNextIdFromHistory(state.history);
+    const historyId = generateRandomId();
+    console.log("ensureLanguageAvailable", historyId);
     dispatch(
       appendToEvalHistory(
         null,

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -1,10 +1,10 @@
 import { postMessageToEditor } from "../port-to-editor";
 import {
   appendToEvalHistory,
-  historyIdGen,
   updateValueInHistory,
   sendStatusResponseToEditor
 } from "./actions";
+import generateNextIdFromHistory from "../../tools/generate-next-id-from-history";
 
 export function addLanguage(languageDefinition) {
   return {
@@ -72,8 +72,8 @@ function loadLanguagePlugin(pluginData, historyId, dispatch) {
 }
 
 export function evaluateLanguagePlugin(pluginText, evalId) {
-  return dispatch => {
-    const historyId = historyIdGen.nextId();
+  return (dispatch, getState) => {
+    const historyId = generateNextIdFromHistory(getState().history);
     dispatch(
       appendToEvalHistory(null, pluginText, undefined, {
         historyId,
@@ -108,7 +108,7 @@ export function ensureLanguageAvailable(languageId, state, dispatch) {
   if (
     Object.prototype.hasOwnProperty.call(state.languageDefinitions, languageId)
   ) {
-    const historyId = historyIdGen.nextId();
+    const historyId = generateNextIdFromHistory(state.history);
     dispatch(
       appendToEvalHistory(
         null,

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -14,7 +14,7 @@ export class HistoryItemUnconnected extends React.Component {
   static propTypes = {
     content: PropTypes.string.isRequired,
     cellId: PropTypes.number,
-    historyId: PropTypes.number.isRequired,
+    historyId: PropTypes.string.isRequired,
     historyType: PropTypes.string.isRequired,
     lastRan: PropTypes.number.isRequired
   };

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -18,7 +18,7 @@ export const historySchema = {
   properties: {
     cellId: { type: ["integer", "null"] },
     content: { type: "string" },
-    historyId: { type: "integer" },
+    historyId: { type: "string" },
     historyType: {
       type: "string",
       enum: [

--- a/src/tools/__tests__/create-history-item.test.js
+++ b/src/tools/__tests__/create-history-item.test.js
@@ -1,0 +1,34 @@
+import createHistoryItem from "../create-history-item";
+
+describe("createHistoryItem", () => {
+  it("creates a new history item and fills in a random ID if no historyId is provided", () => {
+    const h = createHistoryItem({
+      content: "content",
+      historyType: "CELL_EVAL_VALUE"
+    });
+    expect(typeof h.historyId).toBe("string");
+    expect(typeof h.lastRan).toBe("number");
+    expect(Object.keys(h).length).toBe(4);
+  });
+  it("creates a new history item but maintains the passed-in historyId and lastRan", () => {
+    const historyId = "a9vndos8";
+    const lastRan = +new Date();
+    const h = createHistoryItem({
+      content: "content",
+      historyType: "CELL_EVAL_VALUE",
+      historyId,
+      lastRan
+    });
+    expect(h.historyId).toBe(historyId);
+    expect(h.lastRan).toEqual(lastRan);
+    expect(Object.keys(h).length).toBe(4);
+  });
+  it("throws an error if no historyType was provided", () => {
+    expect(() => createHistoryItem({ content: "content" })).toThrowError();
+  });
+  it("throws an error if an invalid historyType was provided", () => {
+    expect(() =>
+      createHistoryItem({ content: "content", historyType: "ABCDEFGHIJK" })
+    ).toThrowError();
+  });
+});

--- a/src/tools/__tests__/create-history-item.test.js
+++ b/src/tools/__tests__/create-history-item.test.js
@@ -23,12 +23,4 @@ describe("createHistoryItem", () => {
     expect(h.lastRan).toEqual(lastRan);
     expect(Object.keys(h).length).toBe(4);
   });
-  it("throws an error if no historyType was provided", () => {
-    expect(() => createHistoryItem({ content: "content" })).toThrowError();
-  });
-  it("throws an error if an invalid historyType was provided", () => {
-    expect(() =>
-      createHistoryItem({ content: "content", historyType: "ABCDEFGHIJK" })
-    ).toThrowError();
-  });
 });

--- a/src/tools/create-history-item.js
+++ b/src/tools/create-history-item.js
@@ -1,0 +1,20 @@
+import generateRandomId from "./generate-random-id";
+import { historySchema } from "../state-schemas/state-schema";
+
+const properties = new Set(Object.keys(historySchema.properties));
+const historyTypes = new Set(historySchema.properties.historyType.enum);
+
+export default function createHistoryItem(args) {
+  Object.keys(args).forEach(k => {
+    if (!properties.has(k))
+      throw Error(`history property ${k} not in history Schema`);
+  });
+  if (!args.historyType)
+    throw new Error("no historyType provided for history item");
+  if (!historyTypes.has(args.historyType))
+    throw new Error(`history type ${args.historyType} not in schema`);
+  const newArgs = Object.assign({}, args);
+  newArgs.historyId = newArgs.historyId || generateRandomId();
+  newArgs.lastRan = newArgs.lastRan || +new Date();
+  return newArgs;
+}

--- a/src/tools/create-history-item.js
+++ b/src/tools/create-history-item.js
@@ -1,18 +1,6 @@
 import generateRandomId from "./generate-random-id";
-import { historySchema } from "../state-schemas/state-schema";
-
-const properties = new Set(Object.keys(historySchema.properties));
-const historyTypes = new Set(historySchema.properties.historyType.enum);
 
 export default function createHistoryItem(args) {
-  Object.keys(args).forEach(k => {
-    if (!properties.has(k))
-      throw Error(`history property ${k} not in history Schema`);
-  });
-  if (!args.historyType)
-    throw new Error("no historyType provided for history item");
-  if (!historyTypes.has(args.historyType))
-    throw new Error(`history type ${args.historyType} not in schema`);
   const newArgs = Object.assign({}, args);
   newArgs.historyId = newArgs.historyId || generateRandomId();
   newArgs.lastRan = newArgs.lastRan || +new Date();

--- a/src/tools/generate-next-id-from-history.js
+++ b/src/tools/generate-next-id-from-history.js
@@ -1,4 +1,0 @@
-export default function generateNextIdFromHistory(history) {
-  if (!history.length) return 0;
-  return Math.max(...history.map(h => h.historyId)) + 1;
-}

--- a/src/tools/generate-next-id-from-history.js
+++ b/src/tools/generate-next-id-from-history.js
@@ -1,0 +1,4 @@
+export default function generateNextIdFromHistory(history) {
+  if (!history.length) return 0;
+  return Math.max(...history.map(h => h.historyId)) + 1;
+}

--- a/src/tools/generate-random-id.js
+++ b/src/tools/generate-random-id.js
@@ -1,0 +1,6 @@
+export default function generateRandomId() {
+  // gist.github.com/6174/6062387
+  return [...Array(10)]
+    .map(i => (~~(Math.random() * 36)).toString(36)) // eslint-disable-line
+    .join("");
+}


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: no new documentation.
- [x] **Changelog**: no user-facing changes.
- [x] **Tests**: this PR updates the tests around history Id creation to reflect that they must be strings now, not integers, and provides new tests around `createHistoryItem`

This removes the history id generation as it was before, and replaces with random strings. This allows us to decouple some stateful stuff that makes it hard (at the moment) to have the editor properly update the history items and have it reflected in the console.

This also creates a function, `createHistoryItem`, which standardizes the creation of new history items for the store. At the moment this is used in the eval frame actions in `appendToEvalHistory` but will be used on the editor side as well once app messages go to the console. Eventually we will remove the history item creation from the eval frame entirely, but this work will help us bridge into that. 