### PR TITLE
Intercept backspace when not focused to prevent backward page navigation

### DIFF
--- a/src/editor/initialization/keybindings.js
+++ b/src/editor/initialization/keybindings.js
@@ -1,8 +1,17 @@
 import Mousetrap from "mousetrap";
 import tasks from "../user-tasks/task-definitions";
-// for now, let's just keep the keybindings here.
 
 Mousetrap.prototype.stopCallback = () => false;
+
+let warnUser = false;
+
+const preventBacknav = e => {
+  if (e.target === document.body) {
+    warnUser = true;
+  } else {
+    warnUser = false;
+  }
+};
 
 export function initializeDefaultKeybindings() {
   Object.keys(tasks).forEach(t => {
@@ -11,7 +20,16 @@ export function initializeDefaultKeybindings() {
       Mousetrap.bind(task.keybindings, task.keybindingCallback);
     }
   });
+  Mousetrap.bind(["delete", "backspace"], preventBacknav);
 }
+
+window.onbeforeunload = () => {
+  if (warnUser) {
+    warnUser = false;
+    return "Are you sure you want to leave?";
+  }
+  return undefined;
+};
 
 // FIXME REMOVE DEAD FUNCTION
 export function addLanguageKeybinding(keys, callback) {

--- a/src/eval-frame/keybindings.js
+++ b/src/eval-frame/keybindings.js
@@ -4,6 +4,12 @@ import tasks from "./actions/eval-frame-tasks";
 
 Mousetrap.prototype.stopCallback = () => false;
 
+const preventBacknav = e => {
+  if (e.target === document.body) {
+    e.preventDefault();
+  }
+};
+
 export function initializeDefaultKeybindings() {
   Object.keys(tasks).forEach(t => {
     const task = tasks[t];
@@ -11,4 +17,5 @@ export function initializeDefaultKeybindings() {
       Mousetrap.bind(task.keybindings, task.keybindingCallback);
     }
   });
+  Mousetrap.bind(["delete", "backspace"], preventBacknav);
 }

--- a/src/eval-frame/keybindings.js
+++ b/src/eval-frame/keybindings.js
@@ -4,6 +4,12 @@ import tasks from "./actions/eval-frame-tasks";
 
 Mousetrap.prototype.stopCallback = () => false;
 
+// FIXME: it is not clear how to make within this iframe
+// the backspace key event to pop up the beforeupload modal.
+// It seems to ignore the same kind of beforeupload trigger I have in the main
+// editor scope.
+// so in the meantime if e.target === document.body let's just
+// prevent default here.
 const preventBacknav = e => {
   if (e.target === document.body) {
     e.preventDefault();

--- a/src/eval-frame/keybindings.js
+++ b/src/eval-frame/keybindings.js
@@ -4,11 +4,10 @@ import tasks from "./actions/eval-frame-tasks";
 
 Mousetrap.prototype.stopCallback = () => false;
 
-// FIXME: it is not clear how to make within this iframe
-// the backspace key event to pop up the beforeupload modal.
-// It seems to ignore the same kind of beforeupload trigger I have in the main
-// editor scope.
-// so in the meantime if e.target === document.body let's just
+// FIXME: it is not clear how to pop up the beforeupload browser modal
+// from within the iframe only on the keypress.
+// It seems to ignore the same kind of beforeupload trigger appraoch I use in the main
+// editor scope. So in the meantime if e.target === document.body let's just
 // prevent default here.
 const preventBacknav = e => {
   if (e.target === document.body) {


### PR DESCRIPTION
Partial solution to #1725. If the main scope is in-focus, this PR triggers the `beforeunload` modal on backspace (but not on page refresh, etc.). If the iframe is in-focus but no inputs are selected, we have to call `e.preventDefault` here since it seems there is more that must happen to pull up the same browser confirmation modal.

If we want to just trigger this for _all_ unloads (page refresh, for instance) then this woudl simplify the code a bit, but if we're interested in _just_ intercepting backspace, this would be one approach.