### PR TITLE
Fix authentication holes in files api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Reduce the image size for small user icons, to improve loading times (fixes #1711)
 - Fix loading revision browser when authentication credentials are required
   for read-only API endpoints (partially fixes #1965)
+- Fix authentication hole in files api validation that would allow any logged-in
+  user to modify or create a file on another's behalf.
 
 # 0.8.0 (2019-06-18)
 

--- a/server/files/api_views.py
+++ b/server/files/api_views.py
@@ -21,7 +21,8 @@ class FileViewSet(viewsets.ModelViewSet):
         super().perform_destroy(instance)
 
     def create(self, request):
-        (metadata, file) = (json.loads(self.request.data["metadata"]), self.request.data["file"])
+        metadata = json.loads(self.request.data["metadata"])
+        file =  self.request.data["file"]
 
         notebook = Notebook.objects.get(id=metadata["notebook_id"])
         if notebook.owner != self.request.user:

--- a/server/files/api_views.py
+++ b/server/files/api_views.py
@@ -1,6 +1,7 @@
 import json
 
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -15,39 +16,40 @@ class FileViewSet(viewsets.ModelViewSet):
 
     http_method_names = ["post", "put", "delete"]
 
-    def perform_destroy(self, instance):
-        if instance.notebook.owner != self.request.user:
-            raise PermissionDenied
-        super().perform_destroy(instance)
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance.notebook.owner != request.user:
+             raise PermissionDenied
+        return super().destroy(request, *args, **kwargs)
 
     def create(self, request):
         metadata = json.loads(self.request.data["metadata"])
-        file =  self.request.data["file"]
+        file = self.request.data["file"]
 
-        notebook = Notebook.objects.get(id=metadata["notebook_id"])
+        notebook = get_object_or_404(Notebook, id=metadata["notebook_id"])
         if notebook.owner != self.request.user:
             raise PermissionDenied
 
-        f = File.objects.create(
+        file_obj = File.objects.create(
             notebook_id=notebook.id, filename=metadata["filename"], content=file.read()
         )
-        serializer = FilesSerializer(f)
-        return Response(serializer.data, status=201)
+        return Response(FilesSerializer(file_obj).data, status=201)
 
     def update(self, request, pk):
-        (metadata, file) = (json.loads(self.request.data["metadata"]), self.request.data["file"])
+        metadata = json.loads(self.request.data["metadata"])
+        file = self.request.data["file"]
 
-        notebook = Notebook.objects.get(id=metadata["notebook_id"])
+        notebook = get_object_or_404(Notebook, id=metadata["notebook_id"])
         if notebook.owner != self.request.user:
             raise PermissionDenied
 
-        file_to_update = File.objects.get(pk=pk)
+        file_obj_to_update = get_object_or_404(File, pk=pk)
         updated_filename = metadata["filename"].strip()
-        file_to_update.filename = updated_filename
+        file_obj_to_update.filename = updated_filename
         if file:
-            file_to_update.content = file.read()
-        file_to_update.save()
-        serializer = FilesSerializer(file_to_update)
-        return Response(serializer.data, status=201)
+            file_obj_to_update.content = file.read()
+        file_obj_to_update.save()
+
+        return Response(FilesSerializer(file_obj_to_update).data, status=201)
 
     queryset = File.objects.all()

--- a/server/files/api_views.py
+++ b/server/files/api_views.py
@@ -19,7 +19,7 @@ class FileViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         if instance.notebook.owner != request.user:
-             raise PermissionDenied
+            raise PermissionDenied
         return super().destroy(request, *args, **kwargs)
 
     def create(self, request):

--- a/server/tests/test_file_api.py
+++ b/server/tests/test_file_api.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 
+import pytest
 from django.urls import reverse
 
 from helpers import get_rest_framework_time_string
@@ -37,7 +38,11 @@ def test_post_to_file_api(fake_user, client, test_notebook):
         }
 
 
-def test_post_to_file_api_restricted(fake_user, client, test_notebook):
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_post_to_file_api_restricted(fake_user2, client, test_notebook, logged_in):
+    # two cases: logged in as wrong user, not logged in
+    if logged_in:
+        client.force_login(user=fake_user2)
     with tempfile.NamedTemporaryFile(mode="w+") as f:
         resp = post_file(f, client, test_notebook)
         assert resp.status_code == 403
@@ -75,7 +80,11 @@ def test_put_to_file_api(fake_user, api_client, test_notebook, test_file):
         }
 
 
-def test_put_to_file_api_restricted(fake_user, api_client, test_notebook, test_file):
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_put_to_file_api_restricted(fake_user2, api_client, test_notebook, test_file, logged_in):
+    # two cases: logged in as wrong user, not logged in
+    if logged_in:
+        api_client.force_authenticate(user=fake_user2)
     with tempfile.NamedTemporaryFile(mode="w+") as f:
         resp = put_file(f, api_client, test_file, test_notebook)
         assert resp.status_code == 403


### PR DESCRIPTION
We allowed modifying or adding files to any notebook for a logged in user,
which obviously isn't what we want. We should only allow the user that
owns a notebook to do this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not