### PR TITLE
Remove codemirror dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4928,11 +4928,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "codemirror": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.48.2.tgz",
-      "integrity": "sha512-i9VsmC8AfA5ji6EDIZ+aoSe4vt9FcwPLdHB1k1ItFbVyuOFRrcfvnoKqwZlC7EVA2UmTRiNEypE4Uo7YvzVY8Q=="
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@material-ui/core": "3.9.3",
     "@material-ui/icons": "3.0.2",
     "ajv": "6.10.2",
-    "codemirror": "5.48.2",
     "css-element-queries": "1.2.1",
     "date-fns": "2.0.0-beta.5",
     "debounce-action": "0.1.0",


### PR DESCRIPTION
It looks like we forgot to remove this when we moved to monaco,
