### PR TITLE
Refactor modal actions into their own files and simplify logic

### DIFF
--- a/src/editor/actions/__tests__/verify-action-store-consistency.test.js
+++ b/src/editor/actions/__tests__/verify-action-store-consistency.test.js
@@ -1,5 +1,6 @@
 import { store } from "../../store";
 import * as actions from "../actions";
+import { toggleModal } from "../modal-actions";
 import { evaluateNotebook, setKernelState } from "../eval-actions";
 
 import { stateProperties } from "../../state-schemas/state-schema";
@@ -17,7 +18,7 @@ describe("make sure createValidatedReducer is checking correctly", () => {
     store.dispatch(actions.resetNotebook());
   });
   it("createValidatedReducer should throw an error if we pass an action that inserts an invalid state value", () => {
-    expect(() => store.dispatch(actions.setModalState(100))).toThrowError(
+    expect(() => store.dispatch(toggleModal(100))).toThrowError(
       SchemaValidationError
     );
   });
@@ -83,10 +84,6 @@ describe("make sure action creators leave store in a consitent state", () => {
 
   it("evaluateNotebook", () => {
     expect(() => store.dispatch(evaluateNotebook())).not.toThrow();
-  });
-
-  it("toggleHelpModal", () => {
-    expect(() => store.dispatch(actions.clearVariables())).not.toThrow();
   });
 
   it("toggleEditorLink", () => {

--- a/src/editor/actions/history-modal-actions.js
+++ b/src/editor/actions/history-modal-actions.js
@@ -1,0 +1,76 @@
+import {
+  getRevisionList,
+  getRevisions
+} from "../../shared/server-api/revisions";
+import { haveLocalAutosave } from "../tools/local-autosave";
+import { getRevisionIdsNeededForDisplay } from "../tools/revision-history";
+import { getNotebookID, isLoggedIn } from "../tools/server-tools";
+
+function getRequiredRevisionContent(state, dispatch) {
+  const contentIdsNeeded = getRevisionIdsNeededForDisplay(
+    state.notebookHistory
+  );
+
+  // if we don't need anything, just return here!!
+  if (!contentIdsNeeded.length) {
+    return;
+  }
+
+  dispatch({
+    type: "GETTING_REVISION_CONTENT"
+  });
+  getRevisions(getNotebookID(state), contentIdsNeeded, isLoggedIn(state))
+    .then(revisions => {
+      // reduce the revisions array into an object whose keys
+      // are revision ids, and whose body is the content of
+      // the revisions
+      const revisionContent = revisions.reduce(
+        (acc, r) => Object.assign(acc, { [r.id]: r.content }),
+        {}
+      );
+      dispatch({
+        type: "GOT_REVISION_CONTENT",
+        revisionContent
+      });
+    })
+    .catch(() => {
+      dispatch({ type: "ERROR_GETTING_REVISION_CONTENT" });
+    });
+}
+
+export function updateSelectedRevisionId(selectedRevisionId) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: "UPDATE_NOTEBOOK_HISTORY_BROWSER_SELECTED_REVISION_ID",
+      selectedRevisionId
+    });
+    getRequiredRevisionContent(getState(), dispatch);
+  };
+}
+
+export function getNotebookRevisionList() {
+  return (dispatch, getState) => {
+    dispatch({ type: "GETTING_NOTEBOOK_REVISION_LIST" });
+    getRevisionList(getNotebookID(getState()), isLoggedIn(getState()))
+      .then(revisionList => {
+        haveLocalAutosave(getState())
+          .then(havePendingChanges => {
+            dispatch({
+              type: "UPDATE_NOTEBOOK_HISTORY",
+              hasLocalOnlyChanges: havePendingChanges,
+              revisionList,
+              selectedRevisionId: havePendingChanges
+                ? undefined
+                : revisionList[0].id
+            });
+            getRequiredRevisionContent(getState(), dispatch);
+          })
+          .catch(() => {
+            dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
+          });
+      })
+      .catch(() => {
+        dispatch({ type: "ERROR_GETTING_NOTEBOOK_REVISION_LIST" });
+      });
+  };
+}

--- a/src/editor/actions/modal-actions.js
+++ b/src/editor/actions/modal-actions.js
@@ -1,0 +1,30 @@
+export function closeModals() {
+  return {
+    type: "SET_MODAL_STATE",
+    modalState: "MODALS_CLOSED"
+  };
+}
+
+export function toggleModal(modalStateWhenOn) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: "SET_MODAL_STATE",
+      modalState:
+        getState().modalState === modalStateWhenOn
+          ? "MODALS_CLOSED"
+          : modalStateWhenOn
+    });
+  };
+}
+
+export function toggleHistoryModal() {
+  return toggleModal("HISTORY_MODAL");
+}
+
+export function toggleHelpModal() {
+  return toggleModal("HELP_MODAL");
+}
+
+export function toggleFileModal() {
+  return toggleModal("FILE_MODAL");
+}

--- a/src/editor/components/modals/history-modal.jsx
+++ b/src/editor/components/modals/history-modal.jsx
@@ -7,7 +7,7 @@ import { ModalContainer } from "./modal-container";
 import TitleBar from "./title-bar";
 import RevisionDiff from "./revision-diff";
 import RevisionList from "./revision-list";
-import { getNotebookRevisionList } from "../../actions/actions";
+import { getNotebookRevisionList } from "../../actions/history-modal-actions";
 
 const ModalContentContainer = styled("div")`
   display: grid;

--- a/src/editor/components/modals/iodide-modals-root.jsx
+++ b/src/editor/components/modals/iodide-modals-root.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 
 import Modal from "@material-ui/core/Modal";
 
-import { setModalState } from "../../actions/actions";
+import { closeModals } from "../../actions/modal-actions";
 
 import HelpModal from "./help-modal";
 import HistoryModal from "./history-modal";
@@ -52,7 +52,7 @@ export function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  closeModals: () => setModalState("MODALS_CLOSED")
+  closeModals
 };
 
 export default connect(

--- a/src/editor/components/modals/revision-list.jsx
+++ b/src/editor/components/modals/revision-list.jsx
@@ -8,7 +8,7 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 
-import { updateSelectedRevisionId } from "../../actions/actions";
+import { updateSelectedRevisionId } from "../../actions/history-modal-actions";
 
 const RevisionListContainer = styled("div")`
   overflow: auto;

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -3,6 +3,11 @@ import ExternalLinkTask from "./external-link-task";
 import { store } from "../store";
 import * as actions from "../actions/actions";
 import { evaluateText, evaluateNotebook } from "../actions/eval-actions";
+import {
+  toggleFileModal,
+  toggleHelpModal,
+  toggleHistoryModal
+} from "../actions/modal-actions";
 
 // FIXME: remove requirement to import store in this file by attaching
 // keypress handling to store in initializeDefaultKeybindings() --
@@ -92,7 +97,7 @@ tasks.clearVariables = new UserTask({
 tasks.toggleFileModal = new UserTask({
   title: "Manage Files",
   callback() {
-    dispatcher.toggleFileModal();
+    store.dispatch(toggleFileModal());
   }
 });
 
@@ -100,7 +105,7 @@ tasks.toggleHistoryModal = new UserTask({
   title: "View Notebook History",
   menuTitle: "History",
   callback() {
-    dispatcher.toggleHistoryModal();
+    store.dispatch(toggleHistoryModal());
   }
 });
 
@@ -111,7 +116,7 @@ tasks.toggleHelpModal = new UserTask({
   displayKeybinding: "Alt+h",
   preventDefaultKeybinding: true,
   callback() {
-    dispatcher.toggleHelpModal();
+    store.dispatch(toggleHelpModal());
   }
 });
 


### PR DESCRIPTION
This should hopefully be uncontroversial, just moving some actions relating to modals into their own files and simplifying some things along the way.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A ] **Changelog**: This PR updates the [changelog](../CHANGELOG.md) with any user-visible changes.
- [*] **Tests**: This PR includes thorough tests or an explanation of why it does not
