### PR TITLE
Remove explicit deep-equal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "css-element-queries": "1.2.1",
     "date-fns": "2.0.1",
     "debounce-action": "0.1.0",
-    "deep-equal": "1.0.1",
     "dexie": "2.0.4",
     "dompurify": "1.0.11",
     "emotion": "9.2.12",

--- a/src/editor/components/editor-pane-container.jsx
+++ b/src/editor/components/editor-pane-container.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import deepEqual from "deep-equal";
+import { isEqual } from "lodash";
 
 import IomdEditor from "./iomd-editor/iomd-editor";
 import DeclaredVariablesPane from "./panes/declared-variables-pane";
@@ -17,7 +17,7 @@ class EditorPaneContainer extends React.Component {
   };
 
   shouldComponentUpdate(nextProps) {
-    return !deepEqual(this.props, nextProps);
+    return !isEqual(this.props, nextProps);
   }
 
   render() {

--- a/src/editor/components/iomd-editor/iomd-editor.jsx
+++ b/src/editor/components/iomd-editor/iomd-editor.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import deepEqual from "deep-equal";
+import { isEqual } from "lodash";
 
 /* eslint-disable import/first */
 
@@ -128,7 +128,7 @@ class IomdEditorUnconnected extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return !deepEqual(this.props, nextProps);
+    return !isEqual(this.props, nextProps);
   }
 
   componentDidUpdate(prevProps) {
@@ -152,7 +152,7 @@ class IomdEditorUnconnected extends React.Component {
       this.editor.setValue(content);
     }
 
-    if (!deepEqual(editorPosition, prevProps.editorPosition)) {
+    if (!isEqual(editorPosition, prevProps.editorPosition)) {
       this.editor.layout();
     }
 

--- a/src/editor/components/panes/console-pane.jsx
+++ b/src/editor/components/panes/console-pane.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import deepEqual from "deep-equal";
+import { isEqual } from "lodash";
 import styled from "react-emotion";
 
 import HelpOutline from "@material-ui/icons/HelpOutline";
@@ -30,7 +30,7 @@ export class ConsolePaneUnconnected extends React.Component {
 
   shouldComponentUpdate(nextProps) {
     return (
-      !deepEqual(this.props, nextProps) &&
+      !isEqual(this.props, nextProps) &&
       (this.props.paneVisible || nextProps.paneVisible)
     );
   }
@@ -100,7 +100,7 @@ function areStatesEqual(next, prev) {
   return (
     next.panePositions.ConsolePositioner.display ===
       prev.panePositions.ConsolePositioner.display &&
-    deepEqual(
+    isEqual(
       next.history.map(h => h.historyId),
       prev.history.map(h => h.historyId)
     )

--- a/src/editor/components/panes/declared-variables-pane.jsx
+++ b/src/editor/components/panes/declared-variables-pane.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import deepEqual from "deep-equal";
+import { isEqual } from "lodash";
 
 import { DeclaredVariable } from "./declared-variable";
 
@@ -13,7 +13,7 @@ export class DeclaredVariablesPaneUnconnected extends React.Component {
 
   shouldComponentUpdate(nextProps) {
     return (
-      !deepEqual(this.props, nextProps) &&
+      !isEqual(this.props, nextProps) &&
       (this.props.paneVisible || nextProps.paneVisible)
     );
   }


### PR DESCRIPTION
Internally, we can use lodash's isEqual instead, which is equivalent.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [N/A] **Tests**: This PR includes thorough tests or an explanation of why it does not
