### PR TITLE
(WIP) Simplify eval code, remove dispatch from eval frame

### DIFF
--- a/src/actions/__tests__/eval-actions.test.js
+++ b/src/actions/__tests__/eval-actions.test.js
@@ -1,7 +1,8 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
 
-import { evaluateNotebook, nonRunnableChunkType } from "../actions";
+import { evaluateNotebook } from "../eval-actions";
+import { NONCODE_EVAL_TYPES } from "../../state-schemas/state-schema";
 
 const mockStore = configureMockStore([thunk]);
 
@@ -72,7 +73,7 @@ describe("evaluateNotebook - correct evaluations", () => {
     expect(mockEvalQueue.evaluate.mock.calls.length).toBe(2);
   });
 
-  nonRunnableChunkType.forEach(chunkType => {
+  NONCODE_EVAL_TYPES.forEach(chunkType => {
     it(`doesn't call evalQueueInstance.evaluate for chunktype: ${chunkType}`, async () => {
       testState.jsmdChunks[0].chunkType = chunkType;
       store = mockStore(testState);

--- a/src/actions/__tests__/verify-action-store-consistency.test.js
+++ b/src/actions/__tests__/verify-action-store-consistency.test.js
@@ -1,6 +1,6 @@
 import { store } from "../../store";
 import * as actions from "../actions";
-import { evaluateText, evaluateNotebook } from "../eval-actions";
+import { evaluateNotebook } from "../eval-actions";
 
 import { stateProperties } from "../../state-schemas/state-schema";
 import { SchemaValidationError } from "../../reducers/create-validated-reducer";

--- a/src/actions/__tests__/verify-action-store-consistency.test.js
+++ b/src/actions/__tests__/verify-action-store-consistency.test.js
@@ -1,5 +1,7 @@
 import { store } from "../../store";
 import * as actions from "../actions";
+import { evaluateText, evaluateNotebook } from "../eval-actions";
+
 import { stateProperties } from "../../state-schemas/state-schema";
 import { SchemaValidationError } from "../../reducers/create-validated-reducer";
 import { languageDefinitions } from "../../state-schemas/language-definitions";
@@ -97,7 +99,7 @@ describe("make sure action creators leave store in a consitent state", () => {
   });
 
   it("evaluateNotebook", () => {
-    expect(() => store.dispatch(actions.evaluateNotebook())).not.toThrow();
+    expect(() => store.dispatch(evaluateNotebook())).not.toThrow();
   });
 
   it("loginSuccess", () => {

--- a/src/actions/console-actions.js
+++ b/src/actions/console-actions.js
@@ -1,0 +1,23 @@
+import evalQueue from "./evaluation-queue";
+
+export function evalConsoleInput(consoleText) {
+  return (dispatch, getState) => {
+    const state = getState();
+    // exit if there is no code in the console to  eval
+    if (!consoleText) {
+      return undefined;
+    }
+    const evalLanguageId = state.languageLastUsed;
+
+    dispatch({ type: "CLEAR_CONSOLE_TEXT_CACHE" });
+    dispatch({ type: "RESET_HISTORY_CURSOR" });
+    evalQueue.evaluate({
+      chunkType: evalLanguageId,
+      chunkId: undefined,
+      chunkContent: consoleText,
+      evalFlags: ""
+    });
+    dispatch({ type: "UPDATE_CONSOLE_TEXT", consoleText: "" });
+    return Promise.resolve();
+  };
+}

--- a/src/actions/eval-actions.js
+++ b/src/actions/eval-actions.js
@@ -29,7 +29,7 @@ export function evaluateText() {
 
     if (editorSelections.length === 0) {
       const activeChunk = getChunkContainingLine(jsmdChunks, editorCursor.line);
-      evalQueue.evaluate(activeChunk, dispatch);
+      evalQueue.evaluate(activeChunk);
     } else {
       const selectionChunkSet = editorSelections
         .map(selection => ({
@@ -40,7 +40,7 @@ export function evaluateText() {
         .map(selection => selectionToChunks(selection, jsmdChunks))
         .map(removeDuplicatePluginChunksInSelectionSet());
       selectionChunkSet.forEach(selection => {
-        selection.forEach(chunk => evalQueue.evaluate(chunk, dispatch));
+        selection.forEach(chunk => evalQueue.evaluate(chunk));
       });
     }
   };

--- a/src/actions/eval-actions.js
+++ b/src/actions/eval-actions.js
@@ -1,0 +1,61 @@
+import {
+  getChunkContainingLine,
+  selectionToChunks,
+  removeDuplicatePluginChunksInSelectionSet
+} from "./jsmd-selection";
+import { setKernelState } from "./actions";
+import evalQueue from "./evaluation-queue";
+
+import { NONCODE_EVAL_TYPES } from "../state-schemas/state-schema";
+
+export function evaluateText() {
+  return (dispatch, getState) => {
+    const {
+      jsmdChunks,
+      kernelState,
+      editorSelections,
+      editorCursor
+    } = getState();
+
+    if (kernelState !== "KERNEL_BUSY") dispatch(setKernelState("KERNEL_BUSY"));
+
+    if (editorSelections.length === 0) {
+      const activeChunk = getChunkContainingLine(jsmdChunks, editorCursor.line);
+      evalQueue.evaluate(activeChunk, dispatch);
+    } else {
+      const selectionChunkSet = editorSelections
+        .map(selection => ({
+          start: selection.start.line,
+          end: selection.end.line,
+          selectedText: selection.selectedText
+        }))
+        .map(selection => selectionToChunks(selection, jsmdChunks))
+        .map(removeDuplicatePluginChunksInSelectionSet());
+      selectionChunkSet.forEach(selection => {
+        selection.forEach(chunk => evalQueue.evaluate(chunk, dispatch));
+      });
+    }
+  };
+}
+
+const chunkIsRunnable = chunk => !NONCODE_EVAL_TYPES.includes(chunk.chunkType);
+
+const chunkNotSkipped = chunk =>
+  !(
+    chunk.evalFlags.includes("skipRunAll") ||
+    chunk.evalFlags.includes("skiprunall")
+  );
+
+export function evaluateNotebook(evalQueueInstance = evalQueue) {
+  return (dispatch, getState) => {
+    const { jsmdChunks, kernelState } = getState();
+
+    if (kernelState !== "KERNEL_BUSY") dispatch(setKernelState("KERNEL_BUSY"));
+
+    jsmdChunks.forEach(chunk => {
+      if (chunkIsRunnable(chunk) && chunkNotSkipped(chunk)) {
+        evalQueueInstance.evaluate(chunk);
+      }
+    });
+  };
+}

--- a/src/actions/eval-actions.js
+++ b/src/actions/eval-actions.js
@@ -8,6 +8,14 @@ import evalQueue from "./evaluation-queue";
 
 import { NONCODE_EVAL_TYPES } from "../state-schemas/state-schema";
 
+const chunkIsRunnable = chunk => !NONCODE_EVAL_TYPES.includes(chunk.chunkType);
+
+const chunkNotSkipped = chunk =>
+  !(
+    chunk.evalFlags.includes("skipRunAll") ||
+    chunk.evalFlags.includes("skiprunall")
+  );
+
 export function evaluateText() {
   return (dispatch, getState) => {
     const {
@@ -37,14 +45,6 @@ export function evaluateText() {
     }
   };
 }
-
-const chunkIsRunnable = chunk => !NONCODE_EVAL_TYPES.includes(chunk.chunkType);
-
-const chunkNotSkipped = chunk =>
-  !(
-    chunk.evalFlags.includes("skipRunAll") ||
-    chunk.evalFlags.includes("skiprunall")
-  );
 
 export function evaluateNotebook(evalQueueInstance = evalQueue) {
   return (dispatch, getState) => {

--- a/src/actions/task-definitions.js
+++ b/src/actions/task-definitions.js
@@ -2,6 +2,7 @@ import UserTask from "./user-task";
 import ExternalLinkTask from "./external-link-task";
 import { store } from "../store";
 import * as actions from "./actions";
+import { evaluateText, evaluateNotebook } from "./eval-actions";
 
 // FIXME: remove requirement to import store in this file by attaching
 // keypress handling to store in initializeDefaultKeybindings() --
@@ -33,7 +34,7 @@ tasks.evaluateChunk = new UserTask({
   keybindings: ["mod+enter"],
   displayKeybinding: `${commandKey}+Enter`,
   callback() {
-    dispatcher.evaluateText();
+    store.dispatch(evaluateText());
   }
 });
 
@@ -41,7 +42,7 @@ tasks.evaluateNotebook = new UserTask({
   title: "Run Full Notebook",
   menuTitle: "Run Full Notebook",
   callback() {
-    dispatcher.evaluateNotebook();
+    store.dispatch(evaluateNotebook());
   }
 });
 
@@ -51,7 +52,7 @@ tasks.evaluateChunkAndSelectBelow = new UserTask({
   displayKeybinding: "Shift+Enter",
   preventDefaultKeybinding: true,
   callback() {
-    dispatcher.evaluateText();
+    store.dispatch(evaluateText());
     dispatcher.moveCursorToNextChunk();
   }
 });

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -161,12 +161,18 @@ export function evaluateText(
 ) {
   return async (dispatch, getState) => {
     // FIXME: pretty much all of this logic should live on the editor side.
-    //  The editor should send down messages for distinct eval types,
-    //  and in particular, the editor should know if a language (like pyodide)
-    //  is known but not yet loaded, and should kick off and await completion
-    //  of the language loading process before attemping to eval code.
+    // The editor should send down messages for distinct eval types,
+    // and in particular, the editor should know if a language (like pyodide)
+    // is known but not yet loaded, and should kick off and await completion
+    // of the language loading process before attemping to eval code.
     // Eval operations should also not use dispatch at all, they should just
     // send back updates as they go.
+
+    if (NONCODE_EVAL_TYPES.includes(evalType) || evalType === "") {
+      // if this chunk is not of an evaluable type, bail out right away
+      sendStatusResponseToEditor("SUCCESS", evalId);
+      return Promise.resolve();
+    }
 
     MOST_RECENT_CHUNK_ID.set(chunkId);
     const sideEffect = document.getElementById(
@@ -206,8 +212,6 @@ export function evaluateText(
       } catch (error) {
         return Promise.reject();
       }
-    } else if (NONCODE_EVAL_TYPES.includes(evalType) || evalType === "") {
-      sendStatusResponseToEditor("SUCCESS", evalId);
     } else {
       sendStatusResponseToEditor("ERROR", evalId);
       dispatch(

--- a/src/eval-frame/actions/actions.js
+++ b/src/eval-frame/actions/actions.js
@@ -76,29 +76,6 @@ export function consoleHistoryStepBack(consoleCursorDelta) {
   };
 }
 
-export function evalConsoleInput(consoleText) {
-  return (_, getState) => {
-    const state = getState();
-    // const code = state.consoleText
-    // exit if there is no code in the console to  eval
-    if (!consoleText) {
-      return undefined;
-    }
-    const evalLanguageId = state.languageLastUsed;
-
-    sendActionToEditor({ type: "CLEAR_CONSOLE_TEXT_CACHE" });
-    sendActionToEditor({ type: "RESET_HISTORY_CURSOR" });
-    addToEvaluationQueue({
-      chunkType: evalLanguageId,
-      chunkId: undefined,
-      chunkContent: consoleText,
-      evalFlags: ""
-    });
-    sendActionToEditor(updateConsoleText(""));
-    return Promise.resolve();
-  };
-}
-
 async function evaluateCode(code, language, evalId) {
   try {
     const output = await runCodeWithLanguage(language, code);

--- a/src/eval-frame/actions/console-history-actions.js
+++ b/src/eval-frame/actions/console-history-actions.js
@@ -1,0 +1,41 @@
+import generateRandomId from "../../tools/generate-random-id";
+import createHistoryItem from "../../tools/create-history-item";
+
+export const EVALUATION_RESULTS = {};
+
+export function addToConsoleHistory({
+  historyType,
+  content,
+  value,
+  level,
+  language,
+  historyId = generateRandomId()
+}) {
+  const historyAction = createHistoryItem({
+    content,
+    historyType,
+    historyId,
+    level,
+    language
+  });
+  historyAction.type = "ADD_TO_CONSOLE_HISTORY";
+
+  EVALUATION_RESULTS[historyAction.historyId] = value;
+
+  return historyAction;
+}
+
+export function updateConsoleEntry(args) {
+  const updatedHistoryItem = Object.assign({}, args);
+  const { value, historyId } = updatedHistoryItem;
+  if (value) {
+    EVALUATION_RESULTS[historyId] = value;
+    delete updatedHistoryItem.value;
+  }
+  return {
+    type: "UPDATE_VALUE_IN_HISTORY",
+    historyItem: {
+      ...updatedHistoryItem
+    }
+  };
+}

--- a/src/eval-frame/actions/editor-message-senders.js
+++ b/src/eval-frame/actions/editor-message-senders.js
@@ -1,0 +1,5 @@
+import messagePasserEval from "../../redux-to-port-message-passer";
+
+export function sendStatusResponseToEditor(status, evalId) {
+  messagePasserEval.postMessage("EVALUATION_RESPONSE", { status, evalId });
+}

--- a/src/eval-frame/actions/editor-message-senders.js
+++ b/src/eval-frame/actions/editor-message-senders.js
@@ -3,3 +3,7 @@ import messagePasserEval from "../../redux-to-port-message-passer";
 export function sendStatusResponseToEditor(status, evalId) {
   messagePasserEval.postMessage("EVALUATION_RESPONSE", { status, evalId });
 }
+
+export function sendActionToEditor(action) {
+  messagePasserEval.postMessage("REDUX_ACTION", action);
+}

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -1,10 +1,11 @@
 import parseFetchCell from "./fetch-cell-parser";
+import { updateUserVariables } from "./actions";
+import { sendStatusResponseToEditor } from "./editor-message-senders";
+
 import {
   addToConsoleHistory,
-  updateConsoleEntry,
-  updateUserVariables,
-  sendStatusResponseToEditor
-} from "./actions";
+  updateConsoleEntry
+} from "./console-history-actions";
 
 import {
   genericFetch as fetchLocally,

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -1,5 +1,4 @@
 import parseFetchCell from "./fetch-cell-parser";
-import { updateUserVariables } from "./actions";
 import { sendStatusResponseToEditor } from "./editor-message-senders";
 
 import {
@@ -142,9 +141,6 @@ export function evaluateFetchText(fetchText, evalId) {
     );
 
     return Promise.all(fetchCalls)
-      .finally(() => {
-        dispatch(updateUserVariables());
-      })
       .then(outcomes => {
         // check for error.
         const hasError = outcomes.some(f => f.text.startsWith("ERROR"));

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -104,13 +104,6 @@ export function evaluateFetchText(fetchText, evalId) {
     const outputHistoryId = generateRandomId();
     const fetches = parseFetchCell(fetchText);
     const syntaxErrors = fetches.filter(fetchInfo => fetchInfo.parsed.error);
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_INPUT",
-        language: "fetch",
-        content: fetchText
-      })
-    );
     if (syntaxErrors.length) {
       dispatch(
         addToConsoleHistory({

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -1,4 +1,4 @@
-import { postMessageToEditor } from "../port-to-editor";
+import messagePasserEval from "../../redux-to-port-message-passer";
 import {
   addToConsoleHistory,
   updateConsoleEntry,
@@ -72,7 +72,10 @@ function loadLanguagePlugin(pluginData, dispatch) {
         pr.then(() => {
           value = `${displayName} plugin ready`;
           dispatch(addLanguage(pluginData));
-          postMessageToEditor("POST_LANGUAGE_DEF_TO_EDITOR", pluginData);
+          messagePasserEval.postMessage(
+            "POST_LANGUAGE_DEF_TO_EDITOR",
+            pluginData
+          );
           dispatch(
             updateConsoleEntry({ historyId, content: value, level: "LOG" })
           );

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -127,14 +127,19 @@ export function evaluateLanguagePlugin(pluginText, evalId) {
     });
 }
 
-export function runCodeWithLanguage(
-  language,
-  code,
-  messageCallback = () => {}
-) {
+export function runCodeWithLanguage(language, code) {
   const { module, evaluator, asyncEvaluator } = language;
   if (asyncEvaluator !== undefined) {
     try {
+      const messageCallback = msg => {
+        sendActionToEditor(
+          addToConsoleHistory({
+            content: msg,
+            historyType: "CONSOLE_MESSAGE",
+            level: "LOG"
+          })
+        );
+      };
       return window[module][asyncEvaluator](code, messageCallback);
     } catch (e) {
       if (e.message === "window[module] is undefined") {

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -1,9 +1,9 @@
 import messagePasserEval from "../../redux-to-port-message-passer";
+import { sendStatusResponseToEditor } from "./editor-message-senders";
 import {
   addToConsoleHistory,
-  updateConsoleEntry,
-  sendStatusResponseToEditor
-} from "./actions";
+  updateConsoleEntry
+} from "./console-history-actions";
 import generateRandomId from "../../tools/generate-random-id";
 
 export function addLanguage(languageDefinition) {
@@ -13,7 +13,7 @@ export function addLanguage(languageDefinition) {
   };
 }
 
-function loadLanguagePlugin(pluginData, dispatch) {
+export function loadLanguagePlugin(pluginData, dispatch) {
   let value;
   let languagePluginPromise;
 
@@ -137,34 +137,6 @@ export function evaluateLanguagePlugin(pluginText, evalId) {
         return err;
       });
   };
-}
-
-export function ensureLanguageAvailable(languageId, state, dispatch) {
-  if (Object.prototype.hasOwnProperty.call(state.loadedLanguages, languageId)) {
-    return new Promise(resolve => resolve(state.loadedLanguages[languageId]));
-  }
-
-  if (
-    Object.prototype.hasOwnProperty.call(state.languageDefinitions, languageId)
-  ) {
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_MESSAGE",
-        content: `Loading ${
-          state.languageDefinitions[languageId].displayName
-        } language plugin`,
-        level: "LOG"
-      })
-    );
-    return loadLanguagePlugin(
-      state.languageDefinitions[languageId],
-      dispatch
-    ).then(() => state.languageDefinitions[languageId]);
-  }
-  // There is neither a loaded language or a predefined definition that matches...
-  // FIXME: It would be hard to get here in the UX, but with direct JSMD
-  // editing you could...
-  return new Promise((resolve, reject) => reject());
 }
 
 export function runCodeWithLanguage(

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -99,13 +99,6 @@ export function loadLanguagePlugin(pluginData, dispatch) {
 
 export function evaluateLanguagePlugin(pluginText, evalId) {
   return dispatch => {
-    dispatch(
-      addToConsoleHistory({
-        historyType: "CONSOLE_INPUT",
-        content: pluginText,
-        language: "plugin"
-      })
-    );
     let pluginData;
     try {
       pluginData = JSON.parse(pluginText);

--- a/src/eval-frame/actions/language-actions.js
+++ b/src/eval-frame/actions/language-actions.js
@@ -6,13 +6,6 @@ import {
 } from "./console-history-actions";
 import generateRandomId from "../../tools/generate-random-id";
 
-export function addLanguage(languageDefinition) {
-  return {
-    type: "ADD_LANGUAGE_TO_EVAL_FRAME",
-    languageDefinition
-  };
-}
-
 export function loadLanguagePlugin(pluginData, dispatch) {
   let value;
   let languagePluginPromise;
@@ -71,7 +64,6 @@ export function loadLanguagePlugin(pluginData, dispatch) {
 
         pr.then(() => {
           value = `${displayName} plugin ready`;
-          dispatch(addLanguage(pluginData));
           messagePasserEval.postMessage(
             "POST_LANGUAGE_DEF_TO_EDITOR",
             pluginData

--- a/src/eval-frame/components/panes/console/console-input-field.jsx
+++ b/src/eval-frame/components/panes/console/console-input-field.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { evalConsoleInput } from "../../../actions/actions";
-import { postActionToEditor } from "../../../port-to-editor";
+import {
+  postActionToEditor,
+  postMessageToEditor
+} from "../../../port-to-editor";
 
 import THEME from "../../../../shared/theme";
 
@@ -154,7 +156,9 @@ export const ConsoleInputMessagePasser = connectMessagePassers(
       postActionToEditor({
         type: "CONSOLE_HISTORY_MOVE",
         consoleCursorDelta
-      })
+      }),
+    evalConsoleInput: consoleText =>
+      postMessageToEditor("CONSOLE_NEEDS_EVALUATION", consoleText)
   }
 );
 
@@ -164,15 +168,4 @@ export function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    evalConsoleInput: consoleText => {
-      dispatch(evalConsoleInput(consoleText));
-    }
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ConsoleInputMessagePasser);
+export default connect(mapStateToProps)(ConsoleInputMessagePasser);

--- a/src/eval-frame/components/panes/console/console-language-menu.jsx
+++ b/src/eval-frame/components/panes/console/console-language-menu.jsx
@@ -10,7 +10,8 @@ import MenuItem from "../../../../shared/components/menu-item";
 import { TextButton } from "../../../../shared/components/buttons";
 import BaseIcon from "./base-icon";
 
-import { setConsoleLanguage as setConsoleLanguageAction } from "../../../actions/actions";
+import { setConsoleLanguage } from "../../../actions/actions";
+import { sendActionToEditor } from "../../../actions/editor-message-senders";
 
 const ArrowDropUp = styled(BaseIcon(ArrowDropUpIcon))`
   display: inline-block;
@@ -62,8 +63,7 @@ const onMenuClickCreator = (fcn, languageId) => () => {
 
 const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
-  currentLanguage,
-  setConsoleLanguage
+  currentLanguage
 }) => {
   return (
     <React.Fragment>
@@ -83,7 +83,8 @@ const ConsoleLanguageMenuUnconnected = ({
             <MenuItem
               key={language.languageId}
               onClick={onMenuClickCreator(
-                setConsoleLanguage,
+                languageId =>
+                  sendActionToEditor(setConsoleLanguage(languageId)),
                 language.languageId
               )}
             >
@@ -104,8 +105,7 @@ ConsoleLanguageMenuUnconnected.propTypes = {
       languageId: PropTypes.string.isRequired
     })
   ).isRequired,
-  currentLanguage: PropTypes.string.isRequired,
-  setConsoleLanguage: PropTypes.func.isRequired
+  currentLanguage: PropTypes.string.isRequired
 };
 
 export function mapStateToProps(state) {
@@ -118,15 +118,4 @@ export function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    setConsoleLanguage: languageId => {
-      dispatch(setConsoleLanguageAction(languageId));
-    }
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ConsoleLanguageMenuUnconnected);
+export default connect(mapStateToProps)(ConsoleLanguageMenuUnconnected);

--- a/src/eval-frame/components/panes/history-item.jsx
+++ b/src/eval-frame/components/panes/history-item.jsx
@@ -9,7 +9,7 @@ import PreformattedTextItemsHandler from "../../../components/reps/preformatted-
 import HistoryInputItem from "./console/history-input-item";
 import ConsoleMessage from "./console/console-message";
 
-import { EVALUATION_RESULTS } from "../../actions/actions";
+import { EVALUATION_RESULTS } from "../../actions/console-history-actions";
 
 export class HistoryItemUnconnected extends React.Component {
   static propTypes = {

--- a/src/eval-frame/index.jsx
+++ b/src/eval-frame/index.jsx
@@ -31,7 +31,6 @@ window.iodide = iodide;
 initializeDefaultKeybindings();
 // initialize variables available to the user in an empty notebook, such as
 // the iodide API.
-initializeUserVariables(store);
 
 render(
   <CSSCascadeProvider>
@@ -48,3 +47,5 @@ render(
   </Provider>,
   document.getElementById("view-mode-styles")
 );
+
+initializeUserVariables();

--- a/src/eval-frame/initialize-user-variables.js
+++ b/src/eval-frame/initialize-user-variables.js
@@ -1,5 +1,6 @@
 import { updateUserVariables } from "./actions/actions";
+import { sendActionToEditor } from "./actions/editor-message-senders";
 
-export default store => {
-  store.dispatch(updateUserVariables());
+export default () => {
+  sendActionToEditor(updateUserVariables());
 };

--- a/src/eval-frame/reducers/reducer.js
+++ b/src/eval-frame/reducers/reducer.js
@@ -1,29 +1,3 @@
-// /*  global IODIDE_BUILD_MODE */
-import { postActionToEditor } from "../port-to-editor";
-
-function reduceReducers(...reducers) {
-  return (previous, current) =>
-    reducers.reduce((p, r) => r(p, current), previous);
-}
-
-function replaceStateFromEditor(state, action) {
+export default function reducer(state, action) {
   return action.type === "REPLACE_STATE" ? action.state : state;
 }
-
-// this function forwards actions to the editor
-// FIXME THIS IS CRITICAL
-// for securty reasons, any actions forwarded must be whitelisted
-// and verified against schema on the editor side.
-const actionForwarder = (state, action) => {
-  // FIXME: this try.catch required to allow the eval frame to load properly --
-  // because we have circular dependencies in imports, postActionToEditor
-  // is not actually initialized when this is called the first time
-  try {
-    if (action.type !== "REPLACE_STATE") postActionToEditor(action);
-  } catch (error) {
-    console.log("EVAL FRAME ACTION POST TO EDITOR FAILED");
-  }
-  return state;
-};
-
-export default reduceReducers(replaceStateFromEditor, actionForwarder);

--- a/src/eval-frame/store.js
+++ b/src/eval-frame/store.js
@@ -29,6 +29,4 @@ const initialState = evalFrameStateSelector(newNotebook());
 
 const store = createStore(reducer, initialState, enhancer);
 
-const { dispatch } = store;
-
-export { store, dispatch };
+export { store };

--- a/src/eval-frame/tools/fetch-file-from-parent-context.js
+++ b/src/eval-frame/tools/fetch-file-from-parent-context.js
@@ -1,4 +1,4 @@
-import { postMessageToEditor } from "../port-to-editor";
+import messagePasserEval from "../../redux-to-port-message-passer";
 
 const FETCH_RESOLVERS = {};
 
@@ -30,6 +30,6 @@ export default async function fetchFileFromParentContext(path, fetchType) {
     // resolve and reject are handled in port-to-editor.js when
     // the file is received by the editor.
     addResolvers(path, resolve, reject);
-    postMessageToEditor("REQUEST_FETCH", { path, fetchType });
+    messagePasserEval.postMessage("REQUEST_FETCH", { path, fetchType });
   });
 }

--- a/src/handle-report-view-mode-initialization.js
+++ b/src/handle-report-view-mode-initialization.js
@@ -1,4 +1,6 @@
-import { setViewMode, evaluateNotebook } from "./actions/actions";
+import { setViewMode } from "./actions/actions";
+import { evaluateNotebook } from "./actions/eval-actions";
+
 import { getStatePropsFromUrlParams } from "./tools/query-param-tools";
 
 export default function handleReportViewModeInitialization(store) {

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -2,6 +2,7 @@
 
 import Mousetrap from "mousetrap";
 import { addLanguage, setKernelState } from "./actions/actions";
+import { evalConsoleInput } from "./actions/console-actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
@@ -36,6 +37,10 @@ function receiveMessage(event) {
       case "ADD_TO_EVALUATION_QUEUE": {
         evalQueue.evaluate(message);
         messagePasserEditor.dispatch(setKernelState("KERNEL_BUSY"));
+        break;
+      }
+      case "CONSOLE_NEEDS_EVALUATION": {
+        messagePasserEditor.dispatch(evalConsoleInput(message));
         break;
       }
       case "EVALUATION_RESPONSE": {


### PR DESCRIPTION
builds on  #1643 (superset of those changes)

this substantially simplifies the eval-frame's evaluation code, mostly by removing its use of dispatch in almost all cases. This is done by de-thunking a number of functions having to do with evaluation. doing this clears the way for removing the rest of the instances of dispatch from other parts of the eval frame.

the main file with substantive logical changes is src/eval-frame/actions/actions.js. a bunch of the stuff at the top that appears to have been cut has really just moved to other files, but `evaluateCode` and `evaluateText` have major changes.

i've tried to leave many comments to guide you through this review. i think it may not actually be too too bad, at least i hope not.

there are some more architecture changes that need to be in place before test writing begins, but this PR already gets us very close to the longstanding dream of shrinking our use of redux in the eval frame to almost nothing, and finally removes the need for the heinous hack of having a special reducer that forwards actions from the eval frame to the editor

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
