### PR TITLE
simplify updateIomdContent action to get rid of obsolete dispatch

### DIFF
--- a/src/editor/actions/__tests__/local-autosave-actions.test.js
+++ b/src/editor/actions/__tests__/local-autosave-actions.test.js
@@ -81,21 +81,7 @@ describe("restoreLocalAutosave", () => {
       undefined
     );
     expect(store.getActions()).toEqual([
-      { type: "UPDATE_MARKDOWN_CHUNKS", reportChunks: [] },
-      {
-        type: "UPDATE_IOMD_CONTENT",
-        iomd: "autosaved",
-        iomdChunks: [
-          {
-            chunkContent: "autosaved",
-            chunkId: "1679214136_0",
-            chunkType: "",
-            endLine: 0,
-            evalFlags: [],
-            startLine: 0
-          }
-        ]
-      },
+      { type: "UPDATE_IOMD_CONTENT", iomd: "autosaved" },
       { type: "UPDATE_NOTEBOOK_TITLE", title: "autosaved title" },
       {
         type: "UPDATE_NOTEBOOK_INFO",

--- a/src/editor/actions/__tests__/server-save-actions.test.js
+++ b/src/editor/actions/__tests__/server-save-actions.test.js
@@ -225,22 +225,8 @@ describe("revertToLatestServerRevision", () => {
       undefined
     );
     expect(store.getActions()).toEqual([
-      { type: "UPDATE_MARKDOWN_CHUNKS", reportChunks: [] },
-      {
-        type: "UPDATE_IOMD_CONTENT",
-        iomd: "newer content",
-        iomdChunks: [
-          {
-            chunkContent: "newer content",
-            chunkId: "1476526502_0",
-            chunkType: "",
-            endLine: 0,
-            evalFlags: [],
-            startLine: 0
-          }
-        ]
-      },
-      { title: "newer revision", type: "UPDATE_NOTEBOOK_TITLE" },
+      { type: "UPDATE_IOMD_CONTENT", iomd: "newer content" },
+      { type: "UPDATE_NOTEBOOK_TITLE", title: "newer revision" },
       {
         type: "UPDATE_NOTEBOOK_INFO",
         notebookInfo: {

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -10,7 +10,6 @@ import {
   isLoggedIn
 } from "../tools/server-tools";
 
-import { iomdParser } from "../iomd-tools/iomd-parser";
 import { getChunkContainingLine } from "../iomd-tools/iomd-selection";
 
 import { addAppMessageToConsoleHistory } from "./console-message-actions";
@@ -31,34 +30,7 @@ export function updateAppMessages(messageObj) {
 }
 
 export function updateIomdContent(text) {
-  return (dispatch, getState) => {
-    const iomdChunks = iomdParser(text);
-    const languageDefinitions = getState().languageDefinitions || {};
-    const reportChunkTypes = Object.keys(languageDefinitions).concat([
-      "md",
-      "html",
-      "css"
-    ]);
-    const reportChunks = iomdChunks
-      .filter(c => reportChunkTypes.includes(c.chunkType))
-      .map(c => ({
-        chunkContent: c.chunkContent,
-        chunkType: c.chunkType,
-        chunkId: c.chunkId,
-        evalFlags: c.evalFlags
-      }));
-
-    dispatch({
-      // this dispatch really just forwards to the eval frame
-      type: "UPDATE_MARKDOWN_CHUNKS",
-      reportChunks
-    });
-    dispatch({
-      type: "UPDATE_IOMD_CONTENT",
-      iomd: text,
-      iomdChunks
-    });
-  };
+  return { type: "UPDATE_IOMD_CONTENT", iomd: text };
 }
 
 export function toggleWrapInEditors() {

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -1,5 +1,6 @@
 import { newNotebook } from "../state-schemas/editor-state-prototypes";
 import { historyIdGen } from "../tools/id-generators";
+import { iomdParser } from "../iomd-tools/iomd-parser";
 
 function newAppMessage(
   appMessageId,
@@ -64,8 +65,8 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case "UPDATE_IOMD_CONTENT": {
-      const { iomd, iomdChunks } = action;
-      return Object.assign({}, state, { iomd, iomdChunks });
+      const { iomd } = action;
+      return Object.assign({}, state, { iomd, iomdChunks: iomdParser(iomd) });
     }
 
     case "GETTING_NOTEBOOK_REVISION_LIST": {


### PR DESCRIPTION
this is a teeny code quality PR to remove the "UPDATE_MARKDOWN_CHUNKS" dispatch, which has not actually done anything for like 6 months (it was used as a bridge before we cleaned up how we push state to the eval-frame). this in turn allows us to simplify that thunk down to a plain action, and move more of the logic into the reducer. yay!

(2 tests updated to reflect the change)

@hamilton and @wlach just fyi -- review if you wish, but this is a minor bit of code clean up that i'm comfortable merging, so don't feel the need to context switch. i'll merge tomorrow or maybe later tonight.