### PR TITLE
Remove renovate Python config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,5 @@
     "config:js-app",
     ":maintainLockFilesWeekly",
     ":prNotPending"
-  ],
-  "pip_requirements": {
-    "enabled": true,
-    "fileMatch": ["requirements/.*\\.txt"]
-  }
+  ]
 }


### PR DESCRIPTION
Hashes are not supported and no updates were being posted so removing
for now. See https://github.com/renovatebot/renovate/issues/2444

