### PR TITLE
Clear local autosave on load if no different + fix local autosave detection

### DIFF
--- a/src/editor/actions/actions.js
+++ b/src/editor/actions/actions.js
@@ -4,7 +4,7 @@ import {
   getRevisionList,
   getRevisions
 } from "../../shared/server-api/revisions";
-import { havePendingAutosavedChanges } from "../tools/local-autosave";
+import { haveLocalAutosave } from "../tools/local-autosave";
 import {
   getNotebookID,
   getUserDataFromDocument,
@@ -163,7 +163,7 @@ export function getNotebookRevisionList() {
     dispatch({ type: "GETTING_NOTEBOOK_REVISION_LIST" });
     getRevisionList(getNotebookID(getState()), isLoggedIn(getState()))
       .then(revisionList => {
-        havePendingAutosavedChanges(getState())
+        haveLocalAutosave(getState())
           .then(havePendingChanges => {
             dispatch({
               type: "UPDATE_NOTEBOOK_HISTORY",

--- a/src/editor/actions/local-autosave-actions.js
+++ b/src/editor/actions/local-autosave-actions.js
@@ -1,4 +1,4 @@
-import { getLocalAutosave } from "../tools/local-autosave";
+import { getLocalAutosave, clearLocalAutosave } from "../tools/local-autosave";
 import { getRevisionID } from "../tools/server-tools";
 import { updateIomdContent, updateNotebookInfo, updateTitle } from "./actions";
 
@@ -37,6 +37,9 @@ export function restoreLocalAutosave() {
             localAutosaveState.parentRevisionId === originalLoadedRevisionId
         })
       );
+    } else {
+      // the local autosave is either corrupt or not at all different from what we had, just delete it
+      await clearLocalAutosave(state);
     }
   };
 }

--- a/src/editor/tools/__tests__/local-autosave.test.js
+++ b/src/editor/tools/__tests__/local-autosave.test.js
@@ -1,6 +1,6 @@
 import {
   getLocalAutosave,
-  havePendingAutosavedChanges,
+  haveLocalAutosave,
   writeLocalAutosave,
   clearLocalAutosave
 } from "../local-autosave";
@@ -15,18 +15,16 @@ describe("autosave basics", () => {
     });
 
     expect(await getLocalAutosave(state)).toEqual({});
-    expect(await havePendingAutosavedChanges(state)).toEqual(false);
+    expect(await haveLocalAutosave(state)).toEqual(false);
     await writeLocalAutosave(state);
     expect(await getLocalAutosave(state)).toEqual({
       iomd: state.iomd,
       title: state.title,
       parentRevisionId: state.notebookInfo.revision_id
     });
-    expect(await havePendingAutosavedChanges(state)).toEqual(false);
-    state.iomd += "abc";
-    expect(await havePendingAutosavedChanges(state)).toEqual(true);
+    expect(await haveLocalAutosave(state)).toEqual(true);
     await clearLocalAutosave(state);
     expect(await getLocalAutosave(state)).toEqual({});
-    expect(await havePendingAutosavedChanges(state)).toEqual(false);
+    expect(await haveLocalAutosave(state)).toEqual(false);
   });
 });

--- a/src/editor/tools/local-autosave.js
+++ b/src/editor/tools/local-autosave.js
@@ -14,12 +14,9 @@ async function getLocalAutosave(state) {
   return autosave || {};
 }
 
-async function havePendingAutosavedChanges(state) {
+async function haveLocalAutosave(state) {
   const localAutosave = await getLocalAutosave(state);
-  return (
-    Object.keys(localAutosave).length > 0 &&
-    (localAutosave.iomd !== state.iomd || localAutosave.title !== state.title)
-  );
+  return Object.keys(localAutosave).length > 0;
 }
 
 async function clearLocalAutosave(state) {
@@ -41,7 +38,7 @@ async function writeLocalAutosave(state) {
 
 export {
   getLocalAutosave,
-  havePendingAutosavedChanges,
+  haveLocalAutosave,
   clearLocalAutosave,
   writeLocalAutosave
 };


### PR DESCRIPTION
It is occasionally possible for us to have a copy of a local autosave
which has identical contents to what's already on the server in certain
rare cases (e.g. if we send a no-op update to the server).

We actually need a better model of what's synced/not synced with the
server to handle this properly, but I believe this fix will handle 99% of
the likely cases.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
