### PR TITLE
Fix #1493: Don't crash when the reps error out

### DIFF
--- a/src/components/reps/default-handler.jsx
+++ b/src/components/reps/default-handler.jsx
@@ -8,19 +8,7 @@ export default class DefaultRenderer extends React.Component {
     value: PropTypes.any
   };
 
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  componentDidCatch() {
-    this.setState({ hasError: true });
-  }
-
   render() {
-    if (this.state.hasError) {
-      return <pre>{String(this.props.value)}</pre>;
-    }
     return <Inspector data={this.props.value} shouldShowPlaceholder={false} />;
   }
 }

--- a/src/components/reps/default-handler.jsx
+++ b/src/components/reps/default-handler.jsx
@@ -8,7 +8,19 @@ export default class DefaultRenderer extends React.Component {
     value: PropTypes.any
   };
 
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch() {
+    this.setState({ hasError: true });
+  }
+
   render() {
+    if (this.state.hasError) {
+      return <pre>{String(this.props.value)}</pre>;
+    }
     return <Inspector data={this.props.value} shouldShowPlaceholder={false} />;
   }
 }

--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -11,7 +11,32 @@ export default class ValueRenderer extends React.Component {
     valueToRender: PropTypes.any
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error, errorInfo });
+  }
+
   render() {
+    if (this.state.errorInfo) {
+      return (
+        <div>
+          <h2>A value renderer encountered an error.</h2>
+          <pre>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo.componentStack}
+          </pre>
+          <a href="https://github.com/iodide-project/iodide/issues/new">
+            Please file a bug report.
+          </a>
+        </div>
+      );
+    }
+
     const value = this.props.valueToRender;
     const htmlString = UserReps.getUserRepIfAvailable(value);
     if (htmlString) {

--- a/src/components/reps/value-renderer.jsx
+++ b/src/components/reps/value-renderer.jsx
@@ -21,9 +21,12 @@ export default class ValueRenderer extends React.Component {
   }
 
   render() {
+    const value = this.props.valueToRender;
+
     if (this.state.errorInfo) {
       return (
         <div>
+          <pre>{value.toString()}</pre>
           <h2>A value renderer encountered an error.</h2>
           <pre>
             {this.state.error && this.state.error.toString()}
@@ -37,7 +40,6 @@ export default class ValueRenderer extends React.Component {
       );
     }
 
-    const value = this.props.valueToRender;
     const htmlString = UserReps.getUserRepIfAvailable(value);
     if (htmlString) {
       return <HTMLHandler htmlString={htmlString} />;


### PR DESCRIPTION
There's sort of a weird way one handles exceptions in React components, but this seems to work.

It falls back on `String(obj)` if React inspector crashes while trying to represent something.

@hamilton: Maybe this needs some styling to indicate it's a fallback rep?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
