### PR TITLE
Upgrade to Pyodide 0.12.0

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ let { EVAL_FRAME_ORIGIN } = process.env;
 const { USE_OPENIDC_AUTH } = process.env;
 const { IODIDE_PUBLIC } = process.env || false;
 
-const PYODIDE_VERSION = process.env.PYODIDE_VERSION || "0.11.0";
+const PYODIDE_VERSION = process.env.PYODIDE_VERSION || "0.12.0";
 process.env.PYODIDE_VERSION = PYODIDE_VERSION;
 
 const APP_VERSION_STRING = process.env.APP_VERSION_STRING || "dev";


### PR DESCRIPTION
This is a big one, y'all.

- Packages with pure Python wheels can now be loaded directly from PyPI. See
  `docs/pypi.md` for more information.

- Thanks to PEP 562, you can now `import js` from Python and use it to access
  anything in the global Javascript namespace.

- Passing a Python object to Javascript always creates the same object in
  Javascript. This makes APIs like `removeEventListener` usable.

- Calling `dir()` in Python on a JavaScript proxy now works.

- Passing an `ArrayBuffer` from Javascript to Python now correctly creates
  a `memoryview` object.

- Pyodide now works on Safari.
