### PR TITLE
Fix accidentally added reference to jsmd

### DIFF
--- a/src/editor/components/modals/file-modal/footer.jsx
+++ b/src/editor/components/modals/file-modal/footer.jsx
@@ -8,7 +8,7 @@ const FileFooter = styled.footer`
 export default () => (
   <FileFooter>
     These files can be loaded by{" "}
-    <a href="https://iodide-project.github.io/docs/jsmd/#fetch-chunks-fetch">
+    <a href="https://iodide-project.github.io/docs/iomd/#fetch-chunks-fetch">
       fetch chunks
     </a>{" "}
     and manipulated via the{" "}


### PR DESCRIPTION
We switched to naming everything "iomd", but this managed to sneak in (since
it was in a pending PR)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [N/A] **Tests**: This PR includes thorough tests or an explanation of why it does not
