### PR TITLE
fix hard-coded links to point to newer versions of pyodide tour nb, changed link in iodide starter -> iodide.io/tryit

### DIFF
--- a/src/eval-frame/components/panes/onboarding-content.jsx
+++ b/src/eval-frame/components/panes/onboarding-content.jsx
@@ -92,7 +92,7 @@ export default class OnboardingContent extends React.Component {
           <Element key="examples">
             <ElementTitle>Start with a Template</ElementTitle>
             <ElementBody>
-              <ElementBlockLink href="/new">
+              <ElementBlockLink href="https://extremely-alpha.iodide.io/tryit">
                 Javascript starter
               </ElementBlockLink>
               <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/222/">
@@ -106,7 +106,7 @@ export default class OnboardingContent extends React.Component {
               <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/154/">
                 A Tour Through Iodide
               </ElementBlockLink>
-              <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/151/">
+              <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/300/">
                 Getting Started with Python
               </ElementBlockLink>
             </ElementBody>

--- a/src/shared/components/featured-notebooks.jsx
+++ b/src/shared/components/featured-notebooks.jsx
@@ -24,7 +24,7 @@ export default ({ width }) => (
       description="
                 A tutorial demonstrating how
                 to use Python, Numpy, Pandas, and Matplotlib entirely within your browser."
-      href="https://extremely-alpha.iodide.io/notebooks/151/"
+      href="https://extremely-alpha.iodide.io/notebooks/300/"
       imageSource="https://media.giphy.com/media/65NKOOH1IQrsLx5aZb/giphy.gif"
     />
     <NotebookDisplayItem


### PR DESCRIPTION
javascript starter now goes through https://iodide.io/tryit, python t…our is now NB 300, updated 'getting started with python' link to point to NB 300
