### PR TITLE
implements a basic autosave feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # (Unreleased; add upcoming change notes here)
-# 0.4.0
 - iodide notebooks now automatically save to the server
 - removed `ctrl+s` as a keybinding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # (Unreleased; add upcoming change notes here)
+# 0.4.0
+- iodide notebooks now automatically save to the server
+- removed `ctrl+s` as a keybinding
 
 # 0.3.0 (2019-03-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # (Unreleased; add upcoming change notes here)
 - iodide notebooks now automatically save to the server
-- removed `ctrl+s` as a keybinding
 
 # 0.3.0 (2019-03-06)
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -332,7 +332,7 @@ export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
   };
 }
 
-export function saveNotebookToServer() {
+export function saveNotebookToServer(appMsg = true) {
   return (dispatch, getState) => {
     const state = getState();
     const notebookId = getNotebookID(state);
@@ -347,12 +347,14 @@ export function saveNotebookToServer() {
         .then(() => {
           const message = "Updated Notebook";
           updateAutosave(state, true);
-          dispatch(
-            updateAppMessages({
-              message,
-              messageType: "NOTEBOOK_SAVED"
-            })
-          );
+          if (appMsg) {
+            dispatch(
+              updateAppMessages({
+                message,
+                messageType: "NOTEBOOK_SAVED"
+              })
+            );
+          }
           dispatch({ type: "NOTEBOOK_SAVED" });
         })
         .catch(() => {
@@ -529,4 +531,14 @@ export function saveEnvironment(updateObj, update) {
     updateObj,
     update
   };
+}
+
+export function setPreviouslySavedJsmdToCurrentJsmd() {
+  return {
+    type: "SET_PREVIOUSLY_SAVED_JSMD_TO_CURRENT_JSMD"
+  };
+}
+
+export function changeMadeToJsmd(state) {
+  return state.previouslySavedJsmd !== state.jsmd;
 }

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -273,7 +273,12 @@ export function getNotebookSaveRequestOptions(state, options = undefined) {
   return postRequestOptions;
 }
 
-export function saveNotebookRequest(url, postRequestOptions, dispatch) {
+export function saveNotebookRequest(
+  url,
+  postRequestOptions,
+  dispatch,
+  appMsg = true
+) {
   return fetchWithCSRFTokenAndJSONContent(url, postRequestOptions)
     .then(response => {
       if (!response.ok) {
@@ -305,12 +310,14 @@ export function saveNotebookRequest(url, postRequestOptions, dispatch) {
       return response.json();
     })
     .catch(err => {
-      dispatch(
-        updateAppMessages({
-          message: `Error Saving Notebook.`,
-          messageType: "ERROR_SAVING_NOTEBOOK"
-        })
-      );
+      if (appMsg) {
+        dispatch(
+          updateAppMessages({
+            message: `Error Saving Notebook.`,
+            messageType: "ERROR_SAVING_NOTEBOOK"
+          })
+        );
+      }
       throw new Error(err.message);
     });
 }
@@ -354,7 +361,8 @@ export function saveNotebookToServer(appMsg = true) {
       return saveNotebookRequest(
         `/api/v1/notebooks/${notebookId}/revisions/`,
         getNotebookSaveRequestOptions(state),
-        dispatch
+        dispatch,
+        appMsg
       )
         .then(() => {
           const message = "Updated Notebook";
@@ -547,5 +555,12 @@ export function saveEnvironment(updateObj, update) {
 export function setMostRecentSavedContent() {
   return {
     type: "SET_MOST_RECENT_SAVED_CONTENT"
+  };
+}
+
+export function setConnectionStatus(status) {
+  return {
+    type: "SET_CONNECTION_STATUS",
+    status
   };
 }

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -273,7 +273,7 @@ function getNotebookSaveRequestOptions(state, options = undefined) {
   return postRequestOptions;
 }
 
-function saveNotebookRequest(url, postRequestOptions, dispatch) {
+export function saveNotebookRequest(url, postRequestOptions, dispatch) {
   return fetchWithCSRFTokenAndJSONContent(url, postRequestOptions).then(
     response => {
       if (!response.ok) {
@@ -533,12 +533,8 @@ export function saveEnvironment(updateObj, update) {
   };
 }
 
-export function setPreviouslySavedJsmdToCurrentJsmd() {
+export function setMostRecentSavedContent() {
   return {
-    type: "SET_PREVIOUSLY_SAVED_JSMD_TO_CURRENT_JSMD"
+    type: "SET_MOST_RECENT_SAVED_CONTENT"
   };
-}
-
-export function changeMadeToJsmd(state) {
-  return state.previouslySavedJsmd !== state.jsmd;
 }

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -92,14 +92,13 @@ tasks.newNotebook = new ExternalLinkTask({
   url: "/new"
 });
 
+// this overrides the browser default's ctrl+s but otherwise does nothing.
 tasks.saveNotebook = new UserTask({
   title: "Save Notebook",
   keybindings: ["ctrl+s", "meta+s"],
   displayKeybinding: `${commandKey}+s`,
   preventDefaultKeybinding: true,
-  callback() {
-    dispatcher.saveNotebookToServer();
-  }
+  callback() {}
 });
 
 tasks.exportNotebook = new UserTask({

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -28,6 +28,20 @@ describe("HeaderMessages mapStateToProps", () => {
     ownProps = {};
   });
 
+  it("displays local save message", () => {
+    state.hasPreviousAutoSave = true;
+    state.userData.name = "test1";
+    state.notebookInfo.username = "test2";
+    const connectionModes = ["STANDALONE", "SERVER"];
+    connectionModes.forEach(connectionMode => {
+      state.notebookInfo.connectionMode = connectionMode;
+      expect(mapStateToProps(state, ownProps)).toEqual({
+        message: "HAS_PREVIOUS_AUTOSAVE",
+        connectionModeIsServer: connectionMode === "SERVER"
+      });
+    });
+  });
+
   it("displays login message", () => {
     state.userData.name = undefined;
     state.notebookInfo.user_can_save = false;

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -28,18 +28,6 @@ describe("HeaderMessages mapStateToProps", () => {
     ownProps = {};
   });
 
-  it("displays local save message", () => {
-    state.hasPreviousAutoSave = true;
-    const connectionModes = ["STANDALONE", "SERVER"];
-    connectionModes.forEach(connectionMode => {
-      state.notebookInfo.connectionMode = connectionMode;
-      expect(mapStateToProps(state, ownProps)).toEqual({
-        message: "HAS_PREVIOUS_AUTOSAVE",
-        connectionModeIsServer: connectionMode === "SERVER"
-      });
-    });
-  });
-
   it("displays login message", () => {
     state.userData.name = undefined;
     state.notebookInfo.user_can_save = false;

--- a/src/components/menu/editor-toolbar-menu.jsx
+++ b/src/components/menu/editor-toolbar-menu.jsx
@@ -21,9 +21,6 @@ export class EditorToolbarMenuUnconnected extends React.Component {
           <NotebookMenuItem task={tasks.toggleHistoryModal} />
         )}
         <NotebookMenuItem task={tasks.clearVariables} />
-        {this.props.isAuthenticated && (
-          <NotebookMenuItem task={tasks.saveNotebook} />
-        )}
         <NotebookMenuItem task={tasks.toggleHelpModal} />
       </NotebookIconMenu>
     );

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -40,12 +40,9 @@ export class HeaderMessagesUnconnected extends React.Component {
       "NEED_TO_MAKE_COPY",
       "CONNECTION_LOST"
     ]),
-<<<<<<< HEAD
     owner: PropTypes.string,
     loadAutosave: PropTypes.func.isRequired,
     discardAutosave: PropTypes.func.isRequired,
-=======
->>>>>>> local autosave now applies by default
     login: PropTypes.func.isRequired,
     makeCopy: PropTypes.func.isRequired,
     revisionId: PropTypes.number

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -50,8 +50,6 @@ export class HeaderMessagesUnconnected extends React.Component {
     loadAutosave: PropTypes.func.isRequired,
     discardAutosave: PropTypes.func.isRequired,
     login: PropTypes.func.isRequired,
-    loadAutosave: PropTypes.func.isRequired,
-    discardAutosave: PropTypes.func.isRequired,
     makeCopy: PropTypes.func.isRequired,
     revisionId: PropTypes.number
   };

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -70,19 +70,6 @@ export class HeaderMessagesUnconnected extends React.Component {
   render() {
     let content;
     switch (this.props.message) {
-      case "HAS_PREVIOUS_AUTOSAVE":
-        content = (
-          <React.Fragment>
-            {this.props.connectionModeIsServer
-              ? "You have made changes to this notebook that are only saved locally."
-              : "Modifications to notebook detected in browser's local storage."}
-            &nbsp;
-            <a onClick={this.props.loadAutosave}>Restore</a>
-            &nbsp;or&nbsp;
-            <a onClick={this.props.discardAutosave}>discard</a>.
-          </React.Fragment>
-        );
-        break;
       case "STANDALONE_MODE":
         content =
           "You're viewing this notebook in standalone mode. Changes will be cached in your browser's local storage, but will not be otherwise persisted.";

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -37,7 +37,8 @@ export class HeaderMessagesUnconnected extends React.Component {
     message: PropTypes.oneOf([
       "STANDALONE_MODE",
       "NEED_TO_LOGIN",
-      "NEED_TO_MAKE_COPY"
+      "NEED_TO_MAKE_COPY",
+      "CONNECTION_LOST"
     ]),
 <<<<<<< HEAD
     owner: PropTypes.string,
@@ -70,6 +71,10 @@ export class HeaderMessagesUnconnected extends React.Component {
   render() {
     let content;
     switch (this.props.message) {
+      case "CONNECTION_LOST":
+        content =
+          "Connection to the server has been lost. We'll keep trying. In the meantime, your changes will be preserved locally.";
+        break;
       case "STANDALONE_MODE":
         content =
           "You're viewing this notebook in standalone mode. Changes will be cached in your browser's local storage, but will not be otherwise persisted.";
@@ -115,6 +120,8 @@ export function mapStateToProps(state) {
   if (state.viewMode === "EXPLORE_VIEW") {
     if (connectionModeIsStandalone(state)) {
       return { message: "STANDALONE_MODE" };
+    } else if (state.notebookInfo.connectionStatus === "CONNECTION_LOST") {
+      return { message: "CONNECTION_LOST" };
     } else if (
       state.userData.name === undefined &&
       connectionModeIsServer(state)

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -8,12 +8,7 @@ import {
   connectionModeIsServer,
   connectionModeIsStandalone
 } from "../../tools/server-tools";
-import {
-  createNewNotebookOnServer,
-  discardAutosave,
-  loadAutosave,
-  login
-} from "../../actions/actions";
+import { createNewNotebookOnServer, login } from "../../actions/actions";
 
 const HeaderMessageContainer = styled("div")`
   background-color: lightyellow;
@@ -40,14 +35,16 @@ const HeaderMessageContainer = styled("div")`
 export class HeaderMessagesUnconnected extends React.Component {
   static propTypes = {
     message: PropTypes.oneOf([
-      "HAS_PREVIOUS_AUTOSAVE",
       "STANDALONE_MODE",
       "NEED_TO_LOGIN",
       "NEED_TO_MAKE_COPY"
     ]),
+<<<<<<< HEAD
     owner: PropTypes.string,
     loadAutosave: PropTypes.func.isRequired,
     discardAutosave: PropTypes.func.isRequired,
+=======
+>>>>>>> local autosave now applies by default
     login: PropTypes.func.isRequired,
     makeCopy: PropTypes.func.isRequired,
     revisionId: PropTypes.number
@@ -129,12 +126,7 @@ export class HeaderMessagesUnconnected extends React.Component {
 
 export function mapStateToProps(state) {
   if (state.viewMode === "EXPLORE_VIEW") {
-    if (state.hasPreviousAutoSave) {
-      return {
-        message: "HAS_PREVIOUS_AUTOSAVE",
-        connectionModeIsServer: connectionModeIsServer(state)
-      };
-    } else if (connectionModeIsStandalone(state)) {
+    if (connectionModeIsStandalone(state)) {
       return { message: "STANDALONE_MODE" };
     } else if (
       state.userData.name === undefined &&
@@ -160,12 +152,6 @@ function mapDispatchToProps(dispatch) {
   return {
     login: () => {
       dispatch(login());
-    },
-    discardAutosave: () => {
-      dispatch(discardAutosave());
-    },
-    loadAutosave: () => {
-      dispatch(loadAutosave());
     },
     makeCopy: revisionId => {
       dispatch(createNewNotebookOnServer({ forkedFrom: revisionId }));

--- a/src/eval-frame/actions/eval-frame-tasks.js
+++ b/src/eval-frame/actions/eval-frame-tasks.js
@@ -7,9 +7,7 @@ tasks.saveNotebook = new UserTask({
   title: "Save Notebook",
   keybindings: ["ctrl+s", "meta+s"],
   preventDefaultKeybinding: true,
-  callback() {
-    postKeypressToEditor(this.keybindings[0]);
-  }
+  callback() {}
 });
 
 tasks.exportNotebook = new UserTask({

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -38,6 +38,7 @@ import "./tools/initialize-dom";
 import { checkForAutosave, subscribeToAutoSave } from "./tools/autosave";
 import evalQueue from "./actions/evaluation-queue";
 import CSSCascadeProvider from "./shared/css-cascade-provider";
+import { checkForServerAutosave } from "./tools/server-autosave";
 
 evalQueue.connectDispatch(store.dispatch);
 
@@ -49,6 +50,7 @@ handleServerVariables(store);
 handleInitialJsmd(store);
 handleReportViewModeInitialization(store);
 checkForAutosave(store);
+checkForServerAutosave(store);
 
 render(
   <Provider store={store}>

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -277,8 +277,13 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { panePositions: action.panePositions });
     }
 
-    case "SET_PREVIOUSLY_SAVED_JSMD_TO_CURRENT_JSMD": {
-      return Object.assign({}, state, { previouslySavedJsmd: state.jsmd });
+    case "SET_MOST_RECENT_SAVED_CONTENT": {
+      return Object.assign({}, state, {
+        previouslySavedContent: {
+          jsmd: state.jsmd,
+          title: state.title
+        }
+      });
     }
 
     default: {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -277,6 +277,10 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { panePositions: action.panePositions });
     }
 
+    case "SET_PREVIOUSLY_SAVED_JSMD_TO_CURRENT_JSMD": {
+      return Object.assign({}, state, { previouslySavedJsmd: state.jsmd });
+    }
+
     default: {
       return state;
     }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -70,6 +70,13 @@ const notebookReducer = (state = newNotebook(), action) => {
       return Object.assign({}, state, { hasPreviousAutoSave });
     }
 
+    case "SET_CONNECTION_STATUS": {
+      const { status } = action;
+      return Object.assign({}, state, {
+        notebookInfo: { ...state.notebookInfo, connectionStatus: status }
+      });
+    }
+
     case "EVAL_FRAME_READY": {
       state.evalFrameMessageQueue.forEach(actionToPost => {
         postActionToEvalFrame(actionToPost);

--- a/src/shared/fetch-with-csrf-token.js
+++ b/src/shared/fetch-with-csrf-token.js
@@ -23,7 +23,9 @@ export default function fetchWithCSRFToken(url, otherParts, headers = {}) {
   return fetch(
     url,
     Object.assign({}, otherParts, { headers: combinedHeaders })
-  );
+  ).catch(err => {
+    throw Error(err);
+  });
 }
 
 // for POST, DELETE of notebooks and revisions,

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -128,9 +128,13 @@ export const stateProperties = {
     type: "string",
     default: ""
   },
-  previouslySavedJsmd: {
-    type: "string",
-    default: ""
+  previouslySavedContent: {
+    type: "object",
+    default: { title: "", jsmd: "" },
+    properties: {
+      title: { type: "string" },
+      jsmd: { type: "string" }
+    }
   },
   jsmdChunks: {
     type: "array",

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -128,6 +128,10 @@ export const stateProperties = {
     type: "string",
     default: ""
   },
+  previouslySavedJsmd: {
+    type: "string",
+    default: ""
+  },
   jsmdChunks: {
     type: "array",
     items: {

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -234,6 +234,10 @@ export const stateProperties = {
     properties: {
       user_can_save: { type: "boolean" },
       notebook_id: { type: "integer" },
+      connectionStatus: {
+        type: "string",
+        enum: ["CONNECTION_ACTIVE", "CONNECTION_LOST"]
+      },
       connectionMode: {
         type: "string",
         enum: ["SERVER", "STANDALONE"]
@@ -243,7 +247,8 @@ export const stateProperties = {
     default: {
       notebook_id: undefined,
       user_can_save: false,
-      connectionMode: "STANDALONE"
+      connectionMode: "STANDALONE",
+      connectionStatus: "CONNECTION_ACTIVE"
     }
   },
   panePositions: {

--- a/src/tools/autosave.js
+++ b/src/tools/autosave.js
@@ -36,7 +36,11 @@ async function checkForAutosave(store) {
     autosaveState.dirtyCopy &&
     autosaveState.dirtyCopy !== autosaveState.originalCopy
   ) {
-    store.dispatch(loadAutosave());
+    const automaticallyApply =
+      state.notebookInfo.username === state.userData.name;
+    if (automaticallyApply) {
+      store.dispatch(loadAutosave());
+    }
     store.dispatch(setPreviousAutosave(true));
   }
 }

--- a/src/tools/autosave.js
+++ b/src/tools/autosave.js
@@ -1,6 +1,6 @@
 import db from "./autosave-client";
 import { connectionModeIsServer } from "./server-tools";
-import { setPreviousAutosave } from "../actions/actions";
+import { setPreviousAutosave, loadAutosave } from "../actions/actions";
 
 function exportJsmd(state) {
   return state.jsmd;
@@ -36,6 +36,7 @@ async function checkForAutosave(store) {
     autosaveState.dirtyCopy &&
     autosaveState.dirtyCopy !== autosaveState.originalCopy
   ) {
+    store.dispatch(loadAutosave());
     store.dispatch(setPreviousAutosave(true));
   }
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -10,11 +10,16 @@ export function notebookChangedSinceSave(state) {
 
 export function checkForServerAutosave(store) {
   store.dispatch(setMostRecentSavedContent());
-  setInterval(() => {
+  setInterval(async () => {
     const state = store.getState();
     if (notebookChangedSinceSave(state)) {
-      store.dispatch(saveNotebookToServer(false));
-      store.dispatch(setMostRecentSavedContent());
+      try {
+        await store.dispatch(saveNotebookToServer(false));
+        store.dispatch(setMostRecentSavedContent());
+      } catch (err) {
+        // FIXME: come up with a compelling error case
+        console.error(Error(err.message));
+      }
     }
   }, 10000);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -1,0 +1,18 @@
+import {
+  setPreviouslySavedJsmdToCurrentJsmd,
+  saveNotebookToServer
+} from "../actions/actions";
+
+export function changeMadeToJsmd(state) {
+  return state.previouslySavedJsmd !== state.jsmd;
+}
+export function checkForServerAutosave(store) {
+  store.dispatch(setPreviouslySavedJsmdToCurrentJsmd());
+  setInterval(() => {
+    const state = store.getState();
+    if (changeMadeToJsmd(state)) {
+      store.dispatch(saveNotebookToServer(false));
+      store.dispatch(setPreviouslySavedJsmdToCurrentJsmd());
+    }
+  }, 6000);
+}

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -14,5 +14,5 @@ export function checkForServerAutosave(store) {
       store.dispatch(saveNotebookToServer(false));
       store.dispatch(setPreviouslySavedJsmdToCurrentJsmd());
     }
-  }, 6000);
+  }, 10000);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -1,18 +1,20 @@
 import {
-  setPreviouslySavedJsmdToCurrentJsmd,
+  setMostRecentSavedContent,
   saveNotebookToServer
 } from "../actions/actions";
 
-export function changeMadeToJsmd(state) {
-  return state.previouslySavedJsmd !== state.jsmd;
+export function notebookChangedSinceSave(state) {
+  const { previouslySavedContent: previous } = state;
+  return previous.jsmd !== state.jsmd || previous.title !== state.title;
 }
+
 export function checkForServerAutosave(store) {
-  store.dispatch(setPreviouslySavedJsmdToCurrentJsmd());
+  store.dispatch(setMostRecentSavedContent());
   setInterval(() => {
     const state = store.getState();
-    if (changeMadeToJsmd(state)) {
+    if (notebookChangedSinceSave(state)) {
       store.dispatch(saveNotebookToServer(false));
-      store.dispatch(setPreviouslySavedJsmdToCurrentJsmd());
+      store.dispatch(setMostRecentSavedContent());
     }
   }, 10000);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -17,7 +17,11 @@ export function checkForServerAutosave(store) {
     const { username: notebookOwner } = state.notebookInfo;
     const { name: thisUser } = state.userData;
     let validAutosave = false;
-    if (notebookChangedSinceSave(state) && notebookOwner === thisUser) {
+    if (
+      notebookChangedSinceSave(state) && // has the notebook changed?
+      thisUser !== undefined && // is this a logged-in-user?
+      notebookOwner === thisUser // is this notebook owned by the current user?
+    ) {
       try {
         await store.dispatch(saveNotebookToServer(false));
         validAutosave = true;

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -2,6 +2,7 @@ import {
   setMostRecentSavedContent,
   saveNotebookToServer
 } from "../actions/actions";
+import { clearAutosave } from "./autosave";
 
 export function notebookChangedSinceSave(state) {
   const { previouslySavedContent: previous } = state;
@@ -16,6 +17,8 @@ export function checkForServerAutosave(store) {
       try {
         await store.dispatch(saveNotebookToServer(false));
         store.dispatch(setMostRecentSavedContent());
+        // remove previous autosave if we've successfully saved.
+        clearAutosave(state);
       } catch (err) {
         // FIXME: come up with a compelling error case
         console.error(Error(err.message));

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -14,9 +14,10 @@ export function checkForServerAutosave(store) {
   store.dispatch(setMostRecentSavedContent());
   setInterval(async () => {
     const state = store.getState();
+    const { username: notebookOwner } = state.notebookInfo;
+    const { name: thisUser } = state.userData;
     let validAutosave = false;
-
-    if (notebookChangedSinceSave(state)) {
+    if (notebookChangedSinceSave(state) && notebookOwner === thisUser) {
       try {
         await store.dispatch(saveNotebookToServer(false));
         validAutosave = true;
@@ -34,5 +35,5 @@ export function checkForServerAutosave(store) {
         }
       }
     }
-  }, 10000);
+  }, 2000);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -34,5 +34,5 @@ export function checkForServerAutosave(store) {
         }
       }
     }
-  }, 4000);
+  }, 10000);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -5,6 +5,8 @@ import {
 } from "../actions/actions";
 import { clearAutosave } from "./autosave";
 
+const SERVER_AUTOSAVE_INTERVAL = 30000;
+
 export function notebookChangedSinceSave(state) {
   const { previouslySavedContent: previous } = state;
   return previous.jsmd !== state.jsmd || previous.title !== state.title;
@@ -39,5 +41,5 @@ export function checkForServerAutosave(store) {
         }
       }
     }
-  }, 10000);
+  }, SERVER_AUTOSAVE_INTERVAL);
 }

--- a/src/tools/server-autosave.js
+++ b/src/tools/server-autosave.js
@@ -35,5 +35,5 @@ export function checkForServerAutosave(store) {
         }
       }
     }
-  }, 2000);
+  }, 10000);
 }


### PR DESCRIPTION
Every _k_ (_k_=10 in this PR) seconds, we compare the last-saved version to the current jsmd, and if different, save to server. If you lose your connection, surface a message saying you've lost the connection, that you'll keep trying, and that in the meantime your changes will be preserved locally.

Some minor extensions:

- [x] we can actually have it so that if there's a local autosave (vs. a server one) always apply it, since the server might eventually pick up the change & that's the behavior we want, for the most part.
- [x] this needs to pick up network error issues, 
- [x] and have a way of somewhat gracefully surfacing those network errors so they're obvious but not too unobtrusive.