### PR TITLE
Fix notebook ownership issues on fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - only show notebooks with 10 or more edits on the server's index page list
 - fixes bug where fetch chunks with errors don't halt further evaluation
 - adds `arrayBuffer` type to fetch chunks (see docs)
+- fix bug where you couldn't save a notebook after forking it
 
 # 0.5.0 (2019-03-28)
 

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -246,6 +246,7 @@ export function moveCursorToNextChunk() {
 
 export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
   return async (dispatch, getState) => {
+    const { forkedFrom } = options;
     const state = getState();
     try {
       const notebook = await createNotebookRequest(
@@ -261,8 +262,16 @@ export function createNewNotebookOnServer(options = { forkedFrom: undefined }) {
         })
       );
       dispatch({ type: "ADD_NOTEBOOK_ID", id: notebook.id });
-      window.history.replaceState({}, "", `/notebooks/${notebook.id}`);
+      window.history.replaceState({}, "", `/notebooks/${notebook.id}/`);
       dispatch({ type: "NOTEBOOK_SAVED" });
+      // update owner info, so we know that we can save
+      if (forkedFrom) {
+        dispatch({
+          type: "SET_NOTEBOOK_OWNER_IN_SESSION",
+          owner: state.userData,
+          forkedFrom
+        });
+      }
     } catch (err) {
       dispatch(
         updateAppMessages({

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -310,6 +310,17 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
+    case "SET_NOTEBOOK_OWNER_IN_SESSION": {
+      const { notebookInfo, userData } = state;
+      const newNotebookInfo = Object.assign({}, notebookInfo);
+      newNotebookInfo.username = userData.name;
+      newNotebookInfo.user_can_save = true;
+      newNotebookInfo.files = newNotebookInfo.files.map(f =>
+        Object.assign({}, f)
+      );
+      return Object.assign({}, state, { notebookInfo: newNotebookInfo });
+    }
+
     default: {
       return state;
     }


### PR DESCRIPTION
Fixes #1746.

Prior to this PR, on fork the `notebookInfo` part of the store as not updated to reflect the new ownership. As such, the file API wasn't working upon first fork. If you reload the forked notebook, however, it does work.

This additionally adds a trailing slash to the end of the url after forking, which prevents all sorts of problems with the file API.