### PR TITLE
Move version.json generation to deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,15 +52,6 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Create version.json
-          command: |
-            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
-            "$CIRCLE_SHA1" \
-            "$CIRCLE_TAG" \
-            "$CIRCLE_PROJECT_USERNAME" \
-            "$CIRCLE_PROJECT_REPONAME" \
-            "$CIRCLE_BUILD_URL" > version.json
-      - run:
           name: Build Docker image
           command: docker build -t app:build .
       # save the built docker container into CircleCI's cache. This is
@@ -138,6 +129,15 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          name: Create version.json
+          command: |
+            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+            "$CIRCLE_SHA1" \
+            "$CIRCLE_TAG" \
+            "$CIRCLE_PROJECT_USERNAME" \
+            "$CIRCLE_PROJECT_REPONAME" \
+            "$CIRCLE_BUILD_URL" > version.json
       # We are not using the cached docker file here b/c we want the production
       # build to use only the required Python files.
       - run:


### PR DESCRIPTION
In #1548 a change was made that stopped using the cached docker image generated in the `build` job. In the `build` job there is a task that generates a version.json file which is used for image verification as part of deployment into our environments. Since this file is no longer available in the docker image the deployments are failing. I've moved this task into the `deploy` job which should fix this issue.

https://bugzilla.mozilla.org/show_bug.cgi?id=1534646

