### PR TITLE
solve high cpu usage of start-and-serve

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,7 +107,7 @@ module.exports = env => {
         }
       ]
     },
-    watchOptions: { poll: true },
+    watchOptions: { poll: true, ignored: /node_modules/ },
     plugins: [
       ...plugins,
       new CircularDependencyPlugin({


### PR DESCRIPTION
Hi,
I experienced high (200%) CPU usage of node even when passively serving static files. This solves the issue.