### PR TITLE
PROPOSAL: iodide.file API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guid
 
 `fileType` is the file type to handle. These are the same as the file types in [fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch): `js` (load this file as javascript, eg a library), `css` (load this file as a stylesheet, applying the styles to the report), `json` (load this file as json and parse into a javascript object), `text` (load this file as text), `blob` (load this file as binary).
 
-`variableName` (required for `json`, `text`, and `blob` file types, otherwise not applicable): the variable name in which to load the data.
+`variableName` (required for `json`, `text`, and `blob` file types, otherwise not applicable): the variable name in which to load the data, available in the browser `window` namespace.
 
 
 #### `iodide.file.load` patterns

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ if (iodide.file.exists(FILENAME)) {
   iodide.file.load(FILENAME, 'text', 'evictionsData')
     .then(() => {
       evictionsData = d3.parseCsv(evictionsData)
-    }) ...
+    })
 } else {
   // if we don't have the cached file, let's go ahead
   // and download the bigger one, manipulate it with some
@@ -145,7 +145,7 @@ if (iodide.file.exists(FILENAME)) {
     .then(processDataAndReduceItsSize)
     .then((finalData) => {
       evictionsData = finalData
-      iodide.file.save(evictionsData, 'dataset.csv', d3.csvFormat)
+      return iodide.file.save(evictionsData, 'dataset.csv', d3.csvFormat)
     })
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,22 +10,28 @@ tracker](https://github.com/iodide-project/iodide/issues/new).
 
 ## `iodide.file`
 
-The `iodide.file` API provides convenience functions around working with files uploaded to the Iodide server in your notebook.
+The `iodide.file` API provides convenience functions around working with files
+uploaded to the Iodide server in your notebook.
 
 
 
 ### `iodide.file.save(data, fileName[, saveOptions])`
 
-Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises), which, when resolved, will signal that `data` was uploaded to the server under the filename `fileName`.
+Returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises),
+which, when resolved, will signal that `data` was uploaded to the server under
+the filename `fileName`.
 
-`data` (required) is any object or variable in the eval name space. It can be anything, really - an array of data, or a csv, or a binary blob.
+`data` (required) is any object or variable in the eval name space. It can be
+anything, really - an array of data, or a csv, or a binary blob.
 
-`filename` (required) is a string that represents the file name.
+`fileName` (required) is a string that represents the file name.
 
 The optional argument `saveOptions` has the following keys:
 
-- `overwrite` (optional, default `false`): if `true`, will overwrite whatever is at `fileName` with `data`. If `false`, will throw an error and halt the subsequent enqueued evaluation (similar to a syntax error).
-- `serializer` (optional): a function that transforms `data` to its final form.
+- `overwrite` (optional, default `false`): if `true`, will overwrite whatever is
+  at `fileName` with `data`. If `false`, will throw an error and halt the
+  subsequent enqueued evaluation (similar to a syntax error).
 
 
 ##### `iodide.file.save` patterns
@@ -51,13 +57,30 @@ iodide.file.save(new ArrayBuffer(...), 'model-output.bin')
 
 ### `iodide.file.load(fileName, fileType[, variableName])`
 
-Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) that, when resolved, loads into the notebook the save file `fileName`. For each notebook can find a list of uploaded files in the [upload modal](#link-required) or on your notebook's [Revisions Page](#needs-link). You can also access any uploaded file through the fetch chunk, [following this pattern](https://iodide-project.github.io/docs/workflows/#uploading-data-to-an-iodide-notebook). For most use cases using [fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch) is preferable and more straightforward. In more dynamic programmatic cases, however, `iodide.file.load` can provide more nuanced workflows.
+Returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
+that, when resolved, loads into the notebook the save file `fileName`. For each
+notebook can find a list of uploaded files in the [upload modal](#link-required)
+or on your notebook's [Revisions Page](#needs-link). You can also access any
+uploaded file through the fetch chunk, [following this
+pattern](https://iodide-project.github.io/docs/workflows/#uploading-data-to-an-iodide-notebook).
+For most use cases using [fetch
+chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch) is
+preferable and more straightforward. In more dynamic programmatic cases,
+however, `iodide.file.load` can provide more nuanced workflows.
 
 `fileName` is the name of the file uploaded to the Iodide server. 
 
-`fileType` is the file type to handle. These are the same as the file types in [fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch): `js` (load this file as javascript, eg a library), `css` (load this file as a stylesheet, applying the styles to the report), `json` (load this file as json and parse into a javascript object), `text` (load this file as text), `blob` (load this file as binary).
+`fileType` is the file type to handle. These are the same as the file types in
+[fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch):
+`js` (load this file as javascript, eg a library), `css` (load this file as a
+stylesheet, applying the styles to the report), `json` (load this file as json
+and parse into a javascript object), `text` (load this file as text), `blob`
+(load this file as binary).
 
-`variableName` (required for `json`, `text`, and `blob` file types, otherwise not applicable): the variable name in which to load the data, available in the browser `window` namespace.
+`variableName` (required for `json`, `text`, and `blob` file types, otherwise
+not applicable): the variable name in which to load the data, available in the
+browser `window` namespace.
 
 
 #### `iodide.file.load` patterns
@@ -89,11 +112,14 @@ iodide.file.load('analysis-helpers.js', 'js')
 
 ### `iodide.file.delete(fileName[, deleteOptions])`
 
-Deletes the file specified by `fileName`. Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) that when resolved, denotes that the file was deleted on the server.
+Deletes the file specified by `fileName`. Returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)
+that when resolved, denotes that the file was deleted on the server.
 
 `deleteOptions` is an object with the following keys:
 
-- `throwIfDoesNotExist` (optional, default `true`): will throw an error and halt the evaluation queue if `true`.
+- `throwIfDoesNotExist` (optional, default `true`): will throw an error and halt
+  the evaluation queue if `true`.
 
 
 
@@ -108,22 +134,26 @@ Returns an Array of file names available to the current notebook.
 ```javascript
 // delete the various pngs originally saved to this notebook
 iodide.file.list()
-	.filter(filename => !filename.includes('.png'))
-	.forEach(iodide.file.delete)
+  .filter(filename => !filename.includes('.png'))
+  .forEach(iodide.file.delete)
 ```
 
 
 ### `iodide.file.exists(fileName)`
 
-Returns `true` if the file `fileName` is available to the notebook, and `false` otherwise.
+Returns `true` if the file `fileName` is available to the notebook, and `false`
+otherwise.
 
-The below code chunk, for instance, checks to see if a csv file already exists on the server. If it does, then Iodide will load that. Otherwise,
-the notebook will fetch the data, process it using a numb er of steps, and save the output to the server.
+The below code chunk, for instance, checks to see if a csv file already exists
+on the server. If it does, then Iodide will load that. Otherwise, the notebook
+will fetch the data, process it using a numb er of steps, and save the output to
+the server.
 
 
 #### `iodide.file.exists` patterns
 
-The example below loads cached data if it exists on the server, and otherwise downloads the larger dataset remotely, processes it, then caches it.
+The example below loads cached data if it exists on the server, and otherwise
+downloads the larger dataset remotely, processes it, then caches it.
 
 ```javascript
 
@@ -154,7 +184,8 @@ if (iodide.file.exists(FILENAME)) {
 
 ### `iodide.file.lastUpdated(fileName)`
 
-returns a `Date` object that represents when the file associated with `fileName` was last updated.
+returns a `Date` object that represents when the file associated with `fileName`
+was last updated.
 
 #### `iodide.file.lastUpdated` patterns
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,7 @@ iodide.file.list()
 
 ### `iodide.file.exists(fileName)`
 
-Returns `true` if the file has been uploaded to the server, and `false` otherwise.
+Returns `true` if the file `fileName` is available to the notebook, and `false` otherwise.
 
 The below code chunk, for instance, checks to see if a csv file already exists on the server. If it does, then Iodide will load that. Otherwise,
 the notebook will fetch the data, process it using a numb er of steps, and save the output to the server.

--- a/docs/api.md
+++ b/docs/api.md
@@ -128,7 +128,6 @@ The example below loads cached data if it exists on the server, and otherwise do
 ```javascript
 
 const FILENAME = 'dataset.csv'
-let promise
 if (iodide.file.exists(FILENAME)) {
   // since the cached file already exists, let's load it.
   iodide.file.load(FILENAME, 'text', 'evictionsData')

--- a/docs/api.md
+++ b/docs/api.md
@@ -145,7 +145,7 @@ if (iodide.file.exists(FILENAME)) {
     .then(processDataAndReduceItsSize)
     .then((finalData) => {
       evictionsData = finalData
-      iodide.file.save(evictionsData, 'dataset.csv', (d) => d3.formatCSV(d))
+      iodide.file.save(evictionsData, 'dataset.csv', d3.csvFormat)
     })
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,172 @@ challenges presented by JavaScript and web browsers.
 Please direct clarifications or observations of inaccuracy to [our issue
 tracker](https://github.com/iodide-project/iodide/issues/new).
 
+
+
+## `iodide.file`
+
+The `iodide.file` API provides convenience functions around working with files uploaded to the Iodide server in your notebook.
+
+
+
+### `iodide.file.save(data, fileName[, saveOptions])`
+
+Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises), which, when resolved, will signal that `data` was uploaded to the server under the filename `fileName`.
+
+`data` (required) is any object or variable in the eval name space. It can be anything, really - an array of data, or a csv, or a binary blob.
+
+`filename` (required) is a string that represents the file name.
+
+The optional argument `saveOptions` has the following keys:
+
+- `overwrite` (optional, default `false`): if `true`, will overwrite whatever is at `fileName` with `data`. If `false`, will throw an error and halt the subsequent enqueued evaluation (similar to a syntax error).
+- `serializer` (optional): a function that transforms `data` to its final form.
+
+
+##### `iodide.file.save` patterns
+
+```javascript
+
+// upload a csv to the server. Assume the object csvData is an array of objects
+// representing a columnar dataset. This overwrites whatever is in `cached-data.csv`
+// because overwrite is set to true.
+
+const csvData = [{x1: 10, x2: 'test1'}, {x1: 20, x2: 'test2'}, ...]
+
+iodide.file.save(csvData, 'cached-data.csv' {
+  overwrite: true,
+  serializer: d3.csvFormat
+})
+
+// iodide.file.save works with ArrayBuffers as well.
+iodide.file.save(new ArrayBuffer(...), 'model-output.bin')
+```
+
+
+
+### `iodide.file.load(fileName, fileType[, variableName])`
+
+Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) that, when resolved, loads into the notebook the save file `fileName`. For each notebook can find a list of uploaded files in the [upload modal](#link-required) or on your notebook's [Revisions Page](#needs-link). You can also access any uploaded file through the fetch chunk, [following this pattern](https://iodide-project.github.io/docs/workflows/#uploading-data-to-an-iodide-notebook). For most use cases using [fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch) is preferable and more straightforward. In more dynamic programmatic cases, however, `iodide.file.load` can provide more nuanced workflows.
+
+`fileName` is the name of the file uploaded to the Iodide server. 
+
+`fileType` is the file type to handle. These are the same as the file types in [fetch chunks](https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch): `js` (load this file as javascript, eg a library), `css` (load this file as a stylesheet, applying the styles to the report), `json` (load this file as json and parse into a javascript object), `text` (load this file as text), `blob` (load this file as binary).
+
+`variableName` (required for `json`, `text`, and `blob` file types, otherwise not applicable): the variable name in which to load the data.
+
+
+#### `iodide.file.load` patterns
+
+```javascript
+
+// load a csv
+iodide.file.load('cached-data.csv', 'text', 'cachedData').then(() => {
+  cachedData = d3.csvParsed(cachedData)
+})
+
+// load a video
+iodide.file.load('gritty.mp4', 'blob', 'gritty').then(() => {
+  // load this gritty video into a <video /> tag in the report.
+  var urlCreator = window.URL || window.webkitURL;
+  var imageUrl = urlCreator.createObjectURL(gritty);
+  document.querySelector("#gritty").src = imageUrl;
+})
+
+// load a style sheet and apply the style
+iodide.file.load('corporate-report-style.css', 'css')
+
+// load some javascript helpers
+iodide.file.load('analysis-helpers.js', 'js')
+
+```
+
+
+
+### `iodide.file.delete(fileName[, deleteOptions])`
+
+Deletes the file specified by `fileName`. Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) that when resolved, denotes that the file was deleted on the server.
+
+`deleteOptions` is an object with the following keys:
+
+- `throwIfDoesNotExist` (optional, default `true`): will throw an error and halt the evaluation queue if `true`.
+
+
+
+### `iodide.file.list()`
+
+Returns an Array of file names available to the current notebook.
+
+
+#### `iodide.file.list` patterns
+
+
+```javascript
+// delete the various pngs originally saved to this notebook
+iodide.file.list()
+	.filter(filename => !filename.includes('.png'))
+	.forEach(iodide.file.delete)
+```
+
+
+### `iodide.file.exists(fileName)`
+
+Returns `true` if the file has been uploaded to the server, and `false` otherwise.
+
+The below code chunk, for instance, checks to see if a csv file already exists on the server. If it does, then Iodide will load that. Otherwise,
+the notebook will fetch the data, process it using a numb er of steps, and save the output to the server.
+
+
+#### `iodide.file.exists` patterns
+
+The example below loads cached data if it exists on the server, and otherwise downloads the larger dataset remotely, processes it, then caches it.
+
+```javascript
+
+const FILENAME = 'dataset.csv'
+let promise
+if (iodide.file.exists(FILENAME)) {
+  // since the cached file already exists, let's load it.
+  iodide.file.load(FILENAME, 'text', 'evictionsData')
+    .then(() => {
+      evictionsData = d3.parseCsv(evictionsData)
+    }) ...
+} else {
+  // if we don't have the cached file, let's go ahead
+  // and download the bigger one, manipulate it with some
+  // function processDataAndReduceItsSize, then save it to the server
+  // so the next time we run this code chunk, we'll just load the 
+  // cached (smaller) version.
+  fetch('http://...')
+    .then((r) => r.json())
+    .then(processDataAndReduceItsSize)
+    .then((finalData) => {
+      evictionsData = finalData
+      iodide.file.save(evictionsData, 'dataset.csv', (d) => d3.formatCSV(d))
+    })
+}
+```
+
+
+
+### `iodide.file.lastUpdated(fileName)`
+
+returns a `Date` object that represents when the file associated with `fileName` was last updated.
+
+#### `iodide.file.lastUpdated` patterns
+
+```javascript
+
+// get the oldest csv file
+
+const oldestDate = Math.min(
+  ...iodide.file.list()
+     .filter(f => f.includes('.csv'))
+     .map(iodide.file.lastUpdated)
+)
+```
+
+
+
 ## `iodide.addOutputRenderer(rendererSpecification)`
 
 Adds a custom output renderer to Iodide.

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -515,3 +515,12 @@ export function setConnectionStatus(status) {
     status
   };
 }
+
+export function addFile(filename, lastUpdated, fileId) {
+  return {
+    type: "ADD_FILE_TO_NOTEBOOK",
+    filename,
+    lastUpdated,
+    fileId
+  };
+}

--- a/src/actions/evaluation-queue.js
+++ b/src/actions/evaluation-queue.js
@@ -52,7 +52,7 @@ export class EvaluationQueue {
   }
 
   clear(evalId) {
-    this.evaluationResolvers[evalId].reject();
+    if (evalId) this.evaluationResolvers[evalId].reject();
     this.evaluationResolvers = {};
     this.queue = Promise.resolve();
     return this;

--- a/src/eval-frame/iodide-api/__test__/file-mocks.js
+++ b/src/eval-frame/iodide-api/__test__/file-mocks.js
@@ -1,0 +1,13 @@
+export const store = {
+  getState() {
+    return {
+      notebookInfo: {
+        files: [
+          { name: "file1.csv" },
+          { name: "file2.csv" },
+          { name: "file3.csv" }
+        ]
+      }
+    };
+  }
+};

--- a/src/eval-frame/iodide-api/__test__/file-mocks.js
+++ b/src/eval-frame/iodide-api/__test__/file-mocks.js
@@ -3,9 +3,9 @@ export const store = {
     return {
       notebookInfo: {
         files: [
-          { name: "file1.csv" },
-          { name: "file2.csv" },
-          { name: "file3.csv" }
+          { filename: "file1.csv", id: 0, lastUpdated: "yesterday" },
+          { filename: "file2.csv", id: 1, lastUpdated: "tomorrow" },
+          { filename: "file3.csv", id: 2, lastUpdated: "never" }
         ]
       }
     };

--- a/src/eval-frame/iodide-api/__test__/file.test.js
+++ b/src/eval-frame/iodide-api/__test__/file.test.js
@@ -1,0 +1,28 @@
+import { connectList, connectExists } from "../file";
+
+import { store } from "./file-mocks";
+
+describe("save", () => {});
+
+describe("load", () => {});
+
+describe("iodide.file.list", () => {
+  const list = connectList(store);
+  it("lists all the files available to the current notebook", () => {
+    const files = list();
+    expect(files).toEqual(["file1.csv", "file2.csv", "file3.csv"]);
+  });
+});
+
+describe("iodide.file.exists", () => {
+  const exists = connectExists(store);
+  it("returns true / false if a file exists / doesn't exist", () => {
+    expect(exists("file1.csv")).toBe(true);
+    expect(exists("nonexistant-file.json")).toBe(false);
+  });
+  it("throws if something other than a string is passed in", () => {
+    expect(() => exists()).toThrow();
+    expect(() => exists(12345)).toThrow();
+    expect(() => exists(new Date())).toThrow();
+  });
+});

--- a/src/eval-frame/iodide-api/api.js
+++ b/src/eval-frame/iodide-api/api.js
@@ -6,6 +6,7 @@
 import UserReps from "../../components/reps/user-reps-manager";
 import { environment } from "./environment";
 import { output } from "./output";
+import { file } from "./file";
 
 function getDataSync(url) {
   const re = new XMLHttpRequest();
@@ -31,6 +32,7 @@ containing the fields "shouldRender" and "render`);
   getDataSync,
   environment,
   output,
+  file,
   VERSION: IODIDE_VERSION
 };
 

--- a/src/eval-frame/iodide-api/file.js
+++ b/src/eval-frame/iodide-api/file.js
@@ -28,13 +28,13 @@ export function connectExists(store) {
       );
     }
     const { files } = store.getState().notebookInfo;
-    return files.map(f => f.name).includes(fileName);
+    return files.map(f => f.filename).includes(fileName);
   };
 }
 
 export function connectList(store) {
   return function list() {
-    return store.getState().notebookInfo.files.map(f => f.name);
+    return store.getState().notebookInfo.files.map(f => f.filename);
   };
 }
 

--- a/src/eval-frame/iodide-api/file.js
+++ b/src/eval-frame/iodide-api/file.js
@@ -1,0 +1,62 @@
+import { store as reduxStore } from "../store";
+import fetchFileFromParentContext from "../tools/fetch-file-from-parent-context";
+import saveFileInParentContext from "../tools/save-file-in-parent-context";
+
+const VARIABLE_TYPE_FILES = ["text", "json", "blob"];
+
+// custom file saving functionality, needs to work like fetchFromParentContext or whatever?
+
+export function connectLoad(fetchFunction) {
+  return async function load(fileName, fileType, variableName = undefined) {
+    return fetchFunction(`files/${fileName}`, fileType).then(file => {
+      if (VARIABLE_TYPE_FILES.includes(fileType) && variableName) {
+        window[variableName] = file;
+      }
+      // set window, if applicable
+      return file;
+    });
+  };
+}
+
+export function deleteFile() {}
+
+export function connectExists(store) {
+  return function exists(fileName) {
+    if (!(typeof fileName === "string" || fileName instanceof String)) {
+      throw new Error(
+        `fileName must be a string, instead received ${typeof fileName}`
+      );
+    }
+    const { files } = store.getState().notebookInfo;
+    return files.map(f => f.name).includes(fileName);
+  };
+}
+
+export function connectList(store) {
+  return function list() {
+    return store.getState().notebookInfo.files.map(f => f.name);
+  };
+}
+
+export function connectSave(store, saveFunction) {
+  return function save(data, fileName, saveOptions = { overwrite: true }) {
+    // first thing first = check to see if exists in store.
+    const exists = connectExists(store);
+    if (!saveOptions.overwrite && exists(fileName)) {
+      throw new Error("cannot overwrite this file ughhhh!!!!!!");
+    }
+    return saveFunction(
+      store.getState().notebookInfo.notebook_id,
+      data,
+      fileName
+    );
+  };
+}
+
+export const file = {
+  save: connectSave(reduxStore, saveFileInParentContext),
+  load: connectLoad(fetchFileFromParentContext),
+  delete: deleteFile,
+  exists: connectExists(reduxStore),
+  list: connectList(reduxStore)
+};

--- a/src/eval-frame/iodide-api/file.js
+++ b/src/eval-frame/iodide-api/file.js
@@ -6,6 +6,10 @@ const VARIABLE_TYPE_FILES = ["text", "json", "blob"];
 
 // custom file saving functionality, needs to work like fetchFromParentContext or whatever?
 
+function getFiles(store) {
+  return store.getState().notebookInfo.files;
+}
+
 export function connectLoad(fetchFunction) {
   return async function load(fileName, fileType, variableName = undefined) {
     return fetchFunction(`files/${fileName}`, fileType).then(file => {
@@ -43,12 +47,23 @@ export function connectSave(store, saveFunction) {
     // first thing first = check to see if exists in store.
     const exists = connectExists(store);
     if (!saveOptions.overwrite && exists(fileName)) {
-      throw new Error("cannot overwrite this file ughhhh!!!!!!");
+      throw new Error(
+        `file ${fileName} already exists. Try setting overwrite: true`
+      );
     }
+
+    const updateFile = saveOptions.overwrite && exists(fileName);
+    const files = getFiles(store);
+    const fileID = exists(fileName)
+      ? files[files.findIndex(f => f.filename === fileName)].id
+      : undefined;
+
     return saveFunction(
       store.getState().notebookInfo.notebook_id,
       data,
-      fileName
+      fileName,
+      updateFile, // this flag tells us if we need to update the file
+      fileID // for updating the file
     );
   };
 }

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -7,6 +7,10 @@ import {
   onParentContextFileFetchError
 } from "./tools/fetch-file-from-parent-context";
 import messagePasserEval from "../redux-to-port-message-passer";
+import {
+  onParentContextFileSaveSuccess,
+  onParentContextFileSaveError
+} from "./tools/save-file-in-parent-context";
 
 const mc = new MessageChannel();
 const portToEditor = mc.port1;
@@ -54,6 +58,14 @@ function receiveMessage(event) {
           type: "REPLACE_STATE",
           state: message
         });
+        break;
+      }
+      case "FILE_SAVED_SUCCESS": {
+        onParentContextFileSaveSuccess(message.path);
+        break;
+      }
+      case "FILE_SAVED_ERROR": {
+        onParentContextFileSaveError(message.reason, message.path);
         break;
       }
       case "REQUESTED_FILE_SUCCESS": {

--- a/src/eval-frame/tools/fetch-file-from-parent-context.js
+++ b/src/eval-frame/tools/fetch-file-from-parent-context.js
@@ -29,6 +29,7 @@ export default async function fetchFileFromParentContext(path, fetchType) {
   return new Promise((resolve, reject) => {
     // resolve and reject are handled in port-to-editor.js when
     // the file is received by the editor.
+    console.log(path, fetchType);
     addResolvers(path, resolve, reject);
     messagePasserEval.postMessage("REQUEST_FETCH", { path, fetchType });
   });

--- a/src/eval-frame/tools/save-file-in-parent-context.js
+++ b/src/eval-frame/tools/save-file-in-parent-context.js
@@ -1,0 +1,35 @@
+import { postMessageToEditor } from "../port-to-editor";
+
+const SAVE_FILE_RESOLVERS = {};
+
+function addResolvers(path, resolve, reject) {
+  SAVE_FILE_RESOLVERS[path] = { resolve, reject };
+}
+
+function getResolvers(path) {
+  return SAVE_FILE_RESOLVERS[path];
+}
+
+function deleteResolvers(path) {
+  delete SAVE_FILE_RESOLVERS[path];
+}
+
+export function onParentContextFileSaveSuccess(path) {
+  getResolvers(path).resolve();
+  deleteResolvers(path);
+}
+
+export function onParentContextFileSaveError(reason, path) {
+  getResolvers(path).reject(new Error(reason));
+  deleteResolvers(path);
+}
+
+export default async function saveFileInParentContext(notebookID, data, path) {
+  // used in eval frame.
+  return new Promise((resolve, reject) => {
+    // resolve and reject are handled in port-to-editor.js when
+    // the file is received by the editor.
+    addResolvers(path, resolve, reject);
+    postMessageToEditor("SAVE_FILE", { notebookID, path, data });
+  });
+}

--- a/src/eval-frame/tools/save-file-in-parent-context.js
+++ b/src/eval-frame/tools/save-file-in-parent-context.js
@@ -24,12 +24,24 @@ export function onParentContextFileSaveError(reason, path) {
   deleteResolvers(path);
 }
 
-export default async function saveFileInParentContext(notebookID, data, path) {
+export default async function saveFileInParentContext(
+  notebookID,
+  data,
+  path,
+  updateFile = false,
+  fileID = undefined
+) {
   // used in eval frame.
   return new Promise((resolve, reject) => {
     // resolve and reject are handled in port-to-editor.js when
     // the file is received by the editor.
     addResolvers(path, resolve, reject);
-    postMessageToEditor("SAVE_FILE", { notebookID, path, data });
+    postMessageToEditor("SAVE_FILE", {
+      notebookID,
+      path,
+      data,
+      updateFile,
+      fileID
+    });
   });
 }

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -9,7 +9,6 @@ import {
 } from "./actions/actions";
 import { evalConsoleInput } from "./actions/console-actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
-import createHistoryItem from "./tools/create-history-item";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
 import messagePasserEditor from "./redux-to-port-message-passer";

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -4,7 +4,8 @@ import Mousetrap from "mousetrap";
 import {
   addLanguage,
   setKernelState,
-  updateAppMessages
+  updateAppMessages,
+  addFile
 } from "./actions/actions";
 import { evalConsoleInput } from "./actions/console-actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
@@ -59,19 +60,21 @@ function receiveMessage(event) {
         break;
       }
       case "SAVE_FILE": {
-        saveFileToServer(message.notebookID, message.data, message.path).then(
-          () => {
+        saveFileToServer(message.notebookID, message.data, message.path)
+          .then(r => r.json())
+          .then(fileInfo => {
+            const { filename, lastUpdated, id } = fileInfo;
             postMessageToEvalFrame("FILE_SAVED_SUCCESS", {
-              path: message.path
+              path: filename
             });
             messagePasserEditor.dispatch(
               updateAppMessages({
-                message: `file ${message.path} saved`,
+                message: `file ${filename} saved`,
                 messageType: `NOTEBOOK_SAVED`
               })
             );
-          }
-        );
+            messagePasserEditor.dispatch(addFile(filename, lastUpdated, id));
+          });
         break;
       }
       case "REQUEST_FETCH": {

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -79,18 +79,25 @@ function receiveMessage(event) {
               })
             );
             messagePasserEditor.dispatch(addFile(filename, lastUpdated, id));
+            postMessageToEvalFrame("FILE_SAVED_SUCCESS", {
+              path
+            });
           })
           .catch(err => {
-            // we need to error here.
-            evalQueue.clear();
-            const historyAction = createHistoryItem({
-              content: err.message,
-              level: "ERROR",
-              historyType: "CONSOLE_MESSAGE"
+            postMessageToEvalFrame("FILE_SAVED_ERROR", {
+              reason: err.message,
+              path
             });
-            historyAction.type = "ADD_TO_CONSOLE_HISTORY";
-            messagePasserEditor.dispatch(historyAction);
-            messagePasserEditor.dispatch(setKernelState("KERNEL_IDLE"));
+            // we need to error here.
+            // evalQueue.clear();
+            // const historyAction = createHistoryItem({
+            //   content: err.message,
+            //   level: "ERROR",
+            //   historyType: "CONSOLE_MESSAGE"
+            // });
+            // historyAction.type = "ADD_TO_CONSOLE_HISTORY";
+            // messagePasserEditor.dispatch(historyAction);
+            // messagePasserEditor.dispatch(setKernelState("KERNEL_IDLE"));
           });
         break;
       }

--- a/src/port-to-eval-frame.js
+++ b/src/port-to-eval-frame.js
@@ -1,12 +1,17 @@
 /* global IODIDE_EVAL_FRAME_ORIGIN  */
 
 import Mousetrap from "mousetrap";
-import { addLanguage, setKernelState } from "./actions/actions";
+import {
+  addLanguage,
+  setKernelState,
+  updateAppMessages
+} from "./actions/actions";
 import { evalConsoleInput } from "./actions/console-actions";
 import { genericFetch as fetchFileFromServer } from "./tools/fetch-tools";
 import evalQueue from "./actions/evaluation-queue";
 import validateActionFromEvalFrame from "./actions/eval-frame-action-validator";
 import messagePasserEditor from "./redux-to-port-message-passer";
+import { saveFileToServer } from "./shared/upload-file";
 
 let portToEvalFrame;
 
@@ -51,6 +56,22 @@ function receiveMessage(event) {
         if (!queueSize) {
           messagePasserEditor.dispatch(setKernelState("KERNEL_IDLE"));
         }
+        break;
+      }
+      case "SAVE_FILE": {
+        saveFileToServer(message.notebookID, message.data, message.path).then(
+          () => {
+            postMessageToEvalFrame("FILE_SAVED_SUCCESS", {
+              path: message.path
+            });
+            messagePasserEditor.dispatch(
+              updateAppMessages({
+                message: `file ${message.path} saved`,
+                messageType: `NOTEBOOK_SAVED`
+              })
+            );
+          }
+        );
         break;
       }
       case "REQUEST_FETCH": {

--- a/src/reducers/notebook-reducer.js
+++ b/src/reducers/notebook-reducer.js
@@ -204,6 +204,25 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
+    case "ADD_FILE_TO_NOTEBOOK": {
+      const { filename, lastUpdated, fileId } = action;
+      const { files } = state.notebookInfo;
+      if (!files.map(f => f.filename).includes(filename))
+        files.push({
+          filename,
+          lastUpdated,
+          id: fileId
+        });
+      else {
+        const i = files.findIndex(f => f.filename === filename);
+        files[i].lastUpdated = lastUpdated;
+      }
+      const notebookInfo = Object.assign({}, state.notebookInfo, {
+        files
+      });
+      return Object.assign({}, state, { notebookInfo });
+    }
+
     case "ADD_NOTEBOOK_ID": {
       const notebookId = action.id;
       const notebookInfo = Object.assign({}, state.notebookInfo);

--- a/src/shared/upload-file.js
+++ b/src/shared/upload-file.js
@@ -43,14 +43,9 @@ export function makeFormData(notebookID, data, fileName) {
 
 export function uploadFile(formData) {
   return fetchWithCSRFToken("/api/v1/files/", {
-    body: formData,
-    method: "POST"
+    method: "POST",
+    body: formData
   });
-}
-
-export function saveFileToServer(notebookID, data, fileName) {
-  const formData = makeFormData(notebookID, data, fileName);
-  return uploadFile(formData);
 }
 
 export function updateFile(fileID, formData) {
@@ -58,6 +53,20 @@ export function updateFile(fileID, formData) {
     method: "PUT",
     body: formData
   });
+}
+
+export function saveFileToServer(
+  notebookID,
+  data,
+  fileName,
+  updateFileFlag = false,
+  fileID = undefined
+) {
+  const formData = makeFormData(notebookID, data, fileName);
+  const fetchRequest = updateFileFlag
+    ? fd => updateFile(fileID, fd)
+    : fd => uploadFile(fd);
+  return fetchRequest(formData);
 }
 
 export function selectAndUploadFile(notebookID, successCallback = () => {}) {
@@ -68,7 +77,6 @@ export function selectAndUploadFile(notebookID, successCallback = () => {}) {
   filePicker.click();
   filePicker.addEventListener("change", evt => {
     const file = evt.target.files[0];
-    console.log(file);
     const formData = new FormData();
     formData.append(
       "metadata",

--- a/src/shared/upload-file.js
+++ b/src/shared/upload-file.js
@@ -23,11 +23,34 @@ export function selectFileAndFormatMetadata(notebookID) {
   });
 }
 
+export function valueToFile(data, fileName) {
+  return new File([data], fileName);
+}
+
+export function makeFormData(notebookID, data, fileName) {
+  const file = valueToFile(data, fileName);
+  const formData = new FormData();
+  formData.append(
+    "metadata",
+    JSON.stringify({
+      filename: file.name,
+      notebook_id: notebookID
+    })
+  );
+  formData.append("file", file);
+  return formData;
+}
+
 export function uploadFile(formData) {
   return fetchWithCSRFToken("/api/v1/files/", {
     body: formData,
     method: "POST"
   });
+}
+
+export function saveFileToServer(notebookID, data, fileName) {
+  const formData = makeFormData(notebookID, data, fileName);
+  return uploadFile(formData);
 }
 
 export function updateFile(fileID, formData) {
@@ -45,6 +68,7 @@ export function selectAndUploadFile(notebookID, successCallback = () => {}) {
   filePicker.click();
   filePicker.addEventListener("change", evt => {
     const file = evt.target.files[0];
+    console.log(file);
     const formData = new FormData();
     formData.append(
       "metadata",

--- a/src/state-schemas/eval-frame-state-selector.js
+++ b/src/state-schemas/eval-frame-state-selector.js
@@ -15,7 +15,8 @@ const propsToCopy = [
   "panePositions.WorkspacePositioner",
   "savedEnvironment",
   "userDefinedVarNames",
-  "viewMode"
+  "viewMode",
+  "notebookInfo"
 ];
 
 export default function evalFrameStateSelector(state) {

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -101,6 +101,15 @@ const cursorPositionSchema = {
   additionalProperties: false
 };
 
+const fileSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string", default: "" },
+    lastUpdated: { type: "string", default: "" }
+  },
+  additionalProperties: false
+};
+
 export const stateProperties = {
   appMessages: {
     type: "array",
@@ -288,7 +297,8 @@ export const stateProperties = {
         type: "string",
         enum: ["SERVER", "STANDALONE"]
       },
-      tryItMode: { type: "boolean" }
+      tryItMode: { type: "boolean" },
+      files: { type: "array", items: fileSchema }
     },
     default: {
       notebook_id: undefined,

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -101,15 +101,6 @@ const cursorPositionSchema = {
   additionalProperties: false
 };
 
-const fileSchema = {
-  type: "object",
-  properties: {
-    name: { type: "string", default: "" },
-    lastUpdated: { type: "string", default: "" }
-  },
-  additionalProperties: false
-};
-
 export const stateProperties = {
   appMessages: {
     type: "array",
@@ -297,8 +288,7 @@ export const stateProperties = {
         type: "string",
         enum: ["SERVER", "STANDALONE"]
       },
-      tryItMode: { type: "boolean" },
-      files: { type: "array", items: fileSchema }
+      tryItMode: { type: "boolean" }
     },
     default: {
       notebook_id: undefined,


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not

This is an API proposal for `iodide.file`, which gives programmatic file read-write access in our "virtual" file environment (the server). It proposes `iodide.file.save`, `iodide.file.load`, `iodide.file.delete`, `iodide.file.list`, `iodide.file.exists`, and `iodide.file.lastUpdated`.

The `iodide.file.load` API specifically is meant to mirror the fetch chunk API, generally, but only for uploaded files. The goal is **not** to replace the fetch chunks - rather, it's about unlocking the kind of file-ish workflows a lot of users might be expecting. For most use cases we should still be pushing users towards using the fetch chunk, because it is substantially more straightforward than using this API for basic uses.

I thought I'd try writing some docs around this proposed API to get the conversation going before actually implementing, so others can see what I had in mind before I did the actual work / suggest changes.

Some notes:

- this is likely blocked a bit by the file uploader branch that @openjck is working on, mostly because I think we will want to have each notebook have all the file names / metadata for files loaded in the store from the server, and he'll likely get to that in his work before I do.
- I think this PR also is blocked by fixing #597 so we can make sure to block further chunk evaluation on the Promises returned by `iodide.file.load`, `iodide.file.save`, and `iodide.file.delete`. After migrating to the cell-less flat-text world, I see more merit to this approach than I did before, and I think that if programmatic file access is what we get from making sequential these async return values, then so be it.
- @mdboom I'm especially curious to hear your thoughts and how this might interop with language plugins. I want to make it easy to use this stuff from within pyodide and other languages without introducing too much overhead.
- I would encourage everyone to also spend some time thinking about the implications of this direction. This means I can actually do a bunch of expensive computations in my notebook and cache them for others pretty easily. It also might open the door to do a "server-side" evaluation of an expensive notebook, especially if that could lead to generating cached data that makes notebooks load more quickly.
- (EDIT) I have not really considered what will happen if a user does not own the notebook and they are attempting to use `iodide.file.save` or `iodide.file.delete`. Perhaps there is an option we can include in those to ignore such calls, or just throw an error. Thoughts here would be appreciated.