### PR TITLE
fetch cells will now halt further evaluation on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # (Unreleased; add upcoming change notes here)
-- introduces iodide.file API
-
+- introduces iodide.file API (see docs)
 - restore tabular data viewer for arrays of objects
 - add "TinyRep" components
 - implement `storybook` for visually testing rep components
 - only show notebooks with 10 or more edits on the server's index page list
+- fixes bug where fetch chunks with errors don't halt further evaluation
+- adds `arrayBuffer` type to fetch chunks (see docs)
 
 # 0.5.0 (2019-03-28)
 

--- a/src/editor/components/codemirror-fetch-mode.js
+++ b/src/editor/components/codemirror-fetch-mode.js
@@ -14,5 +14,8 @@ CodeMirror.defineSimpleMode("fetch", {
       regex: /text: |blob: |json: |js: |css: |arrayBuffer: /,
       token: "fetch-type"
     }
-  ]
+  ],
+  meta: {
+    lineComment: "//"
+  }
 });

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -169,4 +169,5 @@ export async function evaluateFetchText(fetchText, evalId) {
   } else {
     sendStatusResponseToEditor("SUCCESS", evalId);
   }
+  return undefined;
 }

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -139,19 +139,18 @@ export async function evaluateFetchText(fetchText, evalId) {
       historyId: outputHistoryId
     })
   );
-  const fetchCalls = fetches.map((f, i) =>
-    handleFetch(f).then(outcome => {
-      progressStrings = progressStrings.map(entry => Object.assign({}, entry));
-      progressStrings[i] = outcome;
-      sendActionToEditor(
-        updateConsoleEntry({
-          historyId: outputHistoryId,
-          value: progressStrings
-        })
-      );
-      return outcome;
-    })
-  );
+  const fetchCalls = fetches.map(async (f, i) => {
+    const outcome = await handleFetch(f);
+    progressStrings = progressStrings.map(entry => Object.assign({}, entry));
+    progressStrings[i] = outcome;
+    sendActionToEditor(
+      updateConsoleEntry({
+        historyId: outputHistoryId,
+        value: progressStrings
+      })
+    );
+    return outcome;
+  });
 
   const outcomes = await Promise.all(fetchCalls);
   const errors = outcomes.filter(f => f.text.startsWith("ERROR"));

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -87,7 +87,7 @@ async function receiveMessage(event) {
       }
       case "EVAL_FETCH": {
         const { fetchText, taskId } = message;
-        evaluateFetchText(fetchText, taskId);
+        await evaluateFetchText(fetchText, taskId);
         break;
       }
       case "EVAL_LANGUAGE_PLUGIN": {


### PR DESCRIPTION
fixes #1707 

You can test with this notebook:

```
%% js

iodide.file.save('ok.txt', 'text', 'soidfnsodifndsoifn', {overwrite: true})

%% fetch

text: test = https://whatever.whatever/whatever.whatever
text: thing = files/ok.txt
%% js

x = 10
x
```

If you hit run all it shouldn't get to the last JS cell