### PR TITLE
Hide empty revision

### DIFF
--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -166,51 +166,43 @@ export function getNotebookRevisionList() {
     });
     getRevisionList(getNotebookID(getState()), isLoggedIn(getState()))
       .then(revisionList => {
-        if (getState().notebookHistory.selectedRevisionId === undefined) {
-          getRevisions(
-            getNotebookID(getState()),
-            [revisionList[0].id],
-            isLoggedIn(getState())
-          )
-            .then(revisions => {
-              if (revisions.length > 0) {
-                if (getState().iomd.trim() === revisions[0].content.trim()) {
-                  dispatch({
-                    type:
-                      "UPDATE_NOTEBOOK_HISTORY_BROWSER_SELECTED_REVISION_ID",
-                    selectedRevisionId: revisions[0].id
-                  });
-                  dispatch({
-                    type:
-                      "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES",
-                    hasLocalOnlyChanges: false
-                  });
-                  dispatch({
-                    type: "GOT_NOTEBOOK_REVISION_LIST",
-                    selectedRevisionId: revisions[0].id,
-                    revisionList
-                  });
-                  getRequiredRevisionContent(getState(), dispatch);
-                } else {
-                  dispatch({
-                    type: "GOT_NOTEBOOK_REVISION_LIST",
-                    revisionList
-                  });
-                }
+        getRevisions(
+          getNotebookID(getState()),
+          [revisionList[0].id],
+          isLoggedIn(getState())
+        )
+          .then(revisions => {
+            if (revisions.length > 0) {
+              if (getState().iomd.trim() === revisions[0].content.trim()) {
+                dispatch({
+                  type: "UPDATE_NOTEBOOK_HISTORY_BROWSER_SELECTED_REVISION_ID",
+                  selectedRevisionId: revisions[0].id
+                });
+                dispatch({
+                  type:
+                    "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES",
+                  hasLocalOnlyChanges: false
+                });
+                dispatch({
+                  type: "GOT_NOTEBOOK_REVISION_LIST",
+                  selectedRevisionId: revisions[0].id,
+                  revisionList
+                });
+                getRequiredRevisionContent(getState(), dispatch);
               } else {
-                dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
+                dispatch({
+                  type: "GOT_NOTEBOOK_REVISION_LIST",
+                  revisionList
+                });
+                getRequiredRevisionContent(getState(), dispatch);
               }
-            })
-            .catch(() => {
+            } else {
               dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
-            });
-        } else {
-          dispatch({
-            type: "GOT_NOTEBOOK_REVISION_LIST",
-            revisionList
+            }
+          })
+          .catch(() => {
+            dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
           });
-          getRequiredRevisionContent(getState(), dispatch);
-        }
       })
       .catch(() => {
         dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });

--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -160,13 +160,57 @@ export function updateSelectedRevisionId(selectedRevisionId) {
 export function getNotebookRevisionList() {
   return (dispatch, getState) => {
     dispatch({ type: "GETTING_NOTEBOOK_REVISION_LIST" });
+    dispatch({
+      type: "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES",
+      hasLocalOnlyChanges: true
+    });
     getRevisionList(getNotebookID(getState()), isLoggedIn(getState()))
       .then(revisionList => {
-        dispatch({
-          type: "GOT_NOTEBOOK_REVISION_LIST",
-          revisionList
-        });
-        getRequiredRevisionContent(getState(), dispatch);
+        if (getState().notebookHistory.selectedRevisionId === undefined) {
+          getRevisions(
+            getNotebookID(getState()),
+            [revisionList[0].id],
+            isLoggedIn(getState())
+          )
+            .then(revisions => {
+              if (revisions.length > 0) {
+                if (getState().iomd.trim() === revisions[0].content.trim()) {
+                  dispatch({
+                    type:
+                      "UPDATE_NOTEBOOK_HISTORY_BROWSER_SELECTED_REVISION_ID",
+                    selectedRevisionId: revisions[0].id
+                  });
+                  dispatch({
+                    type:
+                      "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES",
+                    hasLocalOnlyChanges: false
+                  });
+                  dispatch({
+                    type: "GOT_NOTEBOOK_REVISION_LIST",
+                    selectedRevisionId: revisions[0].id,
+                    revisionList
+                  });
+                  getRequiredRevisionContent(getState(), dispatch);
+                } else {
+                  dispatch({
+                    type: "GOT_NOTEBOOK_REVISION_LIST",
+                    revisionList
+                  });
+                }
+              } else {
+                dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
+              }
+            })
+            .catch(() => {
+              dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
+            });
+        } else {
+          dispatch({
+            type: "GOT_NOTEBOOK_REVISION_LIST",
+            revisionList
+          });
+          getRequiredRevisionContent(getState(), dispatch);
+        }
       })
       .catch(() => {
         dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -23,7 +23,7 @@ class RevisionListUnconnected extends React.Component {
       })
     ),
     selectedRevisionId: PropTypes.number,
-    hideLocalChanges: PropTypes.bool,
+    haveLocalChanges: PropTypes.bool,
     updateSelectedRevisionId: PropTypes.func.isRequired
   };
 
@@ -43,7 +43,7 @@ class RevisionListUnconnected extends React.Component {
   render() {
     if (this.props.revisionList !== undefined) {
       if (
-        this.props.hideLocalChanges &&
+        !this.props.haveLocalChanges &&
         this.props.selectedRevisionId === undefined
       ) {
         if (this.props.revisionList.length > 0) {
@@ -55,7 +55,7 @@ class RevisionListUnconnected extends React.Component {
     return (
       <RevisionListContainer>
         <List>
-          {!this.props.hideLocalChanges && (
+          {this.props.haveLocalChanges && (
             <ListItem
               button
               key="local-changes"
@@ -96,19 +96,19 @@ export function mapStateToProps(state) {
     selectedRevisionId
   } = notebookHistory;
 
-  let hideLocalChanges = true;
+  let haveLocalChanges = false;
 
   if (revisionContentFetchStatus === "IDLE") {
     const previousRevisionContent =
       revisionList.length > 0 ? revisionContent[revisionList[0].id] : "";
 
-    hideLocalChanges = state.iomd === previousRevisionContent;
+    haveLocalChanges = state.iomd !== previousRevisionContent;
   }
 
   return {
     revisionList,
     selectedRevisionId,
-    hideLocalChanges
+    haveLocalChanges
   };
 }
 

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -41,17 +41,6 @@ class RevisionListUnconnected extends React.Component {
   }
 
   render() {
-    if (this.props.revisionList !== undefined) {
-      if (
-        !this.props.haveLocalChanges &&
-        this.props.selectedRevisionId === undefined
-      ) {
-        if (this.props.revisionList.length > 0) {
-          this.revisionClicked(this.props.revisionList[0].id);
-        }
-      }
-    }
-
     return (
       <RevisionListContainer>
         <List>

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -23,6 +23,7 @@ class RevisionListUnconnected extends React.Component {
       })
     ),
     selectedRevisionId: PropTypes.number,
+    hideLocalChanges: PropTypes.bool,
     updateSelectedRevisionId: PropTypes.func.isRequired
   };
 
@@ -40,17 +41,30 @@ class RevisionListUnconnected extends React.Component {
   }
 
   render() {
+    if (this.props.revisionList !== undefined) {
+      if (
+        this.props.hideLocalChanges &&
+        this.props.selectedRevisionId === undefined
+      ) {
+        if (this.props.revisionList.length > 0) {
+          this.revisionClicked(this.props.revisionList[0].id);
+        }
+      }
+    }
+
     return (
       <RevisionListContainer>
         <List>
-          <ListItem
-            button
-            key="local-changes"
-            onClick={() => this.revisionClicked(undefined)}
-            selected={this.props.selectedRevisionId === undefined}
-          >
-            <ListItemText primary="Unsaved Changes" />
-          </ListItem>
+          {!this.props.hideLocalChanges && (
+            <ListItem
+              button
+              key="local-changes"
+              onClick={() => this.revisionClicked(undefined)}
+              selected={this.props.selectedRevisionId === undefined}
+            >
+              <ListItemText primary="Unsaved Changes" />
+            </ListItem>
+          )}
           {this.props.revisionList &&
             this.props.revisionList.map(revision => (
               <ListItem
@@ -75,11 +89,26 @@ class RevisionListUnconnected extends React.Component {
 
 export function mapStateToProps(state) {
   const notebookHistory = state.notebookHistory || {};
-  const { revisionList, selectedRevisionId } = notebookHistory;
+  const {
+    revisionContentFetchStatus,
+    revisionContent,
+    revisionList,
+    selectedRevisionId
+  } = notebookHistory;
+
+  let hideLocalChanges = true;
+
+  if (revisionContentFetchStatus === "IDLE") {
+    const previousRevisionContent =
+      revisionList.length > 0 ? revisionContent[revisionList[0].id] : "";
+
+    hideLocalChanges = state.iomd === previousRevisionContent;
+  }
 
   return {
     revisionList,
-    selectedRevisionId
+    selectedRevisionId,
+    hideLocalChanges
   };
 }
 

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -23,7 +23,7 @@ class RevisionListUnconnected extends React.Component {
       })
     ),
     selectedRevisionId: PropTypes.number,
-    haveLocalChanges: PropTypes.bool,
+    hasLocalOnlyChanges: PropTypes.bool,
     updateSelectedRevisionId: PropTypes.func.isRequired
   };
 
@@ -44,7 +44,7 @@ class RevisionListUnconnected extends React.Component {
     return (
       <RevisionListContainer>
         <List>
-          {this.props.haveLocalChanges && (
+          {this.props.hasLocalOnlyChanges && (
             <ListItem
               button
               key="local-changes"
@@ -79,25 +79,15 @@ class RevisionListUnconnected extends React.Component {
 export function mapStateToProps(state) {
   const notebookHistory = state.notebookHistory || {};
   const {
-    revisionContentFetchStatus,
-    revisionContent,
+    hasLocalOnlyChanges,
     revisionList,
     selectedRevisionId
   } = notebookHistory;
 
-  let haveLocalChanges = false;
-
-  if (revisionContentFetchStatus === "IDLE") {
-    const previousRevisionContent =
-      revisionList.length > 0 ? revisionContent[revisionList[0].id] : "";
-
-    haveLocalChanges = state.iomd !== previousRevisionContent;
-  }
-
   return {
+    hasLocalOnlyChanges,
     revisionList,
-    selectedRevisionId,
-    haveLocalChanges
+    selectedRevisionId
   };
 }
 

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -79,13 +79,26 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case "GOT_NOTEBOOK_REVISION_LIST": {
-      const { revisionList, selectedRevisionId } = action;
+      const { revisionContent, revisionList, selectedRevisionId } = action;
+
+      const previousRevisionContent =
+        revisionList.length > 0 ? revisionContent[revisionList[0].id] : "";
+
+      let passedRevisionId = selectedRevisionId;
+
+      if (
+        selectedRevisionId === undefined &&
+        state.iomd === previousRevisionContent
+      ) {
+        passedRevisionId = revisionList[0].id;
+      }
+
       return Object.assign({}, state, {
         notebookHistory: {
           ...(state.notebookHistory || {}),
           revisionList,
           revisionListFetchStatus: "IDLE",
-          selectedRevisionId
+          passedRevisionId
         }
       });
     }

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -78,11 +78,12 @@ const notebookReducer = (state = newNotebook(), action) => {
       });
     }
 
-    case "GOT_NOTEBOOK_REVISION_LIST": {
-      const { revisionList, selectedRevisionId } = action;
+    case "UPDATE_NOTEBOOK_HISTORY": {
+      const { hasLocalOnlyChanges, revisionList, selectedRevisionId } = action;
       return Object.assign({}, state, {
         notebookHistory: {
           ...(state.notebookHistory || {}),
+          hasLocalOnlyChanges,
           revisionList,
           revisionListFetchStatus: "IDLE",
           selectedRevisionId
@@ -106,16 +107,6 @@ const notebookReducer = (state = newNotebook(), action) => {
         notebookHistory: {
           ...state.notebookHistory,
           selectedRevisionId
-        }
-      });
-    }
-
-    case "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES": {
-      const { hasLocalOnlyChanges } = action;
-      return Object.assign({}, state, {
-        notebookHistory: {
-          ...state.notebookHistory,
-          hasLocalOnlyChanges
         }
       });
     }

--- a/src/editor/reducers/notebook-reducer.js
+++ b/src/editor/reducers/notebook-reducer.js
@@ -79,26 +79,13 @@ const notebookReducer = (state = newNotebook(), action) => {
     }
 
     case "GOT_NOTEBOOK_REVISION_LIST": {
-      const { revisionContent, revisionList, selectedRevisionId } = action;
-
-      const previousRevisionContent =
-        revisionList.length > 0 ? revisionContent[revisionList[0].id] : "";
-
-      let passedRevisionId = selectedRevisionId;
-
-      if (
-        selectedRevisionId === undefined &&
-        state.iomd === previousRevisionContent
-      ) {
-        passedRevisionId = revisionList[0].id;
-      }
-
+      const { revisionList, selectedRevisionId } = action;
       return Object.assign({}, state, {
         notebookHistory: {
           ...(state.notebookHistory || {}),
           revisionList,
           revisionListFetchStatus: "IDLE",
-          passedRevisionId
+          selectedRevisionId
         }
       });
     }
@@ -119,6 +106,16 @@ const notebookReducer = (state = newNotebook(), action) => {
         notebookHistory: {
           ...state.notebookHistory,
           selectedRevisionId
+        }
+      });
+    }
+
+    case "UPDATE_NOTEBOOK_HISTORY_BROWSER_HAS_LOCAL_ONLY_CHANGES": {
+      const { hasLocalOnlyChanges } = action;
+      return Object.assign({}, state, {
+        notebookHistory: {
+          ...state.notebookHistory,
+          hasLocalOnlyChanges
         }
       });
     }

--- a/src/editor/state-schemas/state-schema.js
+++ b/src/editor/state-schemas/state-schema.js
@@ -215,7 +215,7 @@ export const stateProperties = {
     properties: {
       hasLocalOnlyChanges: {
         type: "boolean",
-        default: true
+        default: false
       },
       revisionContentFetchStatus: {
         type: "string",

--- a/src/editor/state-schemas/state-schema.js
+++ b/src/editor/state-schemas/state-schema.js
@@ -213,6 +213,10 @@ export const stateProperties = {
   notebookHistory: {
     type: "object",
     properties: {
+      hasLocalOnlyChanges: {
+        type: "boolean",
+        default: true
+      },
       revisionContentFetchStatus: {
         type: "string",
         enum: ["FETCHING", "ERROR", "IDLE"],
@@ -235,7 +239,7 @@ export const stateProperties = {
         },
         default: []
       },
-      selectedRevision: {
+      selectedRevisionId: {
         type: "number"
       },
       revisionContent: {


### PR DESCRIPTION
This pull request hides "Unsaved Changes" button and resorts to last available revision when there is no change, potentially solving https://github.com/iodide-project/iodide/issues/2046 issue.