### PR TITLE
Iodide 1899 remove global for process env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,6 @@
 - Gravatars are served via https by default (fixes #1930)
 - Add new file management UI (click _Menu > Manage Files_ while logged in and
   viewing a notebook that you own)
-- Migrate from parsing environment variable with global IODIDE_BUILD_MODE to
-  using webpack's process.env.NODE_ENV and the environmentPlugin code quality (#1899)
 
 # 0.7.0 (2019-05-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Gravatars are served via https by default (fixes #1930)
 - Add new file management UI (click _Menu > Manage Files_ while logged in and
   viewing a notebook that you own)
+- Migrate from parsing environment variable with global IODIDE_BUILD_MODE to
+  using webpack's process.env.NODE_ENV and the environmentPlugin code quality (#1899)
 
 # 0.7.0 (2019-05-30)
 

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "node": "8.x"
   },
   "scripts": {
-    "test": "jest --no-cache",
-    "start-and-serve": "webpack-dev-server --watch --mode=development --env=dev",
-    "start": "webpack --watch --mode=development --env=dev",
+    "test": "NODE_ENV=test jest --no-cache",
+    "start-and-serve": "NODE_ENV=dev webpack-dev-server --watch --mode=development",
+    "start": "NODE_ENV=dev webpack --watch --mode=development",
     "build": "webpack",
-    "build-production": "webpack --env=production",
+    "build-production": "webpack -p",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
@@ -32,7 +32,6 @@
     },
     "globals": {
       "window": true,
-      "IODIDE_BUILD_MODE": "test",
       "USE_LOCAL_PYODIDE": false
     },
     "setupFiles": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": "8.x"
   },
   "scripts": {
-    "test": "jest --no-cache --env.NODE_ENV=test",
+    "test": "jest --no-cache && webpack-dev-server --env.NODE_ENV=test",
     "start-and-serve": "webpack-dev-server --watch --mode=development --env.NODE_ENV=dev",
     "start": "webpack --watch --mode=development --env.NODE_ENV=dev",
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "node": "8.x"
   },
   "scripts": {
-    "test": "NODE_ENV=test jest --no-cache",
-    "start-and-serve": "NODE_ENV=dev webpack-dev-server --watch --mode=development",
-    "start": "NODE_ENV=dev webpack --watch --mode=development",
+    "test": "jest --no-cache --env.NODE_ENV=test",
+    "start-and-serve": "webpack-dev-server --watch --mode=development --env.NODE_ENV=dev",
+    "start": "webpack --watch --mode=development --env.NODE_ENV=dev",
     "build": "webpack",
     "build-production": "webpack -p",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start-and-serve": "webpack-dev-server --watch --mode=development --env.NODE_ENV=dev",
     "start": "webpack --watch --mode=development --env.NODE_ENV=dev",
     "build": "webpack --env.NODE_ENV=dev",
-    "build-production": "webpack -p --env.NODE_ENV=production",
+    "build-production": "webpack -p",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "node": "8.x"
   },
   "scripts": {
-    "test": "jest --no-cache && webpack-dev-server --env.NODE_ENV=test",
+    "test": "jest --no-cache",
     "start-and-serve": "webpack-dev-server --watch --mode=development --env.NODE_ENV=dev",
     "start": "webpack --watch --mode=development --env.NODE_ENV=dev",
-    "build": "webpack",
-    "build-production": "webpack -p",
+    "build": "webpack --env.NODE_ENV=dev",
+    "build-production": "webpack -p --env.NODE_ENV=production",
     "lint": "eslint src/ test/ --ext=.js --ext=.jsx -f unix",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/src/editor/components/modals/about-iodide.jsx
+++ b/src/editor/components/modals/about-iodide.jsx
@@ -1,5 +1,3 @@
-/* global IODIDE_VERSION */
-
 import React from "react";
 import styled from "react-emotion";
 import HelpModalContent from "./help-modal-content";
@@ -81,7 +79,8 @@ export default () => (
       <LogoMark />
       <AboutContentHeader>
         <IodideTitle>
-          Iodide<sub>α</sub> <IodideVersion>{IODIDE_VERSION}</IodideVersion>
+          Iodide<sub>α</sub>{" "}
+          <IodideVersion>{process.env.IODIDE_VERSION}</IodideVersion>
         </IodideTitle>
       </AboutContentHeader>
       <MiddleSection>

--- a/src/editor/initialization/initialize-dom.js
+++ b/src/editor/initialization/initialize-dom.js
@@ -1,4 +1,4 @@
-/* global IODIDE_EVAL_FRAME_ORIGIN IODIDE_VERSION */
+/* global IODIDE_EVAL_FRAME_ORIGIN */
 
 /* the code in this file initialize a few DOM elements for the react
 elements to mount. There are a few legacy versions of the DOM template
@@ -28,7 +28,7 @@ if (iframeElt === null && pageElt !== null) {
   // insert an iframe
   iframeElt = document.createElement("iframe");
   iframeElt.id = "eval-frame";
-  iframeElt.src = `${IODIDE_EVAL_FRAME_ORIGIN}/iodide.eval-frame.${IODIDE_VERSION}.html`;
+  iframeElt.src = `${IODIDE_EVAL_FRAME_ORIGIN}/iodide.eval-frame.${process.env.IODIDE_VERSION}.html`;
   iframeElt.setAttribute("sandbox", "allow-scripts allow-same-origin");
   iframeElt.setAttribute("allowfullscreen", "true");
   iframeElt.setAttribute("allowvr", "yes");

--- a/src/editor/reducers/reducer.js
+++ b/src/editor/reducers/reducer.js
@@ -20,7 +20,6 @@ function reduceReducers(...reducers) {
 function sendStateToEvalFrame(state) {
   // FIXME: this is a terrible hack to make the tests work.
   // it must be stamped out.
-  console.log(process.env.NODE_ENV);
   if (process.env.NODE_ENV !== "test") {
     try {
       postMessageToEvalFrame(

--- a/src/editor/reducers/reducer.js
+++ b/src/editor/reducers/reducer.js
@@ -1,5 +1,3 @@
-/* global IODIDE_BUILD_MODE */
-
 import notebookReducer from "./notebook-reducer";
 
 import evalFrameActionReducer from "./eval-frame-reducer";
@@ -22,7 +20,8 @@ function reduceReducers(...reducers) {
 function sendStateToEvalFrame(state) {
   // FIXME: this is a terrible hack to make the tests work.
   // it must be stamped out.
-  if (IODIDE_BUILD_MODE !== "test") {
+  console.log(process.env.NODE_ENV);
+  if (process.env.NODE_ENV !== "test") {
     try {
       postMessageToEvalFrame(
         "STATE_UPDATE_FROM_EDITOR",

--- a/src/editor/state-schemas/language-definitions.js
+++ b/src/editor/state-schemas/language-definitions.js
@@ -1,5 +1,4 @@
 // This defines the "built-in" language definitions
-/* global USE_LOCAL_PYODIDE */
 
 export const jsLanguageDefinition = {
   pluginType: "language",
@@ -13,7 +12,7 @@ export const jsLanguageDefinition = {
   url: ""
 };
 
-const PYODIDE_URL = USE_LOCAL_PYODIDE
+const PYODIDE_URL = process.env.USE_LOCAL_PYODIDE
   ? "/pyodide/pyodide.js"
   : "https://pyodide.cdn.iodide.io/pyodide.js";
 

--- a/src/editor/store.js
+++ b/src/editor/store.js
@@ -1,4 +1,4 @@
-/* global IODIDE_BUILD_MODE IODIDE_REDUX_LOG_MODE */
+/* global IODIDE_REDUX_LOG_MODE */
 import { applyMiddleware, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 import { createLogger } from "redux-logger";
@@ -19,13 +19,16 @@ let finalReducer;
 
 const sagaMiddleware = createSagaMiddleware();
 
-if (IODIDE_BUILD_MODE === "production") {
+if (process.env.NODE_ENV === "production") {
   finalReducer = reducer;
   enhancer = compose(
     applyMiddleware(thunk),
     applyMiddleware(sagaMiddleware)
   );
-} else if (IODIDE_BUILD_MODE === "test" || IODIDE_REDUX_LOG_MODE === "SILENT") {
+} else if (
+  process.env.NODE_ENV === "test" ||
+  IODIDE_REDUX_LOG_MODE === "SILENT"
+) {
   finalReducer = createValidatedReducer(reducer, stateSchema);
   enhancer = compose(
     applyMiddleware(thunk),

--- a/src/editor/store.js
+++ b/src/editor/store.js
@@ -18,7 +18,6 @@ let enhancer;
 let finalReducer;
 
 const sagaMiddleware = createSagaMiddleware();
-
 if (process.env.NODE_ENV === "production") {
   finalReducer = reducer;
   enhancer = compose(

--- a/src/editor/store.js
+++ b/src/editor/store.js
@@ -1,4 +1,3 @@
-/* global IODIDE_REDUX_LOG_MODE */
 import { applyMiddleware, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 import { createLogger } from "redux-logger";
@@ -26,7 +25,7 @@ if (process.env.NODE_ENV === "production") {
   );
 } else if (
   process.env.NODE_ENV === "test" ||
-  IODIDE_REDUX_LOG_MODE === "SILENT"
+  process.env.IODIDE_REDUX_LOG_MODE === "SILENT"
 ) {
   finalReducer = createValidatedReducer(reducer, stateSchema);
   enhancer = compose(

--- a/src/eval-frame/iodide-api/api.js
+++ b/src/eval-frame/iodide-api/api.js
@@ -1,5 +1,3 @@
-/* global IODIDE_VERSION */
-
 // The "Public API" for notebooks. This lets notebooks and third-party plugins
 // extend and manipulate the notebook
 
@@ -22,7 +20,7 @@ export const iodide = {
   environment,
   output,
   file,
-  VERSION: IODIDE_VERSION
+  VERSION: process.env.IODIDE_VERSION
 };
 
 export default iodide;

--- a/src/eval-frame/store.js
+++ b/src/eval-frame/store.js
@@ -1,4 +1,3 @@
-/* global IODIDE_REDUX_LOG_MODE */
 import { applyMiddleware, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 import { createLogger } from "redux-logger";
@@ -13,7 +12,7 @@ if (process.env.NODE_ENV === "production") {
   enhancer = applyMiddleware(thunk);
 } else if (
   process.env.NODE_ENV === "test" ||
-  IODIDE_REDUX_LOG_MODE === "SILENT"
+  process.env.IODIDE_REDUX_LOG_MODE === "SILENT"
 ) {
   enhancer = applyMiddleware(thunk);
 } else {

--- a/src/eval-frame/store.js
+++ b/src/eval-frame/store.js
@@ -1,4 +1,4 @@
-/* global IODIDE_BUILD_MODE IODIDE_REDUX_LOG_MODE */
+/* global IODIDE_REDUX_LOG_MODE */
 import { applyMiddleware, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 import { createLogger } from "redux-logger";
@@ -9,9 +9,12 @@ import evalFrameStateSelector from "../editor/state-schemas/eval-frame-state-sel
 
 let enhancer;
 
-if (IODIDE_BUILD_MODE === "production") {
+if (process.env.NODE_ENV === "production") {
   enhancer = applyMiddleware(thunk);
-} else if (IODIDE_BUILD_MODE === "test" || IODIDE_REDUX_LOG_MODE === "SILENT") {
+} else if (
+  process.env.NODE_ENV === "test" ||
+  IODIDE_REDUX_LOG_MODE === "SILENT"
+) {
   enhancer = applyMiddleware(thunk);
 } else {
   enhancer = compose(

--- a/src/server/pages/home-page.jsx
+++ b/src/server/pages/home-page.jsx
@@ -1,4 +1,3 @@
-/* global IODIDE_PUBLIC */
 import React from "react";
 import PropTypes from "prop-types";
 
@@ -48,8 +47,10 @@ export default class HomePage extends React.Component {
         <Header userInfo={this.props.userInfo} />
         <PageBody>
           <TopContainer>
-            {!isLoggedIn && IODIDE_PUBLIC && <MarketingCopySplash />}
-            {!isLoggedIn && !IODIDE_PUBLIC && <LetsGetStarted />}
+            {!isLoggedIn && process.env.IODIDE_PUBLIC && (
+              <MarketingCopySplash />
+            )}
+            {!isLoggedIn && !process.env.IODIDE_PUBLIC && <LetsGetStarted />}
             {isLoggedIn && <LoggedInSplash userInfo={this.props.userInfo} />}
             <PageHeader>Try These Examples</PageHeader>
             <FeaturedNotebooks width={`${sharedProperties.pageWidth}px`} />

--- a/src/shared/components/footer.jsx
+++ b/src/shared/components/footer.jsx
@@ -1,4 +1,3 @@
-/* global IODIDE_PUBLIC */
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "react-emotion";
@@ -31,7 +30,7 @@ const Footer = ({ showIcon = true }) => (
       <p>
         iodide is brought to you by <a href="https://mozilla.org">Mozilla</a>.
       </p>
-      {IODIDE_PUBLIC && (
+      {process.env.IODIDE_PUBLIC && (
         <p>
           Content available under the terms of the&nbsp;
           <a
@@ -45,7 +44,7 @@ const Footer = ({ showIcon = true }) => (
         </p>
       )}
       {// only display terms of service on an official mozilla installation
-      IODIDE_PUBLIC && (
+      process.env.IODIDE_PUBLIC && (
         <ul>
           <li>Alpha Software</li>
           <li>

--- a/src/shared/components/user-menu.jsx
+++ b/src/shared/components/user-menu.jsx
@@ -1,5 +1,3 @@
-/* global USE_OPENIDC_AUTH */
-
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -109,7 +107,7 @@ export default class UserMenu extends React.Component {
                   <MenuItem onClick={this.goToProfile}>Your Profile</MenuItem>
                   <MenuDivider />
                   <MenuItem onClick={this.goToDocs}>Docs</MenuItem>
-                  {!USE_OPENIDC_AUTH && (
+                  {!process.env.USE_OPENIDC_AUTH && (
                     <MenuItem onClick={this.logout}>Log Out</MenuItem>
                   )}
                 </Menu>

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -23,5 +23,6 @@ global.IODIDE_CSS_PATH = "testing IODIDE_CSS_PATH";
 global.IODIDE_VERSION = "testing IODIDE_VERSION";
 global.IODIDE_EVAL_FRAME_ORIGIN = "testing IODIDE_EVAL_FRAME_ORIGIN";
 global.PYODIDE_VERSION = "testing PYODIDE_VERSION";
+process.env.NODE_ENV = "test";
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,7 +155,7 @@ module.exports = env => {
       new MiniCssExtractPlugin({
         filename: `[name].${APP_VERSION_STRING}.css`
       }),
-      new WriteFilePlugin(),
+      new WriteFilePlugin()
       // Use an external helper script, due to https://github.com/1337programming/webpack-shell-plugin/issues/41
     ],
     devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ const plugins = [];
 // const config
 module.exports = env => {
   env = env || ""; // eslint-disable-line no-param-reassign
-  process.env.NODE_ENV = env.NODE_ENV || "test";
+  process.env.NODE_ENV = env.NODE_ENV || "production";
 
   if (!process.env.NODE_ENV.startsWith("dev")) {
     plugins.push(new UglifyJSPlugin());

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,8 +38,9 @@ const plugins = [];
 // const config
 module.exports = env => {
   env = env || ""; // eslint-disable-line no-param-reassign
+  process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
-  if (!env.startsWith("dev")) {
+  if (!process.env.NODE_ENV.startsWith("dev")) {
     plugins.push(new UglifyJSPlugin());
   }
 
@@ -137,15 +138,15 @@ module.exports = env => {
           IOMD: ""
         })
       }),
+      new webpack.EnvironmentPlugin({
+        NODE_ENV: "production"
+      }),
       new webpack.DefinePlugin({
         IODIDE_VERSION: JSON.stringify(APP_VERSION_STRING),
         IODIDE_EVAL_FRAME_ORIGIN: JSON.stringify(EVAL_FRAME_ORIGIN),
         IODIDE_EDITOR_ORIGIN: JSON.stringify(EDITOR_ORIGIN),
         IODIDE_JS_PATH: JSON.stringify(APP_PATH_STRING),
         IODIDE_CSS_PATH: JSON.stringify(CSS_PATH_STRING),
-        IODIDE_BUILD_MODE: JSON.stringify(
-          env && env.startsWith("dev") ? "dev" : "production"
-        ),
         IODIDE_REDUX_LOG_MODE: JSON.stringify(reduxLogMode),
         USE_LOCAL_PYODIDE: JSON.stringify(USE_LOCAL_PYODIDE),
         USE_OPENIDC_AUTH: JSON.stringify(USE_OPENIDC_AUTH),
@@ -154,7 +155,7 @@ module.exports = env => {
       new MiniCssExtractPlugin({
         filename: `[name].${APP_VERSION_STRING}.css`
       }),
-      new WriteFilePlugin()
+      new WriteFilePlugin(),
       // Use an external helper script, due to https://github.com/1337programming/webpack-shell-plugin/issues/41
     ],
     devServer: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ const plugins = [];
 // const config
 module.exports = env => {
   env = env || ""; // eslint-disable-line no-param-reassign
-  process.env.NODE_ENV = env.NODE_ENV || "production";
+  process.env.NODE_ENV = env.NODE_ENV || "test";
 
   if (!process.env.NODE_ENV.startsWith("dev")) {
     plugins.push(new UglifyJSPlugin());

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,13 +15,12 @@ const reduxLogMode =
   process.env.REDUX_LOGGING === "VERBOSE" ? "VERBOSE" : "SILENT";
 
 const evalFrameHtmlTemplate = require("./src/eval-frame/html-template.js");
+
 const evalFrameHtmlTemplateCompiler = _.template(evalFrameHtmlTemplate);
 
 const DEV_SERVER_PORT = 8000;
 
 const BUILD_DIR = path.resolve(__dirname, "build/");
-let APP_PATH_STRING;
-let CSS_PATH_STRING;
 
 let { EDITOR_ORIGIN } = process.env;
 let { EVAL_FRAME_ORIGIN } = process.env;
@@ -49,8 +48,6 @@ module.exports = env => {
     EDITOR_ORIGIN ||
     process.env.SERVER_URI ||
     `http://localhost:${DEV_SERVER_PORT}/`;
-  APP_PATH_STRING = `${EDITOR_ORIGIN}/`;
-  CSS_PATH_STRING = `${EDITOR_ORIGIN}/`;
 
   EVAL_FRAME_ORIGIN = EVAL_FRAME_ORIGIN || EDITOR_ORIGIN;
 
@@ -113,12 +110,9 @@ module.exports = env => {
         cwd: process.cwd()
       }),
       new UnusedWebpackPlugin({
-        // Source directories
-        directories: [path.join(__dirname, "src")],
-        // Exclude patterns
-        exclude: ["*.test.js"],
-        // Root directory (optional)
-        root: __dirname
+        directories: [path.join(__dirname, "src")], // Source directories
+        exclude: ["*.test.js"], // Exclude patterns
+        root: __dirname // Root directory (optional)
       }),
       new LodashModuleReplacementPlugin(),
       new webpack.ProvidePlugin({
@@ -132,23 +126,18 @@ module.exports = env => {
         fileName: `iodide.eval-frame.${APP_VERSION_STRING}.html`,
         content: evalFrameHtmlTemplateCompiler({
           APP_VERSION_STRING: `eval-frame.${APP_VERSION_STRING}`,
-          EVAL_FRAME_ORIGIN,
-          CSS_PATH_STRING,
-          NOTEBOOK_TITLE: "new notebook",
-          IOMD: ""
+          EVAL_FRAME_ORIGIN
         })
       }),
       new webpack.EnvironmentPlugin(["NODE_ENV"]),
       new webpack.DefinePlugin({
-        IODIDE_VERSION: JSON.stringify(APP_VERSION_STRING),
+        "process.env.IODIDE_VERSION": JSON.stringify(APP_VERSION_STRING),
         IODIDE_EVAL_FRAME_ORIGIN: JSON.stringify(EVAL_FRAME_ORIGIN),
         IODIDE_EDITOR_ORIGIN: JSON.stringify(EDITOR_ORIGIN),
-        IODIDE_JS_PATH: JSON.stringify(APP_PATH_STRING),
-        IODIDE_CSS_PATH: JSON.stringify(CSS_PATH_STRING),
-        IODIDE_REDUX_LOG_MODE: JSON.stringify(reduxLogMode),
-        USE_LOCAL_PYODIDE: JSON.stringify(USE_LOCAL_PYODIDE),
-        USE_OPENIDC_AUTH: JSON.stringify(USE_OPENIDC_AUTH),
-        IODIDE_PUBLIC: !!IODIDE_PUBLIC
+        "process.env.IODIDE_REDUX_LOG_MODE": JSON.stringify(reduxLogMode),
+        "process.env.USE_LOCAL_PYODIDE": JSON.stringify(USE_LOCAL_PYODIDE),
+        "process.env.USE_OPENIDC_AUTH": JSON.stringify(USE_OPENIDC_AUTH),
+        "process.env.IODIDE_PUBLIC": !!IODIDE_PUBLIC
       }),
       new MiniCssExtractPlugin({
         filename: `[name].${APP_VERSION_STRING}.css`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ const plugins = [];
 // const config
 module.exports = env => {
   env = env || ""; // eslint-disable-line no-param-reassign
-  process.env.NODE_ENV = process.env.NODE_ENV || "production";
+  process.env.NODE_ENV = env.NODE_ENV || "production";
 
   if (!process.env.NODE_ENV.startsWith("dev")) {
     plugins.push(new UglifyJSPlugin());
@@ -138,9 +138,7 @@ module.exports = env => {
           IOMD: ""
         })
       }),
-      new webpack.EnvironmentPlugin({
-        NODE_ENV: "production"
-      }),
+      new webpack.EnvironmentPlugin(["NODE_ENV"]),
       new webpack.DefinePlugin({
         IODIDE_VERSION: JSON.stringify(APP_VERSION_STRING),
         IODIDE_EVAL_FRAME_ORIGIN: JSON.stringify(EVAL_FRAME_ORIGIN),


### PR DESCRIPTION
Creating pull Request to migrate from method of parsing environment into IODIDE_BUILD_MODE variable and instead using webpack's defined process.env.NODE_ENV variable. This is a code quality issue in order to align the project more towards Webpack best practices. (#1899).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N / A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible 
changes.
Changelog has been modified to describe change that was made. 
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
There are no automated tests as there were only two major cases that had to be verified via the command line. 
First Case: Is process.env.NODE_ENV exposed properly to the react components on build (pass)
Seconds case: Is process.env.NODE_ENV exposed to webpack.config.js on build. (pass)

