### PR TITLE
Don't allow the creation of empty revisions with no changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - set default document position to (row 1, column 1) on startup (#1568)
 - displays owner name in header message when viewing a notebook you do not own
 - randomly generate initial notebook names (based on a list of iodide compounds) (#1541)
+- don't allow the creation of "empty" revisions on the server
 
 # 0.2.0 (2019-02-28)
 

--- a/server/notebooks/serializers.py
+++ b/server/notebooks/serializers.py
@@ -51,6 +51,14 @@ class NotebookRevisionDetailSerializer(serializers.ModelSerializer):
     Details of a revision for a notebook (includes content)
     """
 
+    def validate(self, attrs):
+        last_revision = NotebookRevision.objects.filter(
+            notebook_id=self.context["notebook_id"]
+        ).first()
+        if attrs["title"] == last_revision.title and attrs["content"] == last_revision.content:
+            raise serializers.ValidationError("Revision unchanged from previous")
+        return serializers.ModelSerializer.validate(self, attrs)
+
     class Meta:
         model = NotebookRevision
         fields = ("id", "title", "created", "content")

--- a/server/tests/test_notebook_revision_api.py
+++ b/server/tests/test_notebook_revision_api.py
@@ -136,9 +136,9 @@ def test_create_notebook_revision(fake_user, test_notebook, client):
     )
     assert resp.status_code == 201
     assert NotebookRevision.objects.count() == 2
-    notebook_revision = NotebookRevision.objects.first()
-    assert notebook_revision.title == post_blob["title"]
-    assert notebook_revision.content == post_blob["content"]
+    new_notebook_revision = NotebookRevision.objects.first()
+    assert new_notebook_revision.title == post_blob["title"]
+    assert new_notebook_revision.content == post_blob["content"]
 
     # make sure that the title gets updated too
     test_notebook.refresh_from_db()


### PR DESCRIPTION
I tested this on the client and it works well. Currently it still says "Notebook updated" while silently not updating anything if you save with no changes. An obvious improvement would be to say "No changes detected" instead but I feel it's better to just leave the client side as-is for now while we work on the auto-save implementation. There are definitely worse usability gotchas in iodide as things stand, and I'd rather not write code/tests that are going to be deleted/massively refactored within the next few weeks.

@robhudson you're probably not too familiar with the surrounding context here, but I thought it would be good to get your opinion on the code changes. Basically we want to prevent people from accidentally creating tons of no-op revisions by pressing Meta-S repeatedly (or when we land an implementation of auto-save, accidentally doing the same automatically). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
