### PR TITLE
Use mapDispatchToProps shorthand

### DIFF
--- a/src/editor/components/iomd-editor.jsx
+++ b/src/editor/components/iomd-editor.jsx
@@ -215,17 +215,16 @@ function mapStateToProps(state) {
 //     actions: bindActionCreators(actions, dispatch)
 //   };
 // }
-export function mapDispatchToProps(dispatch) {
-  return {
-    updateIomdContent: content => {
+const mapDispatchToProps = {
+  updateIomdContent: content => {
+    return dispatch => {
       dispatch(updateIomdContent(content));
       dispatch(updateAutosave());
-    },
-    updateEditorCursor: (line, col) => dispatch(updateEditorCursor(line, col)),
-    updateEditorSelections: selections =>
-      dispatch(updateEditorSelections(selections))
-  };
-}
+    };
+  },
+  updateEditorCursor,
+  updateEditorSelections
+};
 
 export default connect(
   mapStateToProps,

--- a/src/editor/components/menu/view-mode-toggle-button.jsx
+++ b/src/editor/components/menu/view-mode-toggle-button.jsx
@@ -59,12 +59,10 @@ export function mapStateToProps(state) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    setViewModeToReport: () => dispatch(setViewMode("REPORT_VIEW")),
-    setViewModeToExplore: () => dispatch(setViewMode("EXPLORE_VIEW"))
-  };
-}
+const mapDispatchToProps = {
+  setViewModeToReport: () => setViewMode("REPORT_VIEW"),
+  setViewModeToExplore: () => setViewMode("EXPLORE_VIEW")
+};
 
 export default connect(
   mapStateToProps,

--- a/src/editor/components/modals/history-modal.jsx
+++ b/src/editor/components/modals/history-modal.jsx
@@ -52,14 +52,6 @@ class HistoryModalUnconnected extends React.Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    getNotebookRevisionList: () => {
-      dispatch(getNotebookRevisionList());
-    }
-  };
-}
-
 export function mapStateToProps(state) {
   const notebookHistory = state.notebookHistory || {};
   const { errorGettingRevisionList, revisionListFetchStatus } = notebookHistory;
@@ -72,5 +64,5 @@ export function mapStateToProps(state) {
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  { getNotebookRevisionList } // mapDispatchToProps shorthand
 )(HistoryModalUnconnected);

--- a/src/editor/components/modals/iodide-modals-root.jsx
+++ b/src/editor/components/modals/iodide-modals-root.jsx
@@ -51,11 +51,9 @@ export function mapStateToProps(state) {
   };
 }
 
-export function mapDispatchToProps(dispatch) {
-  return {
-    closeModals: () => dispatch(setModalState("MODALS_CLOSED"))
-  };
-}
+const mapDispatchToProps = {
+  closeModals: () => setModalState("MODALS_CLOSED")
+};
 
 export default connect(
   mapStateToProps,

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -73,14 +73,6 @@ class RevisionListUnconnected extends React.Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    updateSelectedRevisionId: revisionId => {
-      dispatch(updateSelectedRevisionId(revisionId));
-    }
-  };
-}
-
 export function mapStateToProps(state) {
   const notebookHistory = state.notebookHistory || {};
   const { revisionList, selectedRevisionId } = notebookHistory;
@@ -93,5 +85,5 @@ export function mapStateToProps(state) {
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  { updateSelectedRevisionId } // mapDispatchToProps shorthand
 )(RevisionListUnconnected);

--- a/src/editor/components/pane-layout/layout-manager.jsx
+++ b/src/editor/components/pane-layout/layout-manager.jsx
@@ -144,13 +144,7 @@ export function mapStateToProps(state) {
   };
 }
 
-export function mapDispatchToProps(dispatch) {
-  return {
-    updateLayoutPositions: layout => dispatch(updateLayoutPositions(layout))
-  };
-}
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  { updateLayoutPositions } // mapDispatchToProps shorthand
 )(LayoutManagerUnconnected);


### PR DESCRIPTION
Where possible / easy, let's use redux's convenience APIs (https://react-redux.js.org/using-react-redux/connect-mapdispatch) for connecting dispatchers to avoid boilerplate.

This is just some incremental cleanup