### PR TITLE
update verbose logging to collapse actions by default,

### DIFF
--- a/src/editor/store.js
+++ b/src/editor/store.js
@@ -32,6 +32,13 @@ if (process.env.NODE_ENV === "production") {
     applyMiddleware(thunk),
     applyMiddleware(sagaMiddleware)
   );
+} else if (process.env.IODIDE_REDUX_LOG_MODE === "VERY_VERBOSE") {
+  finalReducer = createValidatedReducer(reducer, stateSchema);
+  enhancer = compose(
+    applyMiddleware(thunk),
+    applyMiddleware(sagaMiddleware),
+    applyMiddleware(createLogger({ collapsed: () => true }))
+  );
 } else {
   finalReducer = createValidatedReducer(reducer, stateSchema);
   enhancer = compose(
@@ -45,7 +52,8 @@ if (process.env.NODE_ENV === "production") {
             "UPDATE_MARKDOWN_CHUNKS",
             "UPDATE_CURSOR",
             "UPDATE_SELECTIONS"
-          ].includes(action.type)
+          ].includes(action.type),
+        collapsed: () => true
       })
     )
   );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,9 @@ const CircularDependencyPlugin = require("circular-dependency-plugin");
 const UnusedWebpackPlugin = require("unused-webpack-plugin");
 const _ = require("lodash");
 
-const reduxLogMode =
-  process.env.REDUX_LOGGING === "VERBOSE" ? "VERBOSE" : "SILENT";
+const reduxLogMode = process.env.REDUX_LOGGING
+  ? process.env.REDUX_LOGGING
+  : "SILENT";
 
 const evalFrameHtmlTemplate = require("./src/eval-frame/html-template.js");
 


### PR DESCRIPTION
small changes to make the redu action logging more usable:
- update VERBOSE logging to collapse actions by default
- add a VERY_VERBOSE mode that shows all actions (including edit actions)

@wlach @hamilton @mdboom i think this should not be controversial, lmk what you think.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
