### PR TITLE
Fix client only mode port in local-dev.md

### DIFF
--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -11,8 +11,7 @@ Run `npm install` after cloning this repository.
 If you're only working on client code and don't need to use/test any of the server functionality described below,
 you can skip setting up a full docker environment and get up and running quickly. Just run
 `npm run simple-serve` after `npm install`: this should start up a web server which will provide a basic
-version of the editing environment you can access at http://localhost:8080/ (note this is distinct from the Django-based
-environment, which uses port 8000).
+version of the editing environment you can access at http://localhost:8000/.
 
 The command runs in watch mode, so changes to files will be detected and bundled automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
 


### PR DESCRIPTION
Could be a configuration quirk on my local machine but `npm run simple-serve` seems to serve the notebook at 8000 and not 8080. Don't know iodide's stack well enough to figure out if it's a config issue so please consider this part bug report part pull request.

EDIT: After a couple minutes of digging it seems since https://github.com/iodide-project/iodide/blob/master/webpack.config.js#L20 is set to 8000 the notebook environment is always served at 8000. LMK if I missed something!

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not