### PR TITLE
Change `selectedRevision` to `selectedRevisionId`

### DIFF
--- a/src/editor/state-schemas/state-schema.js
+++ b/src/editor/state-schemas/state-schema.js
@@ -235,7 +235,7 @@ export const stateProperties = {
         },
         default: []
       },
-      selectedRevision: {
+      selectedRevisionId: {
         type: "number"
       },
       revisionContent: {


### PR DESCRIPTION
This pull request fixes scheme naming for `selectedRevisionId`