### PR TITLE
Cursor position in state

### DIFF
--- a/src/actions/__tests__/cursor-actions.test.js
+++ b/src/actions/__tests__/cursor-actions.test.js
@@ -1,0 +1,79 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import { moveCursorToNextChunk, updateEditorCursor } from "../actions";
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe("updateEditorCursor - returns correct action", () => {
+  it("should create an action to update the cursor (NO force param)", () => {
+    const [editorCursorLine, editorCursorChar] = [1, 2];
+    const expectedAction = {
+      type: "UPDATE_CURSOR",
+      editorCursorLine,
+      editorCursorChar,
+      editorCursorForceUpdate: false
+    };
+    expect(updateEditorCursor(editorCursorLine, editorCursorChar)).toEqual(
+      expectedAction
+    );
+  });
+
+  it("should create an action to update the cursor (with force param)", () => {
+    const [editorCursorLine, editorCursorChar, editorCursorForceUpdate] = [
+      1,
+      2,
+      true
+    ];
+    const expectedAction = {
+      type: "UPDATE_CURSOR",
+      editorCursorLine,
+      editorCursorChar,
+      editorCursorForceUpdate
+    };
+    expect(
+      updateEditorCursor(
+        editorCursorLine,
+        editorCursorChar,
+        editorCursorForceUpdate
+      )
+    ).toEqual(expectedAction);
+  });
+});
+
+// /*  eslint-disable no-unused-vars */
+// const window = {
+//   /*  eslint-enable no-unused-vars */
+//   getDoc: () => ({ somethingSelected: () => false })
+// };
+window.ACTIVE_CODEMIRROR = {
+  getDoc: () => ({ somethingSelected: () => false })
+};
+
+describe("moveCursorToNextChunk dispatches correct actions", () => {
+  it("no selection, and one chunk", () => {
+    const [editorCursorLine, editorCursorChar] = [1, 2];
+
+    const store = mockStore({
+      editorCursorLine,
+      editorCursorChar,
+      jsmdChunks: [{ startLine: 0, endLine: 10 }]
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        editorCursorLine: 11,
+        editorCursorChar: 0,
+        editorCursorForceUpdate: true
+      }
+    ];
+
+    // return store.dispatch(moveCursorToNextChunk()).then(() => {
+    //   // return of async actions
+    //   expect(store.getActions()).toEqual(expectedActions);
+    // });
+    store.dispatch(moveCursorToNextChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});

--- a/src/actions/__tests__/cursor-actions.test.js
+++ b/src/actions/__tests__/cursor-actions.test.js
@@ -41,16 +41,11 @@ describe("updateEditorCursor - returns correct action", () => {
   });
 });
 
-// /*  eslint-disable no-unused-vars */
-// const window = {
-//   /*  eslint-enable no-unused-vars */
-//   getDoc: () => ({ somethingSelected: () => false })
-// };
-window.ACTIVE_CODEMIRROR = {
-  getDoc: () => ({ somethingSelected: () => false })
-};
-
 describe("moveCursorToNextChunk dispatches correct actions", () => {
+  window.ACTIVE_CODEMIRROR = {
+    getDoc: () => ({ somethingSelected: () => false })
+  };
+
   it("no selection, and one chunk", () => {
     const [editorCursorLine, editorCursorChar] = [1, 2];
 
@@ -69,10 +64,32 @@ describe("moveCursorToNextChunk dispatches correct actions", () => {
       }
     ];
 
-    // return store.dispatch(moveCursorToNextChunk()).then(() => {
-    //   // return of async actions
-    //   expect(store.getActions()).toEqual(expectedActions);
-    // });
+    store.dispatch(moveCursorToNextChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("no selection, multiple chunks", () => {
+    const [editorCursorLine, editorCursorChar] = [12, 25];
+
+    const store = mockStore({
+      editorCursorLine,
+      editorCursorChar,
+      jsmdChunks: [
+        { startLine: 0, endLine: 10 },
+        { startLine: 11, endLine: 15 },
+        { startLine: 16, endLine: 20 }
+      ]
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        editorCursorLine: 16,
+        editorCursorChar: 0,
+        editorCursorForceUpdate: true
+      }
+    ];
+
     store.dispatch(moveCursorToNextChunk());
     expect(store.getActions()).toEqual(expectedActions);
   });

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -188,8 +188,17 @@ export function addLanguage(languageDefinition) {
   };
 }
 
-export function updateEditorCursor(editorCursorLine, editorCursorChar) {
-  return { type: "UPDATE_CURSOR", editorCursorLine, editorCursorChar };
+export function updateEditorCursor(
+  editorCursorLine,
+  editorCursorChar,
+  editorCursorForceUpdate = false
+) {
+  return {
+    type: "UPDATE_CURSOR",
+    editorCursorLine,
+    editorCursorChar,
+    editorCursorForceUpdate
+  };
 }
 
 export function evaluateText() {
@@ -235,7 +244,7 @@ export function moveCursorToNextChunk() {
       getState().jsmdChunks,
       targetLine
     );
-    dispatch(updateEditorCursor(targetChunk.endLine + 1, 0));
+    dispatch(updateEditorCursor(targetChunk.endLine + 1, 0, true));
   };
 }
 

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -188,6 +188,10 @@ export function addLanguage(languageDefinition) {
   };
 }
 
+export function updateEditorCursor(editorCursorLine, editorCursorChar) {
+  return { type: "UPDATE_CURSOR", editorCursorLine, editorCursorChar };
+}
+
 export function evaluateText() {
   return (dispatch, getState) => {
     const { jsmdChunks, kernelState } = getState();
@@ -195,8 +199,10 @@ export function evaluateText() {
     const cm = window.ACTIVE_CODEMIRROR;
     const doc = cm.getDoc();
     if (!doc.somethingSelected()) {
-      const { line } = doc.getCursor();
-      const activeChunk = getChunkContainingLine(jsmdChunks, line);
+      const activeChunk = getChunkContainingLine(
+        jsmdChunks,
+        getState().editorCursorLine
+      );
       evalQueue.evaluate(activeChunk, dispatch);
     } else {
       const selectionChunkSet = getAllSelections(doc)
@@ -216,7 +222,7 @@ export function moveCursorToNextChunk() {
     let targetLine;
 
     if (!doc.somethingSelected()) {
-      targetLine = doc.getCursor().line;
+      targetLine = getState().editorCursorLine;
     } else {
       const selections = doc.listSelections();
       const lastSelection = selections[selections.length - 1];
@@ -229,7 +235,7 @@ export function moveCursorToNextChunk() {
       getState().jsmdChunks,
       targetLine
     );
-    cm.setCursor(targetChunk.endLine + 1, 0);
+    dispatch(updateEditorCursor(targetChunk.endLine + 1, 0));
   };
 }
 

--- a/src/components/jsmd-editor.jsx
+++ b/src/components/jsmd-editor.jsx
@@ -55,12 +55,24 @@ class JsmdEditorUnconnected extends React.Component {
 
   componentDidUpdate() {
     // need to
+    // const cm = this.editor;
+    // const { editorCursorLine, editorCursorChar } = this.props;
+    // if (
+    //   cm.getCursor().line !== editorCursorLine ||
+    //   cm.getCursor().ch !== editorCursorChar
+    // ) {
+    //   console.warn("CURSOR DIRTY +++++++++++++++++++");
+    //   // cm.setCursor(editorCursorLine, editorCursorChar);
+    // }
+
     const cm = this.editor;
-    const { editorCursorLine, editorCursorChar } = this.props;
-    if (
-      cm.getCursor().line !== editorCursorLine ||
-      cm.getCursor().ch !== editorCursorChar
-    ) {
+    const {
+      editorCursorLine,
+      editorCursorChar,
+      editorCursorForceUpdate
+    } = this.props;
+    if (editorCursorForceUpdate) {
+      console.warn("CURSOR DIRTY +++++++++++++++++++");
       cm.setCursor(editorCursorLine, editorCursorChar);
     }
   }
@@ -71,11 +83,16 @@ class JsmdEditorUnconnected extends React.Component {
   }
 
   updateJsmdContent(editor, data, content) {
+    // const { line, ch } = editor.getCursor();
+    // this.props.actions.updateEditorCursor(line, ch);
     this.props.actions.updateJsmdContent(content);
   }
 
-  updateCursor(editor, data) {
-    this.props.actions.updateEditorCursor(data.line, data.ch);
+  updateCursor(editor) {
+    // console.log("editor, data", editor, data);
+    // console.log("editor.getCursor()", editor.getCursor());
+    const { line, ch } = editor.getCursor();
+    this.props.actions.updateEditorCursor(line, ch);
   }
 
   autoComplete = cm => {
@@ -155,16 +172,17 @@ class JsmdEditorUnconnected extends React.Component {
     //   },
     // )
 
-    const { editorCursorLine, editorCursorChar } = this.props;
+    // const { editorCursorLine, editorCursorChar } = this.props;
     return (
       <ReactCodeMirror
         editorDidMount={this.storeEditorInstance}
-        cursor={{ line: editorCursorLine, ch: editorCursorChar }}
+        // cursor={{ line: editorCursorLine, ch: editorCursorChar }}
         value={this.props.content}
         options={this.props.editorOptions}
         onBeforeChange={this.updateJsmdContent}
-        onCursor={this.updateCursor}
+        onCursorActivity={this.updateCursor}
         style={{ height: "100%" }}
+        // autoCursor={false}
       />
     );
   }
@@ -187,12 +205,13 @@ function mapStateToProps(state) {
   if (state.wrapEditors === true) {
     editorOptions.lineWrapping = true;
   }
-  const { editorCursorLine, editorCursorChar } = state;
+  const { editorCursorLine, editorCursorChar, editorCursorForceUpdate } = state;
   return {
     content: state.jsmd,
     editorOptions,
     editorCursorLine,
-    editorCursorChar
+    editorCursorChar,
+    editorCursorForceUpdate
   };
 }
 

--- a/src/components/jsmd-editor.jsx
+++ b/src/components/jsmd-editor.jsx
@@ -43,7 +43,6 @@ class JsmdEditorUnconnected extends React.Component {
   constructor(props) {
     super(props);
     // explicitly bind "this" for all methods in constructors
-    // this.handleFocusChange = this.handleFocusChange.bind(this)
     this.updateJsmdContent = this.updateJsmdContent.bind(this);
     this.updateCursor = this.updateCursor.bind(this);
     this.storeEditorInstance = this.storeEditorInstance.bind(this);
@@ -54,26 +53,11 @@ class JsmdEditorUnconnected extends React.Component {
   }
 
   componentDidUpdate() {
-    // need to
-    // const cm = this.editor;
-    // const { editorCursorLine, editorCursorChar } = this.props;
-    // if (
-    //   cm.getCursor().line !== editorCursorLine ||
-    //   cm.getCursor().ch !== editorCursorChar
-    // ) {
-    //   console.warn("CURSOR DIRTY +++++++++++++++++++");
-    //   // cm.setCursor(editorCursorLine, editorCursorChar);
-    // }
-
-    const cm = this.editor;
-    const {
-      editorCursorLine,
-      editorCursorChar,
-      editorCursorForceUpdate
-    } = this.props;
-    if (editorCursorForceUpdate) {
-      console.warn("CURSOR DIRTY +++++++++++++++++++");
-      cm.setCursor(editorCursorLine, editorCursorChar);
+    if (this.props.editorCursorForceUpdate) {
+      this.editor.setCursor(
+        this.props.editorCursorLine,
+        this.props.editorCursorChar
+      );
     }
   }
 
@@ -83,14 +67,10 @@ class JsmdEditorUnconnected extends React.Component {
   }
 
   updateJsmdContent(editor, data, content) {
-    // const { line, ch } = editor.getCursor();
-    // this.props.actions.updateEditorCursor(line, ch);
     this.props.actions.updateJsmdContent(content);
   }
 
   updateCursor(editor) {
-    // console.log("editor, data", editor, data);
-    // console.log("editor.getCursor()", editor.getCursor());
     const { line, ch } = editor.getCursor();
     this.props.actions.updateEditorCursor(line, ch);
   }
@@ -172,17 +152,16 @@ class JsmdEditorUnconnected extends React.Component {
     //   },
     // )
 
-    // const { editorCursorLine, editorCursorChar } = this.props;
+    const { editorCursorLine, editorCursorChar } = this.props;
     return (
       <ReactCodeMirror
         editorDidMount={this.storeEditorInstance}
-        // cursor={{ line: editorCursorLine, ch: editorCursorChar }}
+        cursor={{ line: editorCursorLine, ch: editorCursorChar }}
         value={this.props.content}
         options={this.props.editorOptions}
         onBeforeChange={this.updateJsmdContent}
         onCursorActivity={this.updateCursor}
         style={{ height: "100%" }}
-        // autoCursor={false}
       />
     );
   }

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -104,6 +104,11 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
+    case "UPDATE_CURSOR": {
+      const { editorCursorLine, editorCursorChar } = action;
+      return Object.assign({}, state, { editorCursorLine, editorCursorChar });
+    }
+
     case "UPDATE_JSMD_CONTENT": {
       const { jsmd, jsmdChunks } = action;
       return Object.assign({}, state, { jsmd, jsmdChunks });

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -105,8 +105,16 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case "UPDATE_CURSOR": {
-      const { editorCursorLine, editorCursorChar } = action;
-      return Object.assign({}, state, { editorCursorLine, editorCursorChar });
+      const {
+        editorCursorLine,
+        editorCursorChar,
+        editorCursorForceUpdate
+      } = action;
+      return Object.assign({}, state, {
+        editorCursorLine,
+        editorCursorChar,
+        editorCursorForceUpdate
+      });
     }
 
     case "UPDATE_JSMD_CONTENT": {

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -102,6 +102,14 @@ export const stateProperties = {
     type: "integer",
     default: 0
   },
+  editorCursorLine: {
+    type: "integer",
+    default: 0
+  },
+  editorCursorChar: {
+    type: "integer",
+    default: 0
+  },
   evalFrameMessageQueue: {
     type: "array",
     items: { type: "object" },

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -110,6 +110,12 @@ export const stateProperties = {
     type: "integer",
     default: 0
   },
+  editorCursorForceUpdate: {
+    // if this is true when the editor recieves it as props,
+    // then the editor must reposition the cursor using internal editor APIs
+    type: "boolean",
+    default: false
+  },
   evalFrameMessageQueue: {
     type: "array",
     items: { type: "object" },

--- a/src/store.js
+++ b/src/store.js
@@ -24,9 +24,11 @@ if (IODIDE_BUILD_MODE === "production") {
     applyMiddleware(
       createLogger({
         predicate: (getState, action) =>
-          !["UPDATE_JSMD_CONTENT", "UPDATE_MARKDOWN_CHUNKS"].includes(
-            action.type
-          )
+          ![
+            "UPDATE_JSMD_CONTENT",
+            "UPDATE_MARKDOWN_CHUNKS",
+            "UPDATE_CURSOR"
+          ].includes(action.type)
       })
     )
   );


### PR DESCRIPTION
part 1 of #1594 fix, moves stuff about cursor position to redux.

there is one notably less than ideal part of this, which is `editorCursorForceUpdate`. this is a weird thing to have in the redux store, but this was actually the least side-effecty way i could find to do force the cursor to update in the case of move triggered outside of code mirror (this whole thing is required because codeMirror is not a fully controlled component, so setting cursor position with props doesn't work other than at initialization, and there is a race condition between when the "UPDATE_CURSOR" actions get back to the component from redux and the position already set internally  within codemirror. (i suspect the same will be true in monaco.))

@hamilton as with all code editing things, please kick the tires on this one throughly -- do all the editing and entry operations you can think of, use all the eval shortcuts and other editor shortcuts, etc.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

no doc or changelog entry needed, no user-facing changes