### PR TITLE
Server session actions cleanup

### DIFF
--- a/src/editor/actions/__tests__/server-session-actions.test.js
+++ b/src/editor/actions/__tests__/server-session-actions.test.js
@@ -1,0 +1,16 @@
+import { loginSuccess, loginFailure } from "../server-session-actions";
+import { store } from "../../store";
+
+const mockUserData = {
+  name: "name",
+  avatar: "avatar"
+};
+
+describe("make sure action creators leave store in a consitent state", () => {
+  it("loginSuccess", () => {
+    expect(() => store.dispatch(loginSuccess(mockUserData))).not.toThrow();
+  });
+  it("loginFailure", () => {
+    expect(() => store.dispatch(loginFailure())).not.toThrow();
+  });
+});

--- a/src/editor/actions/__tests__/verify-action-store-consistency.test.js
+++ b/src/editor/actions/__tests__/verify-action-store-consistency.test.js
@@ -12,11 +12,6 @@ import { languageDefinitions } from "../../state-schemas/language-definitions";
 // according to the state schema.
 // This relies on the functionality in createValidatedReducer
 
-const mockUserData = {
-  name: "name",
-  avatar: "avatar"
-};
-
 describe("make sure createValidatedReducer is checking correctly", () => {
   beforeEach(() => {
     store.dispatch(actions.resetNotebook());
@@ -98,15 +93,6 @@ describe("make sure action creators leave store in a consitent state", () => {
 
   it("evaluateNotebook", () => {
     expect(() => store.dispatch(evaluateNotebook())).not.toThrow();
-  });
-
-  it("loginSuccess", () => {
-    expect(() =>
-      store.dispatch(actions.loginSuccess(mockUserData))
-    ).not.toThrow();
-  });
-  it("loginFailure", () => {
-    expect(() => store.dispatch(actions.loginFailure())).not.toThrow();
   });
 
   it("toggleHelpModal", () => {

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -1,17 +1,10 @@
-import { createNewNotebookOnServer } from "./server-save-actions";
-import { updateAutosave } from "./autosave-actions";
 import { getUrlParams, objectToQueryString } from "../tools/query-param-tools";
 import {
   getRevisionList,
   getRevisions,
   getRevisionIdsNeededForDisplay
 } from "../tools/revision-history";
-import {
-  getNotebookID,
-  getUserDataFromDocument,
-  notebookIsATrial
-} from "../tools/server-tools";
-import { loginToServer, logoutFromServer } from "../../shared/utils/login";
+import { getNotebookID, getUserDataFromDocument } from "../tools/server-tools";
 
 import { jsmdParser } from "../jsmd-tools/jsmd-parser";
 import { getChunkContainingLine } from "../jsmd-tools/jsmd-selection";
@@ -222,70 +215,6 @@ export function getNotebookRevisionList() {
       .catch(() => {
         dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
       });
-  };
-}
-
-export function loginSuccess(userData) {
-  return async (dispatch, getState) => {
-    dispatch({
-      type: "LOGIN_SUCCESS",
-      userData
-    });
-    if (notebookIsATrial(getState())) {
-      createNewNotebookOnServer()(dispatch, getState);
-    } else {
-      dispatch(
-        updateAppMessages({
-          message: "You are logged in",
-          messageType: "LOGGED_IN"
-        })
-      );
-      // trigger a save action immediately
-      dispatch(updateAutosave());
-    }
-  };
-}
-
-export function loginFailure() {
-  return dispatch => {
-    dispatch(
-      updateAppMessages({
-        message: "Login Failed",
-        messageType: "LOGIN_FAILED"
-      })
-    );
-  };
-}
-
-export function login(successCallback) {
-  return dispatch => {
-    const loginSuccessWrapper = userData => {
-      dispatch(loginSuccess(userData));
-      if (successCallback) successCallback(userData);
-    };
-    loginToServer(loginSuccessWrapper);
-  };
-}
-
-function logoutSuccess(dispatch) {
-  dispatch({ type: "LOGOUT" });
-  dispatch(
-    updateAppMessages({ message: "Logged Out", messageType: "LOGGED_OUT" })
-  );
-}
-
-function logoutFailure(dispatch) {
-  dispatch(
-    updateAppMessages({
-      message: "Logout Failed",
-      messageType: "LOGOUT_FAILED"
-    })
-  );
-}
-
-export function logout() {
-  return dispatch => {
-    logoutFromServer(logoutSuccess, logoutFailure, dispatch);
   };
 }
 

--- a/src/editor/actions/server-session-actions.js
+++ b/src/editor/actions/server-session-actions.js
@@ -1,0 +1,69 @@
+import { updateAppMessages } from "./actions";
+import { createNewNotebookOnServer } from "./server-save-actions";
+import { updateAutosave } from "./autosave-actions";
+import { loginToServer, logoutFromServer } from "../../shared/utils/login";
+import { notebookIsATrial } from "../tools/server-tools";
+
+export function loginSuccess(userData) {
+  return async (dispatch, getState) => {
+    dispatch({
+      type: "LOGIN_SUCCESS",
+      userData
+    });
+    if (notebookIsATrial(getState())) {
+      createNewNotebookOnServer()(dispatch, getState);
+    } else {
+      dispatch(
+        updateAppMessages({
+          message: "You are logged in",
+          messageType: "LOGGED_IN"
+        })
+      );
+      // trigger a save action immediately
+      dispatch(updateAutosave());
+    }
+  };
+}
+
+export function loginFailure() {
+  return dispatch => {
+    dispatch(
+      updateAppMessages({
+        message: "Login Failed",
+        messageType: "LOGIN_FAILED"
+      })
+    );
+  };
+}
+
+export function login(successCallback) {
+  return dispatch => {
+    const loginSuccessWrapper = userData => {
+      dispatch(loginSuccess(userData));
+      if (successCallback) successCallback(userData);
+    };
+    loginToServer(loginSuccessWrapper);
+  };
+}
+
+function logoutSuccess(dispatch) {
+  dispatch({ type: "LOGOUT" });
+  dispatch(
+    updateAppMessages({ message: "Logged Out", messageType: "LOGGED_OUT" })
+  );
+}
+
+function logoutFailure(dispatch) {
+  dispatch(
+    updateAppMessages({
+      message: "Logout Failed",
+      messageType: "LOGOUT_FAILED"
+    })
+  );
+}
+
+export function logout() {
+  return dispatch => {
+    logoutFromServer(logoutSuccess, logoutFailure, dispatch);
+  };
+}

--- a/src/editor/components/menu/header-messages.jsx
+++ b/src/editor/components/menu/header-messages.jsx
@@ -8,7 +8,7 @@ import {
   connectionModeIsServer,
   connectionModeIsStandalone
 } from "../../tools/server-tools";
-import { login } from "../../actions/actions";
+import { login } from "../../actions/server-session-actions";
 import {
   createNewNotebookOnServer,
   revertToLatestServerRevision,

--- a/src/editor/components/menu/view-controls.jsx
+++ b/src/editor/components/menu/view-controls.jsx
@@ -9,13 +9,13 @@ import UserMenu from "../../../shared/components/user-menu";
 import ViewModeToggleButton from "./view-mode-toggle-button";
 import NotebookTaskButton from "./notebook-task-button";
 import KernelState from "./kernel-state";
+import { login, logout } from "../../actions/server-session-actions";
+import { connectionModeIsServer } from "../../tools/server-tools";
 
 // FIXME there is NO REASON to use "tasks" here.
 // we should use map dispatch to props and regular actions like
 // we do in every other component
 import tasks from "../../user-tasks/task-definitions";
-
-import { connectionModeIsServer } from "../../tools/server-tools";
 
 const ViewControlsContainer = styled("div")`
   display: flex;
@@ -28,7 +28,9 @@ export class ViewControlsUnconnected extends React.Component {
     isAuthenticated: PropTypes.bool.isRequired,
     name: PropTypes.string,
     avatar: PropTypes.string,
-    isServer: PropTypes.bool.isRequired
+    isServer: PropTypes.bool.isRequired,
+    login: PropTypes.func.isRequired,
+    logout: PropTypes.func.isRequired
   };
 
   render() {
@@ -43,8 +45,8 @@ export class ViewControlsUnconnected extends React.Component {
           // this stuff should not be passed down as props
           <UserMenu
             isAuthenticated={this.props.isAuthenticated}
-            loginCallback={tasks.loginGithub.callback}
-            logoutCallback={tasks.logoutGithub.callback}
+            loginCallback={this.props.login}
+            logoutCallback={this.props.logout}
             avatar={this.props.avatar}
             username={this.props.name}
           />
@@ -66,4 +68,12 @@ export function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(ViewControlsUnconnected);
+const mapDispatchToProps = {
+  login,
+  logout
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ViewControlsUnconnected);

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -57,20 +57,6 @@ tasks.evaluateChunkAndSelectBelow = new UserTask({
   }
 });
 
-tasks.loginGithub = new UserTask({
-  title: "Login using GitHub",
-  callback(loginSuccess = undefined) {
-    dispatcher.login(loginSuccess);
-  }
-});
-
-tasks.logoutGithub = new UserTask({
-  title: "Logout",
-  callback() {
-    dispatcher.logout();
-  }
-});
-
 tasks.toggleWrapInEditors = new UserTask({
   title: "Toggle wrapping in editors",
   displayKeybinding: "Alt+w", // '\u2193',


### PR DESCRIPTION
* Move actions into a seperate server-session-actions file (this fixes the
  last of our input cycle problems)
* Remove login/logout "tasks", just dispatch these redux actions where
  needed

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
