### PR TITLE
Add proper page titles to all server-returned pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - redesign / refactor of console entries
 - fix bug where user would be prompted to save a notebook they already own after logging in
 - add link to github from user pages
+- add document-level titles to all pages returned by the iodide server
 
 # 0.1.0 (2019-02-21)
 

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -50,6 +50,7 @@ def notebook_view(request, pk):
     else:
         notebook_info['forked_from'] = False
     return render(request, 'notebook.html', {
+        'title': revision.title,
         'user_info': _get_user_info_json(request.user),
         'notebook_info': notebook_info,
         'jsmd': revision.content,
@@ -89,6 +90,7 @@ def notebook_revisions(request, pk):
         'date': revision.created.isoformat()}
         for revision in NotebookRevision.objects.filter(notebook_id=pk)])
     return render(request, '../templates/index.html', {
+            'title': f'Revisions - {nb.title}',
             'page_data': {
                 'userInfo': get_user_info_dict(request.user),
                 'ownerInfo': owner_info,

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -64,7 +64,7 @@ def notebook_revisions(request, pk):
     owner = get_object_or_404(User, pk=nb.owner_id)
     owner_info = {
         'username': owner.username,
-        'full_name': '{} {}'.format(owner.first_name, owner.last_name),
+        'full_name': owner.get_full_name(),
         'avatar': owner.avatar,
         'title': nb.title,
         'notebookId': nb.id,

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -3,6 +3,7 @@
 <html lang="en">
   <head>
     {% block head %}{% endblock %}
+    <title>{{ title }}</title>
   </head>
   <body>
     {% block content %}{% endblock %}

--- a/server/tests/helpers/helpers.py
+++ b/server/tests/helpers/helpers.py
@@ -19,3 +19,11 @@ def get_script_block(page_content, id, mimetype='application/json'):
         return json.loads(m.group(1))
     raise Exception('Script block with id `%s` and mimetype %s not found', id,
                     mimetype)
+
+
+# get the specified title of the page
+def get_title_block(page_content):
+    m = re.search(r'<title>(.*)</title>', str(page_content))
+    if m:
+        return m.group(1)
+    raise Exception("Expected to find title element but didn't!")

--- a/server/tests/test_server_pages.py
+++ b/server/tests/test_server_pages.py
@@ -1,7 +1,8 @@
 import pytest
 from django.urls import reverse
 
-from helpers import get_script_block
+from helpers import (get_script_block,
+                     get_title_block)
 from server.base.models import User
 from server.notebooks.models import (Notebook,
                                      NotebookRevision)
@@ -22,6 +23,7 @@ def test_index_view(client, two_test_notebooks, fake_user, logged_in):
         assert fake_user.avatar is None
 
     # assert that the pageData element has the expected structure
+    assert get_title_block(resp.content) == 'Iodide'
     assert get_script_block(resp.content, 'pageData') == {
         'notebookList': [
             {
@@ -62,6 +64,7 @@ def test_user_view_with_different_names(transactional_db, client, username):
                                                content="*fake notebook content*")
     resp = client.get(reverse('user', kwargs={'name': test_user.username}))
     assert resp.status_code == 200
+    assert get_title_block(resp.content) == f'{test_user.username} ({test_user.get_full_name()})'
     assert get_script_block(resp.content, 'pageData') == {
         'notebookList': [
             {

--- a/server/views.py
+++ b/server/views.py
@@ -33,6 +33,7 @@ def index(request):
             for (nb_id, title, latest_revision) in get_formatted_notebooks(request.user)]
     return render(
         request, 'index.html', {
+            'title': 'Iodide',
             'page_data': {
                 'userInfo': user_info,
                 # this is horrible and will not scale
@@ -76,6 +77,7 @@ def user(request, name=None):
 
     notebooks = get_formatted_notebooks(user)
     return render(request, 'index.html', {
+        'title': f"{this_user['name']} ({this_user['full_name']})",
         'page_data': {
             'userInfo': user_info,
             'thisUser': this_user,


### PR DESCRIPTION
This makes pages appear much cleaner in the URL bar (we
already had client-side code to set the title for the notebook
view, but it would only be activated after the page had
fully loaded and its javascript code was interpreted/run)
