### PR TITLE
moved EXPORT_NOTEBOOK logic into exportNotebook action creator

### DIFF
--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -26,6 +26,8 @@ import { fetchWithCSRFTokenAndJSONContent } from "../../shared/fetch-with-csrf-t
 import { jsmdParser } from "../jsmd-tools/jsmd-parser";
 import { getChunkContainingLine } from "../jsmd-tools/jsmd-selection";
 
+import { exportJsmdBundle, titleToHtmlFilename } from "../tools/export-tools";
+
 import createHistoryItem from "../../shared/utils/create-history-item";
 
 export function updateAppMessages(messageObj) {
@@ -141,9 +143,20 @@ export function toggleWrapInEditors() {
 }
 
 export function exportNotebook(exportAsReport = false) {
-  return {
-    type: "EXPORT_NOTEBOOK",
-    exportAsReport
+  return (_, getState) => {
+    const state = getState();
+    const exportState = Object.assign({}, state, {
+      viewMode: exportAsReport ? "REPORT_VIEW" : "EXPLORE_VIEW"
+    });
+    const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(
+      exportJsmdBundle(exportState.jsmd, exportState.title)
+    )}`;
+    const dlAnchorElem = document.getElementById("export-anchor");
+    dlAnchorElem.setAttribute("href", dataStr);
+    const title =
+      exportState.title === undefined ? "new-notebook" : exportState.title;
+    dlAnchorElem.setAttribute("download", titleToHtmlFilename(title));
+    dlAnchorElem.click();
   };
 }
 

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -1,6 +1,5 @@
 import { newNotebook } from "../state-schemas/editor-state-prototypes";
 import { historyIdGen } from "../tools/id-generators";
-import { exportJsmdBundle, titleToHtmlFilename } from "../tools/export-tools";
 
 function newAppMessage(
   appMessageId,
@@ -36,27 +35,9 @@ initialVariables.add("CodeMirror");
 
 const notebookReducer = (state = newNotebook(), action) => {
   let nextState;
-  let title;
   switch (action.type) {
     case "RESET_NOTEBOOK":
       return Object.assign(newNotebook(), action.userData);
-
-    case "EXPORT_NOTEBOOK": {
-      const exportState = Object.assign({}, state, {
-        viewMode: action.exportAsReport ? "REPORT_VIEW" : "EXPLORE_VIEW"
-      });
-      const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(
-        exportJsmdBundle(exportState.jsmd, exportState.title)
-      )}`;
-      const dlAnchorElem = document.getElementById("export-anchor");
-      dlAnchorElem.setAttribute("href", dataStr);
-      title =
-        exportState.title === undefined ? "new-notebook" : exportState.title;
-      dlAnchorElem.setAttribute("download", titleToHtmlFilename(title));
-      dlAnchorElem.click();
-
-      return state;
-    }
 
     case "TOGGLE_WRAP_IN_EDITORS":
       return Object.assign({}, state, { wrapEditors: !state.wrapEditors });


### PR DESCRIPTION
This fixes #995 by removing the `EXPORT_NOTEBOOK` case in the reducer and putting it into the action creator. This case was probably one of our very first ones, before we used thunks. At this point, the reducer itself should be pure-ish. We still have to look at `initialVariables` which are all the various variables from 3rd parties (mousetrap, etc.) in `window` that happens upon the page load.

We will probably refactor the export stuff down the line but this should keep the ball moving forward for now.