### PR TITLE
Enable renovatebot's Python support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":prNotPending"
   ],
   "pip_requirements": {
+    "enabled": true,
     "fileMatch": ["requirements/.*\\.txt"]
   }
 }


### PR DESCRIPTION
I think this is also needed to enable the Python support.