### PR TITLE
(just look at this on background) Uncircle imports 2

### DIFF
--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -161,12 +161,18 @@ export function evaluateText(
 ) {
   return async (dispatch, getState) => {
     // FIXME: pretty much all of this logic should live on the editor side.
-    //  The editor should send down messages for distinct eval types,
-    //  and in particular, the editor should know if a language (like pyodide)
-    //  is known but not yet loaded, and should kick off and await completion
-    //  of the language loading process before attemping to eval code.
+    // The editor should send down messages for distinct eval types,
+    // and in particular, the editor should know if a language (like pyodide)
+    // is known but not yet loaded, and should kick off and await completion
+    // of the language loading process before attemping to eval code.
     // Eval operations should also not use dispatch at all, they should just
     // send back updates as they go.
+
+    if (NONCODE_EVAL_TYPES.includes(evalType) || evalType === "") {
+      // if this chunk is not of an evaluable type, bail out right away
+      sendStatusResponseToEditor("SUCCESS", evalId);
+      return Promise.resolve();
+    }
 
     MOST_RECENT_CHUNK_ID.set(chunkId);
     const sideEffect = document.getElementById(
@@ -206,8 +212,6 @@ export function evaluateText(
       } catch (error) {
         return Promise.reject();
       }
-    } else if (NONCODE_EVAL_TYPES.includes(evalType) || evalType === "") {
-      sendStatusResponseToEditor("SUCCESS", evalId);
     } else {
       sendStatusResponseToEditor("ERROR", evalId);
       dispatch(

--- a/src/eval-frame/actions/console-history-actions.js
+++ b/src/eval-frame/actions/console-history-actions.js
@@ -1,0 +1,41 @@
+import generateRandomId from "../../tools/generate-random-id";
+import createHistoryItem from "../../tools/create-history-item";
+
+export const EVALUATION_RESULTS = {};
+
+export function addToConsoleHistory({
+  historyType,
+  content,
+  value,
+  level,
+  language,
+  historyId = generateRandomId()
+}) {
+  const historyAction = createHistoryItem({
+    content,
+    historyType,
+    historyId,
+    level,
+    language
+  });
+  historyAction.type = "ADD_TO_CONSOLE_HISTORY";
+
+  EVALUATION_RESULTS[historyAction.historyId] = value;
+
+  return historyAction;
+}
+
+export function updateConsoleEntry(args) {
+  const updatedHistoryItem = Object.assign({}, args);
+  const { value, historyId } = updatedHistoryItem;
+  if (value) {
+    EVALUATION_RESULTS[historyId] = value;
+    delete updatedHistoryItem.value;
+  }
+  return {
+    type: "UPDATE_VALUE_IN_HISTORY",
+    historyItem: {
+      ...updatedHistoryItem
+    }
+  };
+}

--- a/src/eval-frame/actions/editor-message-senders.js
+++ b/src/eval-frame/actions/editor-message-senders.js
@@ -1,0 +1,5 @@
+import messagePasserEval from "../../redux-to-port-message-passer";
+
+export function sendStatusResponseToEditor(status, evalId) {
+  messagePasserEval.postMessage("EVALUATION_RESPONSE", { status, evalId });
+}

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -1,10 +1,11 @@
 import parseFetchCell from "./fetch-cell-parser";
+import { updateUserVariables } from "./actions";
+import { sendStatusResponseToEditor } from "./editor-message-senders";
+
 import {
   addToConsoleHistory,
-  updateConsoleEntry,
-  updateUserVariables,
-  sendStatusResponseToEditor
-} from "./actions";
+  updateConsoleEntry
+} from "./console-history-actions";
 
 import {
   genericFetch as fetchLocally,

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -1,5 +1,4 @@
 import parseFetchCell from "./fetch-cell-parser";
-import { updateUserVariables } from "./actions";
 import { sendStatusResponseToEditor } from "./editor-message-senders";
 
 import {
@@ -142,9 +141,6 @@ export function evaluateFetchText(fetchText, evalId) {
     );
 
     return Promise.all(fetchCalls)
-      .finally(() => {
-        dispatch(updateUserVariables());
-      })
       .then(outcomes => {
         // check for error.
         const hasError = outcomes.some(f => f.text.startsWith("ERROR"));

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -104,13 +104,6 @@ export function evaluateFetchText(fetchText, evalId) {
     const outputHistoryId = generateRandomId();
     const fetches = parseFetchCell(fetchText);
     const syntaxErrors = fetches.filter(fetchInfo => fetchInfo.parsed.error);
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_INPUT",
-        language: "fetch",
-        content: fetchText
-      })
-    );
     if (syntaxErrors.length) {
       dispatch(
         addToConsoleHistory({

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -1,4 +1,4 @@
-import { postMessageToEditor } from "../port-to-editor";
+import messagePasserEval from "../../redux-to-port-message-passer";
 import {
   addToConsoleHistory,
   updateConsoleEntry,
@@ -72,7 +72,10 @@ function loadLanguagePlugin(pluginData, dispatch) {
         pr.then(() => {
           value = `${displayName} plugin ready`;
           dispatch(addLanguage(pluginData));
-          postMessageToEditor("POST_LANGUAGE_DEF_TO_EDITOR", pluginData);
+          messagePasserEval.postMessage(
+            "POST_LANGUAGE_DEF_TO_EDITOR",
+            pluginData
+          );
           dispatch(
             updateConsoleEntry({ historyId, content: value, level: "LOG" })
           );

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -1,9 +1,9 @@
 import messagePasserEval from "../../redux-to-port-message-passer";
+import { sendStatusResponseToEditor } from "./editor-message-senders";
 import {
   addToConsoleHistory,
-  updateConsoleEntry,
-  sendStatusResponseToEditor
-} from "./actions";
+  updateConsoleEntry
+} from "./console-history-actions";
 import generateRandomId from "../../tools/generate-random-id";
 
 export function addLanguage(languageDefinition) {
@@ -13,7 +13,7 @@ export function addLanguage(languageDefinition) {
   };
 }
 
-function loadLanguagePlugin(pluginData, dispatch) {
+export function loadLanguagePlugin(pluginData, dispatch) {
   let value;
   let languagePluginPromise;
 
@@ -137,34 +137,6 @@ export function evaluateLanguagePlugin(pluginText, evalId) {
         return err;
       });
   };
-}
-
-export function ensureLanguageAvailable(languageId, state, dispatch) {
-  if (Object.prototype.hasOwnProperty.call(state.loadedLanguages, languageId)) {
-    return new Promise(resolve => resolve(state.loadedLanguages[languageId]));
-  }
-
-  if (
-    Object.prototype.hasOwnProperty.call(state.languageDefinitions, languageId)
-  ) {
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_MESSAGE",
-        content: `Loading ${
-          state.languageDefinitions[languageId].displayName
-        } language plugin`,
-        level: "LOG"
-      })
-    );
-    return loadLanguagePlugin(
-      state.languageDefinitions[languageId],
-      dispatch
-    ).then(() => state.languageDefinitions[languageId]);
-  }
-  // There is neither a loaded language or a predefined definition that matches...
-  // FIXME: It would be hard to get here in the UX, but with direct JSMD
-  // editing you could...
-  return new Promise((resolve, reject) => reject());
 }
 
 export function runCodeWithLanguage(

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -99,13 +99,6 @@ export function loadLanguagePlugin(pluginData, dispatch) {
 
 export function evaluateLanguagePlugin(pluginText, evalId) {
   return dispatch => {
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_INPUT",
-        content: pluginText,
-        language: "plugin"
-      })
-    );
     let pluginData;
     try {
       pluginData = JSON.parse(pluginText);

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -6,13 +6,6 @@ import {
 } from "./console-history-actions";
 import generateRandomId from "../../tools/generate-random-id";
 
-export function addLanguage(languageDefinition) {
-  return {
-    type: "ADD_LANGUAGE_TO_EVAL_FRAME",
-    languageDefinition
-  };
-}
-
 export function loadLanguagePlugin(pluginData, dispatch) {
   let value;
   let languagePluginPromise;
@@ -71,7 +64,6 @@ export function loadLanguagePlugin(pluginData, dispatch) {
 
         pr.then(() => {
           value = `${displayName} plugin ready`;
-          dispatch(addLanguage(pluginData));
           messagePasserEval.postMessage(
             "POST_LANGUAGE_DEF_TO_EDITOR",
             pluginData

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -9,7 +9,7 @@ import PreformattedTextItemsHandler from "../../../components/reps/preformatted-
 import HistoryInputItem from "./console/history-input-item";
 import ConsoleMessage from "./console/console-message";
 
-import { EVALUATION_RESULTS } from "../../actions/actions";
+import { EVALUATION_RESULTS } from "../../actions/console-history-actions";
 
 export class HistoryItemUnconnected extends React.Component {
   static propTypes = {

--- a/src/eval-frame/tools/fetch-file-from-parent-context.js
+++ b/src/eval-frame/tools/fetch-file-from-parent-context.js
@@ -1,4 +1,4 @@
-import { postMessageToEditor } from "../port-to-editor";
+import messagePasserEval from "../../redux-to-port-message-passer";
 
 const FETCH_RESOLVERS = {};
 
@@ -30,6 +30,6 @@ export default async function fetchFileFromParentContext(path, fetchType) {
     // resolve and reject are handled in port-to-editor.js when
     // the file is received by the editor.
     addResolvers(path, resolve, reject);
-    postMessageToEditor("REQUEST_FETCH", { path, fetchType });
+    messagePasserEval.postMessage("REQUEST_FETCH", { path, fetchType });
   });
 }


### PR DESCRIPTION
@hamilton this resolves all the import cycles in the eval frame code, and untangles some of the rat's nest around evaluation, especially with languages that are "known" but not yet loaded (pyodide).

highlights are:
- i pulled a few function into their own files, notably the functions about console history so that they can be imported in a few places without cycles
- eliminated `ensureLanguageAvailable` in favor of putting the equivalent code in `evaluateText`
- put all the addToConsoleHistory CONSOLE_INPUT in evaluateText (cut some more cycles)
- put all the updateUserVariables in evaluateText (cut some more cycles)

i did not add tests, even though this code is now much cleaner, more testable, and more maintainable, because having done this, i can now see the path to moving almost all of this logic to the editor and simplifying the eval frame substantially. so this is part 1, tests will come with that in part 2.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
