### PR TITLE
Just alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # (Unreleased; add upcoming change notes here)
+
 - iodide notebooks now automatically save to the server
 - fix bug where we should incorrect revision save times in history viewer,
   also show revision save time down to the second level
+- alpha now less extreme
 
 # 0.3.0 (2019-03-06)
 

--- a/src/eval-frame/components/panes/onboarding-content.jsx
+++ b/src/eval-frame/components/panes/onboarding-content.jsx
@@ -92,10 +92,10 @@ export default class OnboardingContent extends React.Component {
           <Element key="examples">
             <ElementTitle>Start with a Template</ElementTitle>
             <ElementBody>
-              <ElementBlockLink href="https://extremely-alpha.iodide.io/tryit">
+              <ElementBlockLink href="https://iodide.io/tryit">
                 Javascript starter
               </ElementBlockLink>
-              <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/222/">
+              <ElementBlockLink href="https://iodide.io/notebooks/222/">
                 Pyodide starter
               </ElementBlockLink>
             </ElementBody>
@@ -103,10 +103,10 @@ export default class OnboardingContent extends React.Component {
           <Element key="tutorials">
             <ElementTitle>Read a Tutorial</ElementTitle>
             <ElementBody>
-              <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/154/">
+              <ElementBlockLink href="https://iodide.io/notebooks/154/">
                 A Tour Through Iodide
               </ElementBlockLink>
-              <ElementBlockLink href="https://extremely-alpha.iodide.io/notebooks/300/">
+              <ElementBlockLink href="https://iodide.io/notebooks/300/">
                 Getting Started with Python
               </ElementBlockLink>
             </ElementBody>

--- a/src/server/components/footer.jsx
+++ b/src/server/components/footer.jsx
@@ -46,7 +46,7 @@ export default ({ showIcon = true }) => (
       {// only display terms of service on an official mozilla installation
       IODIDE_PUBLIC && (
         <ul>
-          <li>Extremely Alpha Software</li>
+          <li>Alpha Software</li>
           <li>
             <a href="https://github.com/iodide-project/iodide">Contribute</a>
           </li>

--- a/src/shared/components/featured-notebooks.jsx
+++ b/src/shared/components/featured-notebooks.jsx
@@ -8,7 +8,7 @@ export default ({ width }) => (
       title="A Brief Tour through Iodide"
       description="
                    A tutorial that walks through all the important parts of Iodide."
-      href="https://extremely-alpha.iodide.io/notebooks/154/"
+      href="https://iodide.io/notebooks/154/"
       imageSource="https://media.giphy.com/media/5qF68SjjIT6khDkS5T/giphy.gif"
     />
     <NotebookDisplayItem
@@ -16,7 +16,7 @@ export default ({ width }) => (
       description="
                    A concise example demonstrating how powerful
                    a web tech-focused notebook environment is for computational presentations."
-      href="https://extremely-alpha.iodide.io/notebooks/34/?viewMode=report"
+      href="https://iodide.io/notebooks/34/?viewMode=report"
       imageSource="https://media.giphy.com/media/ftdkB78fuQ1Eb3J2o1/giphy.gif"
     />
     <NotebookDisplayItem
@@ -24,26 +24,26 @@ export default ({ width }) => (
       description="
                 A tutorial demonstrating how
                 to use Python, Numpy, Pandas, and Matplotlib entirely within your browser."
-      href="https://extremely-alpha.iodide.io/notebooks/300/"
+      href="https://iodide.io/notebooks/300/"
       imageSource="https://media.giphy.com/media/65NKOOH1IQrsLx5aZb/giphy.gif"
     />
     <NotebookDisplayItem
       title="World Happiness Report"
       description="A neat data exploration using the World Happiness Report."
-      href="https://extremely-alpha.iodide.io/notebooks/193/?viewMode=report"
+      href="https://iodide.io/notebooks/193/?viewMode=report"
       imageSource="https://media.giphy.com/media/i4rRuA3cksj8a9R58g/giphy.gif"
     />
     <NotebookDisplayItem
       title="Peering into the Unknown"
       description="One man's cartoon / WebGL journey into his own brain."
-      href="https://extremely-alpha.iodide.io/notebooks/194/?viewMode=report"
+      href="https://iodide.io/notebooks/194/?viewMode=report"
       imageSource="https://media.giphy.com/media/9G6RGV7z6k4uzygzOQ/giphy.gif"
     />
     <NotebookDisplayItem
       title="Eviction Notices By SF Neighborhood, 1999-present"
       description="
                 A small data presentation about one aspect of the SF Housing crisis."
-      href="https://extremely-alpha.iodide.io/notebooks/144/?viewMode=report"
+      href="https://iodide.io/notebooks/144/?viewMode=report"
       imageSource="https://media.giphy.com/media/MohSU55IoyGmAXgEkY/giphy.gif"
     />
   </NotebookDisplay>


### PR DESCRIPTION
@wlach and @hamilton -- removing the explicit `extremely-alpha` from our urls, b/c the redirect to the subdomain works fine, and hey let's say it loud and proud: we're just regular alpha at this point :-)

Also one string change in here. My method was: find-in-all-files for "extremely". Only found hits in 3 files.

Any thing i'm not thinking of here?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not

tests and docs not needed