### PR TITLE
Show revisions to the second in history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # (Unreleased; add upcoming change notes here)
 
+- fix bug where we should incorrect revision save times in history viewer,
+  also show revision save time down to the second level
+
 # 0.3.0 (2019-03-06)
 
 - don't show "new notebook" button on user pages that don't belong to

--- a/src/components/modals/history-modal.jsx
+++ b/src/components/modals/history-modal.jsx
@@ -14,7 +14,7 @@ import THEME from "../../shared/theme";
 
 const ModalContentContainer = styled("div")`
   display: grid;
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: 208px 1fr;
   grid-column-gap: 20px;
   padding: 0px;
   overflow: auto;

--- a/src/components/modals/revision-list.jsx
+++ b/src/components/modals/revision-list.jsx
@@ -62,7 +62,7 @@ class RevisionListUnconnected extends React.Component {
                 <ListItemText
                   primary={format(
                     new Date(revision.created),
-                    "MMM dd, uuuu HH:mm"
+                    "MMM dd, uuuu HH:mm:ss"
                   )}
                 />
               </ListItem>

--- a/src/components/modals/revision-list.jsx
+++ b/src/components/modals/revision-list.jsx
@@ -62,7 +62,7 @@ class RevisionListUnconnected extends React.Component {
                 <ListItemText
                   primary={format(
                     new Date(revision.created),
-                    "MMM dd, uuuu HH:MM"
+                    "MMM dd, uuuu HH:mm"
                   )}
                 />
               </ListItem>


### PR DESCRIPTION
Ideally we would probably have jest tests on the rendering of the history viewer, but I'd rather not gate this simple fix on that.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
