### PR TITLE
fixes the console error that happens on page load

### DIFF
--- a/src/actions/eval-frame-action-validator.js
+++ b/src/actions/eval-frame-action-validator.js
@@ -122,11 +122,15 @@ export default function validateActionFromEvalFrame(action) {
       "Invalid action from eval frame: No action type"
     );
   } else if (!Object.keys(schemas).includes(action.type)) {
-    throw new ActionSchemaValidationError(
-      `Invalid action from eval frame: action type not permitted: ${
-        action.type
-      }`
-    );
+    if (action.type.startsWith("@@redux/INIT")) {
+      console.info("Redux initiated: ", action.type);
+    } else {
+      throw new ActionSchemaValidationError(
+        `Invalid action from eval frame: action type not permitted: ${
+          action.type
+        }`
+      );
+    }
   } else if (!validator(action.type)(action)) {
     throw new ActionSchemaValidationError(`Invalid action from eval frame: bad schema.
 schema error:


### PR DESCRIPTION
Fixes #1411. Redux fires an event of type `@@redux/INIT<strings>`, and our eval frame action validator treats that as an error. So this PR intercepts the error and output a console info instead, which should be a little less alarming to newcomers to iodide development.