### PR TITLE
Remove History menu option for the tryit notebook (fixes #2114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   reuse in multiple server environments (#1943)
 - Hide "unsaved changes" in revision browser if no unsaved changes (#2046)
 - Show revision, docs, contribute links even on non-public sites
+- Disable "History" menu item for the tryit notebook
 
 # 0.10.0 (2019-07-15)
 

--- a/src/editor/actions/__tests__/server-save-actions.test.js
+++ b/src/editor/actions/__tests__/server-save-actions.test.js
@@ -74,6 +74,7 @@ describe("saveNotebookToServer", () => {
           revision_id: 1,
           revision_is_latest: true,
           serverSaveStatus: "OK",
+          tryItMode: false,
           user_can_save: true,
           username: "this-user"
         },
@@ -179,6 +180,7 @@ describe("createNewNotebookOnServer", () => {
             revision_id: forked ? 2 : 1,
             revision_is_latest: true,
             serverSaveStatus: "OK",
+            tryItMode: false,
             user_can_save: true,
             username: "this-user"
           },

--- a/src/editor/actions/server-save-actions.js
+++ b/src/editor/actions/server-save-actions.js
@@ -54,6 +54,7 @@ export function createNewNotebookOnServer() {
           revision_id: notebook.latest_revision.id,
           revision_is_latest: true,
           serverSaveStatus: "OK",
+          tryItMode: false,
           user_can_save: true,
           username: state.userData.name // in case this notebook was forked
         })

--- a/src/editor/components/menu/editor-toolbar-menu.jsx
+++ b/src/editor/components/menu/editor-toolbar-menu.jsx
@@ -5,21 +5,26 @@ import PropTypes from "prop-types";
 import NotebookIconMenu from "./icon-menu";
 import tasks from "../../user-tasks/task-definitions";
 import NotebookMenuItem from "./notebook-menu-item";
-import { connectionModeIsServer } from "../../tools/server-tools";
+import {
+  connectionModeIsServer,
+  notebookIsATrial
+} from "../../tools/server-tools";
 
 export class EditorToolbarMenuUnconnected extends React.Component {
   static propTypes = {
     isServer: PropTypes.bool.isRequired,
-    canUpload: PropTypes.bool
+    canUpload: PropTypes.bool,
+    isTrialNotebook: PropTypes.bool
   };
 
   render() {
     return (
       <NotebookIconMenu>
         {this.props.isServer && <NotebookMenuItem task={tasks.newNotebook} />}
-        {this.props.isServer && (
-          <NotebookMenuItem task={tasks.toggleHistoryModal} />
-        )}
+        <NotebookMenuItem
+          task={tasks.toggleHistoryModal}
+          disabled={this.props.isTrialNotebook}
+        />
         {this.props.canUpload && (
           <NotebookMenuItem task={tasks.toggleFileModal} />
         )}
@@ -35,6 +40,7 @@ export function mapStateToProps(state) {
 
   return {
     isServer,
+    isTrialNotebook: isServer && notebookIsATrial(state),
     canUpload: isServer && Boolean(state.notebookInfo.user_can_save)
   };
 }


### PR DESCRIPTION
Addresses #2114 by not showing the History option for the tryit notebook.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
