### PR TITLE
Allow the microphone in the iframe

### DIFF
--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -11,6 +11,7 @@
   sandbox="allow-scripts allow-same-origin allow-popups"
   allowfullscreen="true"
   allowvr="yes"
+  allow="microphone"
 ></iframe>
 {{ user_info|json_script:"userData" }}
 {{ notebook_info|json_script:"notebookInfo" }}


### PR DESCRIPTION
This change is required to make access to the microphone through the Web Audio API work.

See this example notebook (currently broken on `alpha.iodide.io` obviously):

https://alpha.iodide.io/notebooks/1440/

I am not a security expert, so feel free to reject this on security grounds.  However, my understanding is that the default that iframe's don't have access is based on the fact that iframes are often given over to third-parties (ad servers) to provide.  In this case, we control both the main and iframes, and we already allow all kinds of arbitrary code to run in the iframe.  Additionally, there is still an explicit permission pop-up, a flashing red microphone icon and a tray indicator.

All that said, the use case I have in mind here is just to create a cool demo ;)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
