### PR TITLE
brings file metadata into the notebook client

### DIFF
--- a/server/base/admin.py
+++ b/server/base/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import User
 
 

--- a/server/files/urls.py
+++ b/server/files/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
-from .views import file_view
 from ..settings import MAX_FILENAME_LENGTH
+from .views import file_view
 
 urlpatterns = [
     url(

--- a/server/notebooks/names.py
+++ b/server/notebooks/names.py
@@ -1,6 +1,5 @@
 import random
 
-
 IODINE_COMPOUNDS = [
     "2-amino-5-iodopyridine",
     "4-iodoaniline",

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -33,6 +33,13 @@ def notebook_view(request, pk):
         revision = get_object_or_404(NotebookRevision, pk=int(request.GET["revision"]))
     else:
         revision = notebook.revisions.first()
+    files = [
+        {
+            'filename': file.filename,
+            'id': file.id,
+            'lastUpdated': file.last_updated.isoformat()
+        }
+        for file in File.objects.filter(notebook_id=pk).order_by("-last_updated")]
     notebook_info = {
         "username": notebook.owner.username,
         "user_can_save": notebook.owner_id == request.user.id,
@@ -40,6 +47,7 @@ def notebook_view(request, pk):
         "revision_id": revision.id,
         "connectionMode": "SERVER",
         "title": revision.title,
+        "files": files
     }
     if notebook.forked_from is not None:
         notebook_info["forked_from"] = notebook.forked_from.id

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -6,11 +6,11 @@ from django.template.loader import get_template
 from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from .models import Notebook, NotebookRevision
 from ..base.models import User
 from ..files.models import File
 from ..settings import APP_VERSION_STRING, EVAL_FRAME_ORIGIN
 from ..views import get_user_info_dict
+from .models import Notebook, NotebookRevision
 from .names import get_random_compound
 
 
@@ -34,12 +34,9 @@ def notebook_view(request, pk):
     else:
         revision = notebook.revisions.first()
     files = [
-        {
-            'filename': file.filename,
-            'id': file.id,
-            'lastUpdated': file.last_updated.isoformat()
-        }
-        for file in File.objects.filter(notebook_id=pk).order_by("-last_updated")]
+        {"filename": file.filename, "id": file.id, "lastUpdated": file.last_updated.isoformat()}
+        for file in File.objects.filter(notebook_id=pk).order_by("-last_updated")
+    ]
     notebook_info = {
         "username": notebook.owner.username,
         "user_can_save": notebook.owner_id == request.user.id,
@@ -47,7 +44,7 @@ def notebook_view(request, pk):
         "revision_id": revision.id,
         "connectionMode": "SERVER",
         "title": revision.title,
-        "files": files
+        "files": files,
     }
     if notebook.forked_from is not None:
         notebook_info["forked_from"] = notebook.forked_from.id

--- a/server/urls.py
+++ b/server/urls.py
@@ -7,7 +7,6 @@ from django.views.generic.base import RedirectView
 
 import server.views
 
-
 admin.site.unregister(Group)  # Hide the group, not used right now
 
 

--- a/src/eval-frame/index.jsx
+++ b/src/eval-frame/index.jsx
@@ -31,7 +31,6 @@ window.iodide = iodide;
 initializeDefaultKeybindings();
 // initialize variables available to the user in an empty notebook, such as
 // the iodide API.
-
 render(
   <CSSCascadeProvider>
     <Provider store={store}>

--- a/src/state-schemas/state-schema.js
+++ b/src/state-schemas/state-schema.js
@@ -54,6 +54,16 @@ export const languageSchema = {
   additionalProperties: false
 };
 
+export const fileSchema = {
+  type: "object",
+  properties: {
+    filename: { type: "string" },
+    id: { type: "integer" },
+    lastUpdated: { type: "string" }
+  },
+  additionalProperties: false
+};
+
 const environmentVariableSchema = {
   type: "array",
   items: [
@@ -269,6 +279,7 @@ export const stateProperties = {
     properties: {
       user_can_save: { type: "boolean" },
       notebook_id: { type: "integer" },
+      files: { type: "array", items: fileSchema },
       connectionStatus: {
         type: "string",
         enum: ["CONNECTION_ACTIVE", "CONNECTION_LOST"]
@@ -283,7 +294,8 @@ export const stateProperties = {
       notebook_id: undefined,
       user_can_save: false,
       connectionMode: "STANDALONE",
-      connectionStatus: "CONNECTION_ACTIVE"
+      connectionStatus: "CONNECTION_ACTIVE",
+      files: []
     }
   },
   panePositions: {


### PR DESCRIPTION
This brings in associated files into the notebook, which seeks to give a common basis to work on #1651 and the in-notebook file uploader (which has not been filed as of this PR).

I noticed that `make lintfix` fixed a few files that were in our repository that I did not touch. Apologies - it seems like those probably should have gotten linted before, I'm guessing?

@openjck plz let me know if this has everything you need for your work.