### PR TITLE
Escape IOMD files (fixes #1416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Adds a new feature, file sources, which allows notebook authors to    
   schedule the fetching of files from URLs. This feature is available in the notebook menu (click _Menu > Manage Files_)
+- Fixed a bug where script tags aren't being rendered properly that could lead
+  to arbitrary code execution attacks (#2193)
 
 # 0.11.0 (2019-08-21)
 

--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div id="notebook-header"></div>
 <div id="editor-react-root"></div>
-<script id="iomd" type="text/iomd">{{ iomd|safe }}</script>
+<script id="iomd" type="text/iomd">{{ iomd|escape }}</script>
 <iframe
   id="eval-frame"
   src="{{ iframe_src|safe }}"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -48,15 +48,6 @@ def test_notebook(fake_user):
 
 
 @pytest.fixture
-def test_notebook_with_html_tags(fake_user):
-    notebook = Notebook.objects.create(owner=fake_user, title="Fake notebook")
-    NotebookRevision.objects.create(
-        notebook=notebook, title="First revision", content="</script><script>alert('31337')"
-    )
-    return notebook
-
-
-@pytest.fixture
 def test_file(test_notebook):
     return File.objects.create(
         notebook=test_notebook, filename="test.csv", content=b"a,b\n12,34\n56,78"

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -48,6 +48,15 @@ def test_notebook(fake_user):
 
 
 @pytest.fixture
+def test_notebook_with_html_tags(fake_user):
+    notebook = Notebook.objects.create(owner=fake_user, title="Fake notebook")
+    NotebookRevision.objects.create(
+        notebook=notebook, title="First revision", content="</script><script>alert('31337')"
+    )
+    return notebook
+
+
+@pytest.fixture
 def test_file(test_notebook):
     return File.objects.create(
         notebook=test_notebook, filename="test.csv", content=b"a,b\n12,34\n56,78"

--- a/server/tests/test_notebook_view.py
+++ b/server/tests/test_notebook_view.py
@@ -46,14 +46,12 @@ def test_notebook_view(client, test_notebook):
     assert new_expected_content in str(resp.content)
 
 
-def test_notebook_view_escapes_iomd(client, test_notebook_with_html_tags):
-    initial_revision = NotebookRevision.objects.filter(notebook=test_notebook_with_html_tags).last()
-    iomd_content = initial_revision.content
+def test_notebook_view_escapes_iomd(client, fake_user):
+    notebook = Notebook.objects.create(owner=fake_user, title="Fake notebook")
+    iomd_content = "</script><script>alert('31337')"
+    NotebookRevision.objects.create(notebook=notebook, title="First revision", content=iomd_content)
 
-    # Make sure the content needs to be escaped
-    assert iomd_content != escape(iomd_content)
-
-    resp = client.get(reverse("notebook-view", args=[str(test_notebook_with_html_tags.id)]))
+    resp = client.get(reverse("notebook-view", args=[str(notebook.id)]))
     expected_content = '<script id="iomd" type="text/iomd">{}</script>'.format(escape(iomd_content))
     assert expected_content in str(resp.content)
 

--- a/src/editor/initialization/__tests__/handle-initial-iomd.test.js
+++ b/src/editor/initialization/__tests__/handle-initial-iomd.test.js
@@ -74,10 +74,8 @@ blah blah
 
 describe("handleInitialIomd unescapes #iomd elt content", () => {
   const iomdString = `
-
 %% js
 blah &lt;&gt;&#39;&quot;&amp; blah
-
     `;
   let store;
 
@@ -93,10 +91,8 @@ blah &lt;&gt;&#39;&quot;&amp; blah
   });
 
   const unescapedIomdString = `
-
 %% js
 blah <>'"& blah
-
     `;
   it("iomd is correct", () => {
     handleInitialIomd(store);

--- a/src/editor/initialization/__tests__/handle-initial-iomd.test.js
+++ b/src/editor/initialization/__tests__/handle-initial-iomd.test.js
@@ -71,3 +71,37 @@ blah blah
     ]);
   });
 });
+
+describe("handleInitialIomd unescapes #iomd elt content", () => {
+  const iomdString = `
+
+%% js
+blah &lt;&gt;&#39;&quot;&amp; blah
+
+    `;
+  let store;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+<script id="iomd">${iomdString}</script>
+`;
+    store = mockStore({});
+  });
+
+  it("store is valid", () => {
+    expect(() => handleInitialIomd(store)).not.toThrow();
+  });
+
+  const unescapedIomdString = `
+
+%% js
+blah <>'"& blah
+
+    `;
+  it("iomd is correct", () => {
+    handleInitialIomd(store);
+    expect(store.getActions()).toEqual([
+      { iomd: unescapedIomdString, type: "UPDATE_IOMD_CONTENT" }
+    ]);
+  });
+});

--- a/src/editor/initialization/handle-initial-iomd.js
+++ b/src/editor/initialization/handle-initial-iomd.js
@@ -1,26 +1,9 @@
+import _ from "lodash";
 import { updateIomdContent } from "../actions/editor-actions";
-
-// Undo Django's template escape behavior; see
-// https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#escape
-const unescapeMap = {
-  "&lt;": "<",
-  "&gt;": ">",
-  "&#39;": "'",
-  "&quot;": '"',
-  "&amp;": "&"
-};
 
 export default function handleInitialIomd(store) {
   const iomdElt = document.getElementById("iomd");
-  // FIXME: related to #1416 -- when we rework how we send IOMD to a NB from
-  // the server, we should initialize the store with the initial IOMD, which
-  // will make this file obsolete, and will also allow is to remove the
-  // autosave argument from updateIomdContent
   if (iomdElt && iomdElt.innerHTML) {
-    const content = iomdElt.innerHTML.replace(
-      /&(lt|gt|#39|quot|amp);/g,
-      match => unescapeMap[match]
-    );
-    store.dispatch(updateIomdContent(content, false));
+    store.dispatch(updateIomdContent(_.unescape(iomdElt.innerHTML)));
   }
 }

--- a/src/editor/initialization/handle-initial-iomd.js
+++ b/src/editor/initialization/handle-initial-iomd.js
@@ -1,12 +1,26 @@
 import { updateIomdContent } from "../actions/editor-actions";
 
+// Undo Django's template escape behavior; see
+// https://docs.djangoproject.com/en/2.2/ref/templates/builtins/#escape
+const unescapeMap = {
+  "&lt;": "<",
+  "&gt;": ">",
+  "&#39;": "'",
+  "&quot;": '"',
+  "&amp;": "&"
+};
+
 export default function handleInitialIomd(store) {
   const iomdElt = document.getElementById("iomd");
   // FIXME: related to #1416 -- when we rework how we send IOMD to a NB from
   // the server, we should initialize the store with the initial IOMD, which
-  // will make this file obselete, and will also allow is to remove the
+  // will make this file obsolete, and will also allow is to remove the
   // autosave argument from updateIomdContent
   if (iomdElt && iomdElt.innerHTML) {
-    store.dispatch(updateIomdContent(iomdElt.innerHTML, false));
+    const content = iomdElt.innerHTML.replace(
+      /&(lt|gt|#39|quot|amp);/g,
+      match => unescapeMap[match]
+    );
+    store.dispatch(updateIomdContent(content, false));
   }
 }


### PR DESCRIPTION
Sorry for the turnaround time!

This fixes #1416 by:

1) change IOMD content in the notebook template to be escaped instead of marked safe;
2) unescape the rendered content on load in JS.

Tests have been added to reflect the changes. This is kind of use visible but is a bit of an edge case so will update CHANGELOG.md if you think it's warranted.

LMK if there's a better approach!


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
