### PR TITLE
Do not block compilation for prettier warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,9 @@ module.exports = {
   plugins: ["jest"],
   extends: ["airbnb", "plugin:prettier/recommended", "prettier/react"],
   rules: {
+    // Make prettier emit warnings rather than errors
+    "prettier/prettier": ["warn"],
+
     // Restricting for..of seems pretty controversial, let's disable that.
     // See https://github.com/airbnb/javascript/issues/1271
     "no-restricted-syntax": ["off"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,9 @@ const plugins = [];
 module.exports = env => {
   env = env || ""; // eslint-disable-line no-param-reassign
 
-  if (!env.startsWith("dev")) {
+  const isDev = env.startsWith("dev");
+
+  if (!isDev) {
     plugins.push(new UglifyJSPlugin());
   }
 
@@ -84,8 +86,8 @@ module.exports = env => {
           loader: "eslint-loader",
           options: {
             // eslint options (if necessary)
-            emitWarning: true,
-            emitError: true,
+            emitWarning: !isDev,
+            emitError: !isDev,
             extensions: [".jsx", ".js"]
           }
         },
@@ -181,7 +183,7 @@ module.exports = env => {
         IODIDE_JS_PATH: JSON.stringify(APP_PATH_STRING),
         IODIDE_CSS_PATH: JSON.stringify(CSS_PATH_STRING),
         IODIDE_BUILD_MODE: JSON.stringify(
-          env && env.startsWith("dev") ? "dev" : "production"
+          isDev ? "dev" : "production"
         ),
         IODIDE_REDUX_LOG_MODE: JSON.stringify(reduxLogMode),
         PYODIDE_VERSION: JSON.stringify(PYODIDE_VERSION),


### PR DESCRIPTION
It can be a little frustrating when prettier blocks compilation during
development. This often happens to me while tinkering with props in JSX.
Adding or removing a prop can put the line over or under the 80
character limit, making prettier require whitespace changes. Until those
stylistic changes are made, the new code cannot be compiled or tested in
the browser.
