### PR TITLE
proposes alt+up and alt+down as a keybinding for moving between chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - only show notebooks with 10 or more edits on the server's index page list
 - fixes bug where fetch chunks with errors don't halt further evaluation
 - adds `arrayBuffer` type to fetch chunks (see docs)
+- adds `alt+up` and `alt+down` keybindings, which moves to the previous / next chunk
 
 # 0.5.0 (2019-03-28)
 

--- a/src/editor/actions/__tests__/cursor-actions.test.js
+++ b/src/editor/actions/__tests__/cursor-actions.test.js
@@ -1,6 +1,10 @@
 import configureMockStore from "redux-mock-store";
 import thunk from "redux-thunk";
-import { moveCursorToNextChunk, updateEditorCursor } from "../actions";
+import {
+  moveCursorToNextChunk,
+  moveCursorToPreviousChunk,
+  updateEditorCursor
+} from "../actions";
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -173,6 +177,171 @@ describe("moveCursorToNextChunk dispatches correct actions", () => {
     ];
 
     store.dispatch(moveCursorToNextChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+//
+//
+//
+//
+//
+
+//
+
+// /
+
+describe("moveCursorToPreviousChunk dispatches correct actions", () => {
+  it("no selection, and one chunk", () => {
+    const [line, col] = [1, 2];
+
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [{ startLine: 0, endLine: 10 }],
+      editorSelections: []
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 0,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+
+    store.dispatch(moveCursorToPreviousChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("no selection, multiple chunks", () => {
+    const [line, col] = [17, 25];
+
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [
+        { startLine: 0, endLine: 10 },
+        { startLine: 11, endLine: 15 },
+        { startLine: 16, endLine: 20 }
+      ],
+      editorSelections: []
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 11,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+
+    store.dispatch(moveCursorToPreviousChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  //
+  //
+  //
+  //
+  //
+  //
+
+  it("one selection, and one chunk", () => {
+    const [line, col] = [1, 2];
+
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [{ startLine: 0, endLine: 10 }],
+      editorSelections: [
+        { start: { line: 3, col: 2 }, end: { line: 5, col: 2 } }
+      ]
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 0,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+
+    store.dispatch(moveCursorToPreviousChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("one selection across multiple chunks", () => {
+    const [line, col] = [12, 25];
+
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [
+        { startLine: 0, endLine: 10 },
+        { startLine: 11, endLine: 15 },
+        { startLine: 16, endLine: 20 },
+        { startLine: 21, endLine: 100 }
+      ],
+      editorSelections: [
+        { start: { line: 18, col: 2 }, end: { line: 25, col: 2 } }
+      ]
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 11,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+
+    store.dispatch(moveCursorToPreviousChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it("multiple selections in multiple chunks", () => {
+    const [line, col] = [12, 25];
+
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [
+        { startLine: 0, endLine: 10 },
+        { startLine: 11, endLine: 15 },
+        { startLine: 16, endLine: 20 },
+        { startLine: 21, endLine: 100 }
+      ],
+      editorSelections: [
+        { start: { line: 17, col: 2 }, end: { line: 18, col: 2 } },
+        { start: { line: 22, col: 2 }, end: { line: 32, col: 2 } }
+      ]
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 11,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+
+    store.dispatch(moveCursorToPreviousChunk());
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/src/editor/actions/__tests__/cursor-actions.test.js
+++ b/src/editor/actions/__tests__/cursor-actions.test.js
@@ -115,6 +115,32 @@ describe("moveCursorToNextChunk dispatches correct actions", () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
+  it("defaults to last line if cursor is already in last chunk", () => {
+    const [line, col] = [12, 2];
+    const store = mockStore({
+      editorCursor: {
+        line,
+        col
+      },
+      jsmdChunks: [
+        { startLine: 0, endLine: 10 },
+        { startLine: 11, endLine: 15 }
+      ],
+      editorSelections: []
+    });
+
+    const expectedActions = [
+      {
+        type: "UPDATE_CURSOR",
+        line: 16,
+        col: 0,
+        forceUpdate: true
+      }
+    ];
+    store.dispatch(moveCursorToNextChunk());
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
   it("one selection across multiple chunks", () => {
     const [line, col] = [12, 25];
 

--- a/src/editor/actions/__tests__/cursor-actions.test.js
+++ b/src/editor/actions/__tests__/cursor-actions.test.js
@@ -181,16 +181,6 @@ describe("moveCursorToNextChunk dispatches correct actions", () => {
   });
 });
 
-//
-//
-//
-//
-//
-
-//
-
-// /
-
 describe("moveCursorToPreviousChunk dispatches correct actions", () => {
   it("no selection, and one chunk", () => {
     const [line, col] = [1, 2];
@@ -245,13 +235,6 @@ describe("moveCursorToPreviousChunk dispatches correct actions", () => {
     store.dispatch(moveCursorToPreviousChunk());
     expect(store.getActions()).toEqual(expectedActions);
   });
-
-  //
-  //
-  //
-  //
-  //
-  //
 
   it("one selection, and one chunk", () => {
     const [line, col] = [1, 2];

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -219,8 +219,9 @@ export function moveCursorToNextChunk() {
       editorCursor
     } = getState();
     const lastChunk = jsmdChunks[jsmdChunks.length - 1];
-    // ignore if we are on the last line already
-    if (editorCursor.line === lastChunk.endLine) {
+    // if there is no selection and the cursor is on the last line,
+    // skip the rest of the thunk.
+    if (editorCursor.line === lastChunk.endLine && !selections.length) {
       return;
     }
     const targetLine =

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -219,8 +219,8 @@ export function moveCursorToNextChunk() {
       editorCursor
     } = getState();
     const lastChunk = jsmdChunks[jsmdChunks.length - 1];
+    // ignore if we are on the last line already
     if (editorCursor.line === lastChunk.endLine) {
-      dispatch(updateEditorCursor(lastChunk.endLine, Infinity, true));
       return;
     }
     const targetLine =

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -204,6 +204,14 @@ export function updateEditorCursor(line, col, forceUpdate = false) {
   return { type: "UPDATE_CURSOR", line, col, forceUpdate };
 }
 
+export function moveToNextChunk() {
+  return { type: "MOVE_TO_NEXT_CHUNK" };
+}
+
+export function moveToPreviousChunk() {
+  return { type: "MOVE_TO_PREVIOUS_CHUNK" };
+}
+
 export function updateEditorSelections(selections) {
   return {
     type: "UPDATE_SELECTIONS",

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -218,7 +218,6 @@ export function moveCursorToNextChunk() {
       jsmdChunks,
       editorCursor
     } = getState();
-    // if at end of the doc, return
     const lastChunk = jsmdChunks[jsmdChunks.length - 1];
     if (editorCursor.line === lastChunk.endLine) {
       dispatch(updateEditorCursor(lastChunk.endLine, Infinity, true));
@@ -241,14 +240,13 @@ export function moveCursorToPreviousChunk() {
       editorCursor
     } = getState();
 
-    // set to beginning of doc if there are less than two chunks (could be 0)
+    // set to beginning of doc if there are less than two chunks.
     if (jsmdChunks.length < 2 || editorCursor.line < jsmdChunks[1].startLine) {
       dispatch(updateEditorCursor(0, 0, true));
       return;
     }
-    // look at the last chunk bfore the one containing this.
+    // look at the last chunk before the one containing this.
     const currentChunk = getChunkContainingLine(jsmdChunks, editorCursor.line);
-    // subtract one from targetLine to get the last line of the previous chunk
     const targetLine =
       selections.length === 0
         ? currentChunk.startLine - 1

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -329,38 +329,6 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
-    case "MOVE_TO_NEXT_CHUNK": {
-      // find current cursor position,
-      // find next chunk above cursor position
-      // if at end do nothing.
-      const { editorCursor, jsmdChunks } = state;
-      const nextCursor = Object.assign({}, editorCursor);
-      const nextChunk = jsmdChunks.filter(
-        ch => ch.startLine > editorCursor.line
-      )[0];
-      if (nextChunk) {
-        nextCursor.line = nextChunk.startLine;
-        nextCursor.col = 0;
-        nextCursor.forceUpdate = true;
-      }
-      return Object.assign({}, state, { editorCursor: nextCursor });
-    }
-    case "MOVE_TO_PREVIOUS_CHUNK": {
-      // find current cursor position,
-      // find next chunk above cursor position
-      // if at end do nothing.
-      const { editorCursor, jsmdChunks } = state;
-      const nextCursor = Object.assign({}, editorCursor);
-      let nextChunk = jsmdChunks.filter(ch => ch.startLine < editorCursor.line);
-      nextChunk = nextChunk[nextChunk.length - 1];
-      if (nextChunk) {
-        nextCursor.line = nextChunk.startLine;
-        nextCursor.col = 0;
-        nextCursor.forceUpdate = true;
-      }
-      return Object.assign({}, state, { editorCursor: nextCursor });
-    }
-
     default: {
       return state;
     }

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -329,6 +329,38 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
+    case "MOVE_TO_NEXT_CHUNK": {
+      // find current cursor position,
+      // find next chunk above cursor position
+      // if at end do nothing.
+      const { editorCursor, jsmdChunks } = state;
+      const nextCursor = Object.assign({}, editorCursor);
+      const nextChunk = jsmdChunks.filter(
+        ch => ch.startLine > editorCursor.line
+      )[0];
+      if (nextChunk) {
+        nextCursor.line = nextChunk.startLine;
+        nextCursor.col = 0;
+        nextCursor.forceUpdate = true;
+      }
+      return Object.assign({}, state, { editorCursor: nextCursor });
+    }
+    case "MOVE_TO_PREVIOUS_CHUNK": {
+      // find current cursor position,
+      // find next chunk above cursor position
+      // if at end do nothing.
+      const { editorCursor, jsmdChunks } = state;
+      const nextCursor = Object.assign({}, editorCursor);
+      let nextChunk = jsmdChunks.filter(ch => ch.startLine < editorCursor.line);
+      nextChunk = nextChunk[nextChunk.length - 1];
+      if (nextChunk) {
+        nextCursor.line = nextChunk.startLine;
+        nextCursor.col = 0;
+        nextCursor.forceUpdate = true;
+      }
+      return Object.assign({}, state, { editorCursor: nextCursor });
+    }
+
     default: {
       return state;
     }

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -111,19 +111,19 @@ tasks.exportNotebook = new UserTask({
   }
 });
 
-tasks.moveToNextChunk = new UserTask({
+tasks.moveCursorToNextChunk = new UserTask({
   title: "Move to Next Chunk",
   keybindings: ["alt+down"],
   callback() {
-    dispatcher.moveToNextChunk();
+    dispatcher.moveCursorToNextChunk();
   }
 });
 
-tasks.moveToPreviousChunk = new UserTask({
+tasks.moveCursorToPreviousChunk = new UserTask({
   title: "Move to Previous Chunk",
   keybindings: ["alt+up"],
   callback() {
-    dispatcher.moveToPreviousChunk();
+    dispatcher.moveCursorToPreviousChunk();
   }
 });
 

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -111,6 +111,22 @@ tasks.exportNotebook = new UserTask({
   }
 });
 
+tasks.moveToNextChunk = new UserTask({
+  title: "Move to Next Chunk",
+  keybindings: ["alt+down"],
+  callback() {
+    dispatcher.moveToNextChunk();
+  }
+});
+
+tasks.moveToPreviousChunk = new UserTask({
+  title: "Move to Previous Chunk",
+  keybindings: ["alt+up"],
+  callback() {
+    dispatcher.moveToPreviousChunk();
+  }
+});
+
 tasks.exportNotebookAsReport = new UserTask({
   title: "Export Notebook as Report",
   callback() {


### PR DESCRIPTION
This PR implements the next / previous chunk keybinding suggested in #1421. For this PR, I implemented `alt+up` / `alt+down` since it doesn't seem to clash with any other keybindings to my knowledge, but I'm pretty indifferent to what we end up using, as long as it is easy on the hands.