### PR TITLE
Add Dockerfile ARG for controlling Python deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,11 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - restore_cache:
-          key: v1-{{.Branch}}
+      # We are not using the cached docker file here b/c we want the production
+      # build to use only the required Python files.
       - run:
-          name: Restore Docker image cache
-          command: docker load -i /tmp/docker.tar
+          name: Build Docker image
+          command: docker build -t app:build --build-arg PIP_FILE=build.txt .
       - run:
           name: Push image to Docker Hub
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.7.2-alpine
 
+# Default to building for local development.
+# Override with `--build-arg PIP_FILE=build.txt` to build for production.
+ARG PIP_FILE=all.txt
+
 EXPOSE 8000
 
 WORKDIR /app
@@ -23,7 +27,7 @@ COPY requirements/*.txt /tmp/requirements/
 # Switch to /tmp to install dependencies outside home dir
 WORKDIR /tmp
 # TODO: Consider a way to install only the "build.txt" deps for production.
-RUN pip install --require-hashes --no-cache-dir -r requirements/all.txt
+RUN pip install --require-hashes --no-cache-dir -r requirements/$PIP_FILE
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
TODO:

- [x] Update the CircleCI config to build the production docker for deployment but the testing build for running the tests.

The above may remove any benefits to caching of the docker artifacts.