### PR TITLE
Set default caret position in codemirror to be beginning of document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - don't show "new notebook" button on user pages that don't belong to
   the currently logged in one
 - add docs link to footer on server pages
+- set default document position to (row 1, column 1) on startup (#1568)
 
 # 0.2.0 (2019-02-28)
 

--- a/src/components/jsmd-editor.jsx
+++ b/src/components/jsmd-editor.jsx
@@ -138,9 +138,11 @@ class JsmdEditorUnconnected extends React.Component {
     //   },
     // )
 
+    // FIXME: should set cursor position in redux store (see: https://github.com/iodide-project/iodide/issues/1568)
     return (
       <ReactCodeMirror
         editorDidMount={this.storeEditorInstance}
+        cursor={{ line: 1, ch: 1 }}
         value={this.props.content}
         options={this.props.editorOptions}
         onBeforeChange={this.updateJsmdContent}


### PR DESCRIPTION
Interim fix for #1568. There are some things I'd like to work on this week that seem slightly more pressing, so I'd like to just get a simple fix in for now. It shouldn't be hard to do a follow-up later.

I don't think this is testable, but I verified that this has the intended behaviour locally. When we convert to redux we can obviously add some real jest tests. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
