### PR TITLE
Uncircle imports

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -9,7 +9,7 @@ import {
 } from "./language-actions";
 
 import { evaluateFetchText } from "./fetch-cell-eval-actions";
-import messagePasser from "../../redux-to-port-message-passer";
+import messagePasserEval from "../../redux-to-port-message-passer";
 
 import createHistoryItem from "../../tools/create-history-item";
 
@@ -23,11 +23,11 @@ initialVariables.add("FETCH_RESOLVERS");
 initialVariables.add("__SECRET_EMOTION__");
 
 export function sendStatusResponseToEditor(status, evalId) {
-  messagePasser.postMessage("EVALUATION_RESPONSE", { status, evalId });
+  messagePasserEval.postMessage("EVALUATION_RESPONSE", { status, evalId });
 }
 
 export function addToEvaluationQueue(chunk) {
-  messagePasser.postMessage("ADD_TO_EVALUATION_QUEUE", chunk);
+  messagePasserEval.postMessage("ADD_TO_EVALUATION_QUEUE", chunk);
 }
 
 function getUserDefinedVariablesFromWindow() {

--- a/src/eval-frame/index.jsx
+++ b/src/eval-frame/index.jsx
@@ -19,13 +19,13 @@ import initializeUserVariables from "./initialize-user-variables";
 import EvalContainer from "./components/eval-container";
 import ViewModeStylesHandler from "./components/view-mode-styles-handler";
 import { store } from "./store";
-import messagePasser from "../redux-to-port-message-passer";
+import messagePasserEval from "../redux-to-port-message-passer";
 
 import { iodide } from "./iodide-api/api";
 
 import "./port-to-editor";
 
-messagePasser.connectDispatch(store.dispatch);
+messagePasserEval.connectDispatch(store.dispatch);
 window.iodide = iodide;
 
 initializeDefaultKeybindings();

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -6,7 +6,7 @@ import {
   onParentContextFileFetchSuccess,
   onParentContextFileFetchError
 } from "./tools/fetch-file-from-parent-context";
-import messagePasser from "../redux-to-port-message-passer";
+import messagePasserEval from "../redux-to-port-message-passer";
 
 const mc = new MessageChannel();
 const portToEditor = mc.port1;
@@ -36,7 +36,7 @@ export function postMessageToEditor(messageType, message) {
   portToEditor.postMessage({ messageType, message });
 }
 
-messagePasser.connectPostMessage(postMessageToEditor);
+messagePasserEval.connectPostMessage(postMessageToEditor);
 
 function receiveMessage(event) {
   const trustedMessage = true;
@@ -44,7 +44,7 @@ function receiveMessage(event) {
     const { messageType, message } = event.data;
     switch (messageType) {
       case "STATE_UPDATE_FROM_EDITOR": {
-        messagePasser.dispatch({
+        messagePasserEval.dispatch({
           type: "REPLACE_STATE",
           state: message
         });
@@ -69,7 +69,7 @@ function receiveMessage(event) {
       }
       case "REDUX_ACTION":
         if (message.type === "TRIGGER_TEXT_EVAL_IN_FRAME") {
-          messagePasser.dispatch(
+          messagePasserEval.dispatch(
             evaluateText(
               message.evalText,
               message.evalType,

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -14,6 +14,8 @@ const portToEditor = mc.port1;
 let editorReady = false;
 const listenForEditorReady = messageEvent => {
   if (messageEvent.data === "EDITOR_READY") {
+    // IFRAME CONNECT STEP 4:
+    // when evalfram gets "EDITOR_READY", editorReady flag set
     editorReady = true;
     window.removeEventListener("message", listenForEditorReady, false);
   }
@@ -22,9 +24,13 @@ window.addEventListener("message", listenForEditorReady, false);
 
 function connectToEditor() {
   if (!editorReady) {
+    // IFRAME CONNECT STEP 1:
+    // "EVAL_FRAME_READY" is sent until the editor recieves
     setTimeout(connectToEditor, 50);
     window.parent.postMessage("EVAL_FRAME_READY", IODIDE_EDITOR_ORIGIN);
   } else {
+    // IFRAME CONNECT STEP 5:
+    // when editorReady===true, eval frame sends actual port
     window.parent.postMessage("EVAL_FRAME_SENDING_PORT", IODIDE_EDITOR_ORIGIN, [
       mc.port2
     ]);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,7 @@ import "./style/client-style-defaults";
 import NotebookHeader from "./components/menu/notebook-header";
 import EditorPaneContainer from "./components/editor-pane-container";
 import { store } from "./store";
+import messagePasserEd from "./redux-to-port-message-passer";
 import handleInitialJsmd from "./handle-initial-jsmd";
 import handleServerVariables from "./handle-server-variables";
 import handleReportViewModeInitialization from "./handle-report-view-mode-initialization";
@@ -51,6 +52,7 @@ handleInitialJsmd(store);
 handleReportViewModeInitialization(store);
 checkForAutosave(store);
 checkForServerAutosave(store);
+messagePasserEd.connectDispatch(store.dispatch);
 
 render(
   <Provider store={store}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,7 +26,7 @@ import "./style/client-style-defaults";
 import NotebookHeader from "./components/menu/notebook-header";
 import EditorPaneContainer from "./components/editor-pane-container";
 import { store } from "./store";
-import messagePasserEd from "./redux-to-port-message-passer";
+import messagePasserEditor from "./redux-to-port-message-passer";
 import handleInitialJsmd from "./handle-initial-jsmd";
 import handleServerVariables from "./handle-server-variables";
 import handleReportViewModeInitialization from "./handle-report-view-mode-initialization";
@@ -52,7 +52,7 @@ handleInitialJsmd(store);
 handleReportViewModeInitialization(store);
 checkForAutosave(store);
 checkForServerAutosave(store);
-messagePasserEd.connectDispatch(store.dispatch);
+messagePasserEditor.connectDispatch(store.dispatch);
 
 render(
   <Provider store={store}>

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -35,7 +35,7 @@ function receiveMessage(event) {
     const { messageType, message } = event.data;
     switch (messageType) {
       case "ADD_TO_EVALUATION_QUEUE": {
-        evalQueue.evaluate(message, store.dispatch);
+        evalQueue.evaluate(message);
         store.dispatch(setKernelState("KERNEL_BUSY"));
         break;
       }

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -17,8 +17,6 @@ export function postActionToEvalFrame(actionObj) {
   postMessageToEvalFrame("REDUX_ACTION", actionObj);
 }
 
-messagePasserEd.connectPostMessage(postMessageToEvalFrame);
-
 const approvedKeys = [
   "esc",
   "ctrl+s",
@@ -113,13 +111,18 @@ function receiveMessage(event) {
 
 export const listenForEvalFramePortReady = messageEvent => {
   if (messageEvent.data === "EVAL_FRAME_READY") {
+    // IFRAME CONNECT STEP 2:
+    // when editor gets "EVAL_FRAME_READY", it acks "EDITOR_READY"
     document
       .getElementById("eval-frame")
       .contentWindow.postMessage("EDITOR_READY", IODIDE_EVAL_FRAME_ORIGIN);
   }
   if (messageEvent.data === "EVAL_FRAME_SENDING_PORT") {
+    // IFRAME CONNECT STEP 6:
+    // editor gets port from eval frame, connection ready
     portToEvalFrame = messageEvent.ports[0]; // eslint-disable-line
     portToEvalFrame.onmessage = receiveMessage;
+    messagePasserEd.connectPostMessage(postMessageToEvalFrame);
     messagePasserEd.dispatch({ type: "EVAL_FRAME_READY" });
     // stop listening for messages once a connection to the eval-frame is made
     window.removeEventListener("message", listenForEvalFramePortReady, false);

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -5,7 +5,7 @@ import { addLanguage, setKernelState } from "./actions/actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
-import messagePasserEd from "./redux-to-port-message-passer";
+import messagePasserEditor from "./redux-to-port-message-passer";
 
 let portToEvalFrame;
 
@@ -35,7 +35,7 @@ function receiveMessage(event) {
     switch (messageType) {
       case "ADD_TO_EVALUATION_QUEUE": {
         evalQueue.evaluate(message);
-        messagePasserEd.dispatch(setKernelState("KERNEL_BUSY"));
+        messagePasserEditor.dispatch(setKernelState("KERNEL_BUSY"));
         break;
       }
       case "EVALUATION_RESPONSE": {
@@ -44,7 +44,7 @@ function receiveMessage(event) {
         else evalQueue.clear(evalId);
         const queueSize = evalQueue.getQueueSize();
         if (!queueSize) {
-          messagePasserEd.dispatch(setKernelState("KERNEL_IDLE"));
+          messagePasserEditor.dispatch(setKernelState("KERNEL_IDLE"));
         }
         break;
       }
@@ -82,7 +82,7 @@ function receiveMessage(event) {
       case "REDUX_ACTION":
         // in this case, `message` is a redux action
         if (validateActionFromEvalFrame(message)) {
-          messagePasserEd.dispatch(message);
+          messagePasserEditor.dispatch(message);
         } else {
           console.error(
             `got unapproved redux action from eval frame: ${message.type}`
@@ -101,7 +101,7 @@ function receiveMessage(event) {
         break;
       case "POST_LANGUAGE_DEF_TO_EDITOR":
         // in this case, message is a languageDefinition
-        messagePasserEd.dispatch(addLanguage(message));
+        messagePasserEditor.dispatch(addLanguage(message));
         break;
       default:
         console.error("unknown messageType", message);
@@ -122,8 +122,8 @@ export const listenForEvalFramePortReady = messageEvent => {
     // editor gets port from eval frame, connection ready
     portToEvalFrame = messageEvent.ports[0]; // eslint-disable-line
     portToEvalFrame.onmessage = receiveMessage;
-    messagePasserEd.connectPostMessage(postMessageToEvalFrame);
-    messagePasserEd.dispatch({ type: "EVAL_FRAME_READY" });
+    messagePasserEditor.connectPostMessage(postMessageToEvalFrame);
+    messagePasserEditor.dispatch({ type: "EVAL_FRAME_READY" });
     // stop listening for messages once a connection to the eval-frame is made
     window.removeEventListener("message", listenForEvalFramePortReady, false);
   }

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -6,7 +6,7 @@ import { addLanguage, setKernelState } from "./actions/actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
-import messagePasser from "./redux-to-port-message-passer";
+import messagePasserEd from "./redux-to-port-message-passer";
 
 let portToEvalFrame;
 
@@ -17,6 +17,8 @@ export function postMessageToEvalFrame(messageType, message) {
 export function postActionToEvalFrame(actionObj) {
   postMessageToEvalFrame("REDUX_ACTION", actionObj);
 }
+
+messagePasserEd.connectPostMessage(postMessageToEvalFrame);
 
 const approvedKeys = [
   "esc",

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -6,6 +6,7 @@ import { addLanguage, setKernelState } from "./actions/actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
+import messagePasser from "./redux-to-port-message-passer";
 
 let portToEvalFrame;
 
@@ -35,8 +36,7 @@ function receiveMessage(event) {
     switch (messageType) {
       case "ADD_TO_EVALUATION_QUEUE": {
         evalQueue.evaluate(message, store.dispatch);
-        if (store.getState().kernelState !== "KERNEL_BUSY")
-          store.dispatch(setKernelState("KERNEL_BUSY"));
+        store.dispatch(setKernelState("KERNEL_BUSY"));
         break;
       }
       case "EVALUATION_RESPONSE": {

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -1,7 +1,6 @@
 /* global IODIDE_EVAL_FRAME_ORIGIN  */
 
 import Mousetrap from "mousetrap";
-import { store } from "./store";
 import { addLanguage, setKernelState } from "./actions/actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
@@ -38,7 +37,7 @@ function receiveMessage(event) {
     switch (messageType) {
       case "ADD_TO_EVALUATION_QUEUE": {
         evalQueue.evaluate(message);
-        store.dispatch(setKernelState("KERNEL_BUSY"));
+        messagePasserEd.dispatch(setKernelState("KERNEL_BUSY"));
         break;
       }
       case "EVALUATION_RESPONSE": {
@@ -47,7 +46,7 @@ function receiveMessage(event) {
         else evalQueue.clear(evalId);
         const queueSize = evalQueue.getQueueSize();
         if (!queueSize) {
-          store.dispatch(setKernelState("KERNEL_IDLE"));
+          messagePasserEd.dispatch(setKernelState("KERNEL_IDLE"));
         }
         break;
       }
@@ -85,7 +84,7 @@ function receiveMessage(event) {
       case "REDUX_ACTION":
         // in this case, `message` is a redux action
         if (validateActionFromEvalFrame(message)) {
-          store.dispatch(message);
+          messagePasserEd.dispatch(message);
         } else {
           console.error(
             `got unapproved redux action from eval frame: ${message.type}`
@@ -104,7 +103,7 @@ function receiveMessage(event) {
         break;
       case "POST_LANGUAGE_DEF_TO_EDITOR":
         // in this case, message is a languageDefinition
-        store.dispatch(addLanguage(message));
+        messagePasserEd.dispatch(addLanguage(message));
         break;
       default:
         console.error("unknown messageType", message);
@@ -121,7 +120,7 @@ export const listenForEvalFramePortReady = messageEvent => {
   if (messageEvent.data === "EVAL_FRAME_SENDING_PORT") {
     portToEvalFrame = messageEvent.ports[0]; // eslint-disable-line
     portToEvalFrame.onmessage = receiveMessage;
-    store.dispatch({ type: "EVAL_FRAME_READY" });
+    messagePasserEd.dispatch({ type: "EVAL_FRAME_READY" });
     // stop listening for messages once a connection to the eval-frame is made
     window.removeEventListener("message", listenForEvalFramePortReady, false);
   }


### PR DESCRIPTION
@hamilton this should be another quick one. fixes an import cycle by having the editor use same messagePasser intermediary that we already set up in the evalframe a while back.

(also renamed `messagePasser` -> `messagePasserEval` for ctrl-f later on, you can easily ignore that)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not

this is quite a minor change -- no user facing anythng, no truly new code, just clean up