### PR TITLE
fixes bug where notebooks / revisions cannot be deleted from server

### DIFF
--- a/src/server/components/delete-modal.jsx
+++ b/src/server/components/delete-modal.jsx
@@ -25,19 +25,16 @@ export default class DeleteModal extends React.Component {
     this.deleteObject = this.deleteObject.bind(this);
   }
 
-  deleteObject() {
+  async deleteObject() {
     // add delete here
-
-    this.props
-      .deleteFunction(this.props.elementID)
-      .then(() => {
-        this.props.onClose();
-        this.props.onDelete(this.props.elementID);
-      })
-      .catch(err => {
-        // FIXME: need a better reporting mechanism for delete failures
-        console.error(err);
-      });
+    try {
+      await this.props.deleteFunction(this.props.elementID);
+      this.props.onClose();
+      this.props.onDelete(this.props.elementID);
+    } catch (err) {
+      // FIXME: need a better reporting mechanism for delete failures
+      console.error(err);
+    }
   }
 
   render() {

--- a/src/server/components/delete-modal.jsx
+++ b/src/server/components/delete-modal.jsx
@@ -5,7 +5,6 @@ import ModalTitle from "../../shared/components/modal-title";
 import ModalContent from "../../shared/components/modal-content";
 import ModalCall from "../../shared/components/modal-call";
 import { TextButton } from "../../shared/components/buttons";
-import { deleteFileOnServer } from "../../shared/utils/file-operations";
 
 export default class DeleteModal extends React.Component {
   static propTypes = {
@@ -29,7 +28,8 @@ export default class DeleteModal extends React.Component {
   deleteObject() {
     // add delete here
 
-    deleteFileOnServer(this.props.elementID)
+    this.props
+      .deleteFunction(this.props.elementID)
       .then(() => {
         this.props.onClose();
         this.props.onDelete(this.props.elementID);

--- a/src/server/components/delete-modal.jsx
+++ b/src/server/components/delete-modal.jsx
@@ -14,6 +14,7 @@ export default class DeleteModal extends React.Component {
     onCancel: PropTypes.func,
     visible: PropTypes.bool,
     title: PropTypes.string,
+    deleteFunction: PropTypes.func,
     content: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.string,

--- a/src/server/components/delete-modal.jsx
+++ b/src/server/components/delete-modal.jsx
@@ -35,6 +35,7 @@ export default class DeleteModal extends React.Component {
         this.props.onDelete(this.props.elementID);
       })
       .catch(err => {
+        // FIXME: need a better reporting mechanism for delete failures
         console.error(err);
       });
   }

--- a/src/server/components/file-actions-menu.jsx
+++ b/src/server/components/file-actions-menu.jsx
@@ -55,7 +55,6 @@ export default class FileActionsMenu extends React.Component {
           onClose={this.hideDeleteModal}
           title={`delete the file  "${this.props.filename}"?`}
           deleteFunction={deleteFileOnServer}
-          // url={`/api/v1/files/${this.props.fileID}`}
           content={this.props.modalBody}
           onCancel={this.hideDeleteModal}
           onDelete={this.props.onDelete}

--- a/src/server/components/file-actions-menu.jsx
+++ b/src/server/components/file-actions-menu.jsx
@@ -4,6 +4,7 @@ import Popover from "../../shared/components/popover";
 import Menu from "../../shared/components/menu";
 import MenuItem from "../../shared/components/menu-item";
 import DeleteModal from "./delete-modal";
+import { deleteFileOnServer } from "../../shared/utils/file-operations";
 
 export default class FileActionsMenu extends React.Component {
   static propTypes = {
@@ -53,11 +54,12 @@ export default class FileActionsMenu extends React.Component {
           visible={this.state.deleteModalVisible}
           onClose={this.hideDeleteModal}
           title={`delete the file  "${this.props.filename}"?`}
+          deleteFunction={deleteFileOnServer}
+          // url={`/api/v1/files/${this.props.fileID}`}
           content={this.props.modalBody}
           onCancel={this.hideDeleteModal}
           onDelete={this.props.onDelete}
           elementID={this.props.fileID}
-          url={`/api/v1/files/${this.props.fileID}`}
         />
       </React.Fragment>
     );

--- a/src/server/components/notebook-actions-menu.jsx
+++ b/src/server/components/notebook-actions-menu.jsx
@@ -9,7 +9,8 @@ import UploadModal from "./upload-modal";
 import {
   selectFileAndFormatMetadata,
   uploadFile,
-  updateFile
+  updateFile,
+  deleteNotebookOnServer
 } from "../../shared/utils/file-operations";
 
 export default class NotebookActionsMenu extends React.Component {
@@ -163,7 +164,7 @@ export default class NotebookActionsMenu extends React.Component {
           onCancel={this.hideDeleteModal}
           onDelete={this.props.onDelete}
           elementID={this.props.notebookID}
-          url={`/api/v1/notebooks/${this.props.notebookID}/`}
+          deleteFunction={deleteNotebookOnServer}
         />
         <UploadModal
           visible={this.state.uploadFileConfirmationVisible}

--- a/src/server/components/notebook-actions-menu.jsx
+++ b/src/server/components/notebook-actions-menu.jsx
@@ -9,7 +9,6 @@ import UploadModal from "./upload-modal";
 import {
   selectFileAndFormatMetadata,
   uploadFile,
-  updateFile,
   deleteNotebookOnServer
 } from "../../shared/utils/file-operations";
 
@@ -91,7 +90,7 @@ export default class NotebookActionsMenu extends React.Component {
   }
 
   updateFile() {
-    return updateFile(this.state.oldFile.id, this.state.newFile)
+    return uploadFile(this.state.newFile, this.state.oldFile.id)
       .then(response => response.json())
       .then(response => {
         if (this.props.onUploadFile) this.props.onUploadFile(response);

--- a/src/server/components/notebook-actions-menu.jsx
+++ b/src/server/components/notebook-actions-menu.jsx
@@ -81,21 +81,19 @@ export default class NotebookActionsMenu extends React.Component {
     });
   }
 
-  uploadFile(formData) {
-    return uploadFile(formData)
-      .then(response => response.json())
-      .then(response => {
-        if (this.props.onUploadFile) this.props.onUploadFile(response);
-      });
+  async uploadFile(formData) {
+    const response = await uploadFile(formData).then(r => r.json());
+    // FIXME: uploadFile needs better error handling.
+    if (this.props.onUploadFile) this.props.onUploadFile(response);
   }
 
-  updateFile() {
-    return uploadFile(this.state.newFile, this.state.oldFile.id)
-      .then(response => response.json())
-      .then(response => {
-        if (this.props.onUploadFile) this.props.onUploadFile(response);
-        this.hideUploadFileConfirmationModal();
-      });
+  async updateFile() {
+    const response = await uploadFile(
+      this.state.newFile,
+      this.state.oldFile.id
+    ).then(r => r.json());
+    if (this.props.onUploadFile) this.props.onUploadFile(response);
+    this.hideUploadFileConfirmationModal();
   }
 
   hideDeleteModal() {

--- a/src/server/components/notebook-actions-menu.jsx
+++ b/src/server/components/notebook-actions-menu.jsx
@@ -82,17 +82,19 @@ export default class NotebookActionsMenu extends React.Component {
   }
 
   async uploadFile(formData) {
-    const response = await uploadFile(formData).then(r => r.json());
+    const response = await uploadFile(formData);
     // FIXME: uploadFile needs better error handling.
-    if (this.props.onUploadFile) this.props.onUploadFile(response);
+    const data = await response.json();
+    if (this.props.onUploadFile) this.props.onUploadFile(data);
   }
 
   async updateFile() {
     const response = await uploadFile(
       this.state.newFile,
       this.state.oldFile.id
-    ).then(r => r.json());
-    if (this.props.onUploadFile) this.props.onUploadFile(response);
+    );
+    const data = await response.json();
+    if (this.props.onUploadFile) this.props.onUploadFile(data);
     this.hideUploadFileConfirmationModal();
   }
 

--- a/src/server/components/revision-actions-menu.jsx
+++ b/src/server/components/revision-actions-menu.jsx
@@ -5,6 +5,7 @@ import Menu from "../../shared/components/menu";
 import MenuItem from "../../shared/components/menu-item";
 import MenuDivider from "../../shared/components/menu-divider";
 import DeleteModal from "./delete-modal";
+import { deleteRevisionOnServer } from "../../shared/utils/file-operations";
 
 export default class RevisionsActionsMenu extends React.Component {
   static propTypes = {
@@ -65,9 +66,9 @@ export default class RevisionsActionsMenu extends React.Component {
           onCancel={this.hideDeleteModal}
           onDelete={this.props.onDelete}
           elementID={this.props.revisionID}
-          url={`/api/v1/notebooks/${this.props.notebookID}/revisions/${
-            this.props.revisionID
-          }`}
+          deleteFunction={revisionID =>
+            deleteRevisionOnServer(this.props.notebookID, revisionID)
+          }
         />
       </React.Fragment>
     );

--- a/src/shared/utils/file-operations.js
+++ b/src/shared/utils/file-operations.js
@@ -84,17 +84,16 @@ export function makeFormData(notebookID, data, fileName) {
   return formData;
 }
 
-export function saveFileToServer(
+export async function saveFileToServer(
   notebookID,
   data,
   fileName,
   fileID = undefined
 ) {
   const formData = makeFormData(notebookID, data, fileName);
-  return uploadFile(formData, fileID).then(r => {
-    if (r.status === 500) throw new Error(r.statusText);
-    return r.json();
-  });
+  const r = await uploadFile(formData, fileID);
+  if (r.status === 500) throw new Error(r.statusText);
+  return r.json();
 }
 
 export function makeDeleteRequest(url) {

--- a/src/shared/utils/file-operations.js
+++ b/src/shared/utils/file-operations.js
@@ -38,9 +38,11 @@ export function uploadFile(formData, fileID = undefined) {
   // if fileID not defined, this will upload the file, or return an error if
   // the filename in formData is already in the files table.
   // if fileID is provided, will attempt to update the entry in the files table.
-  return fetchWithCSRFToken(`/api/v1/files/${fileID ? `${fileID}/` : ""}`, {
+  const url = fileID ? `/api/v1/files/${fileID}/` : `/api/v1/files/`;
+  const method = fileID ? "PUT" : "POST";
+  return fetchWithCSRFToken(url, {
     body: formData,
-    method: fileID ? "PUT" : "POST"
+    method
   });
 }
 
@@ -96,7 +98,7 @@ export async function saveFileToServer(
   return r.json();
 }
 
-export function makeDeleteRequest(url) {
+export function makeDeleteRequestPRIVATE(url) {
   return fetchWithCSRFTokenAndJSONContent(url, { method: "DELETE" }).then(r => {
     if (r.status === 500) throw new Error(r.statusText);
     return undefined;
@@ -104,15 +106,15 @@ export function makeDeleteRequest(url) {
 }
 
 export function deleteNotebookOnServer(notebookID) {
-  return makeDeleteRequest(`/api/v1/notebooks/${notebookID}`);
+  return makeDeleteRequestPRIVATE(`/api/v1/notebooks/${notebookID}`);
 }
 
 export function deleteRevisionOnServer(notebookID, revisionID) {
-  return makeDeleteRequest(
+  return makeDeleteRequestPRIVATE(
     `/api/v1/notebooks/${notebookID}/revisions/${revisionID}`
   );
 }
 
 export function deleteFileOnServer(fileID) {
-  return makeDeleteRequest(`/api/v1/files/${fileID}/`);
+  return makeDeleteRequestPRIVATE(`/api/v1/files/${fileID}/`);
 }


### PR DESCRIPTION
fixes #1773, which was likely introduced by the file API PR. This fixes a couple of small aspects of file uploading from the server, but is not meant to refactor the functionality in any substantial way.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
