### PR TITLE
added notebook owner name / link in header message if you are viewing a notebook you don't own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   the currently logged in one
 - add docs link to footer on server pages
 - set default document position to (row 1, column 1) on startup (#1568)
+- displays owner name in header message when viewing a notebook you do not own
 
 # 0.2.0 (2019-02-28)
 

--- a/src/components/menu/__tests__/header-messages.test.js
+++ b/src/components/menu/__tests__/header-messages.test.js
@@ -48,9 +48,10 @@ describe("HeaderMessages mapStateToProps", () => {
 
   it("displays make a copy message", () => {
     state.notebookInfo.user_can_save = false;
-    expect(mapStateToProps(state, ownProps).message).toEqual(
-      "NEED_TO_MAKE_COPY"
-    );
+    state.notebookInfo.username = "test";
+    const props = mapStateToProps(state, ownProps);
+    expect(props.message).toEqual("NEED_TO_MAKE_COPY");
+    expect(props.owner).toEqual("test");
   });
 
   it("displays nothing", () => {

--- a/src/components/menu/header-messages.jsx
+++ b/src/components/menu/header-messages.jsx
@@ -45,6 +45,7 @@ export class HeaderMessagesUnconnected extends React.Component {
       "NEED_TO_LOGIN",
       "NEED_TO_MAKE_COPY"
     ]),
+    owner: PropTypes.string,
     loadAutosave: PropTypes.func.isRequired,
     discardAutosave: PropTypes.func.isRequired,
     login: PropTypes.func.isRequired,
@@ -100,7 +101,8 @@ export class HeaderMessagesUnconnected extends React.Component {
       case "NEED_TO_MAKE_COPY":
         content = (
           <React.Fragment>
-            This notebook is owned by another user. {}
+            This notebook is owned by{" "}
+            <a href={`/${this.props.owner}`}>{this.props.owner}</a>. {}
             <a onClick={() => this.props.makeCopy(this.props.revisionId)}>
               Make a copy to your account
             </a>
@@ -145,7 +147,8 @@ export function mapStateToProps(state) {
     ) {
       return {
         message: "NEED_TO_MAKE_COPY",
-        revisionId: state.notebookInfo.revision_id
+        revisionId: state.notebookInfo.revision_id,
+        owner: state.notebookInfo.username
       };
     }
   }


### PR DESCRIPTION
Closes #1580.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- N/A **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
