### PR TITLE
Remove heroku-run-build-script directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "build-production": "webpack --env=production",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix"
   },
-  "heroku-run-build-script": true,
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
     "transformIgnorePatterns": [


### PR DESCRIPTION
According to the Heroku blog post which announced this feature, this
directive is not needed after March 11, 2019.

https://devcenter.heroku.com/changelog-items/1557