### PR TITLE
Fix notebook creation for users who do not yet exist

### DIFF
--- a/server/github/__init__.py
+++ b/server/github/__init__.py
@@ -1,0 +1,7 @@
+import requests
+
+
+def get_github_user_data(login):
+    r = requests.get(f"https://api.github.com/users/{login}")
+    r.raise_for_status()
+    return r.json()

--- a/server/notebooks/api_views.py
+++ b/server/notebooks/api_views.py
@@ -1,11 +1,17 @@
+import logging
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import Http404
+from requests.exceptions import HTTPError
 from rest_framework import status, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.response import Response
+from social_django.models import UserSocialAuth
 
+from ..github import get_github_user_data
 from .models import Notebook, NotebookRevision
 from .serializers import (
     NotebookDetailSerializer,
@@ -13,6 +19,8 @@ from .serializers import (
     NotebookRevisionDetailSerializer,
     NotebookRevisionSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class NotebookViewSet(viewsets.ModelViewSet):
@@ -31,16 +39,34 @@ class NotebookViewSet(viewsets.ModelViewSet):
             raise PermissionDenied
         super().perform_destroy(instance)
 
+    @transaction.atomic
     def create(self, request):
         if "owner" in self.request.data:
-            if (
-                not self.request.data["owner"]
-                or self.request.data["owner"] == self.request.user.username
-            ):
+            owner_username = self.request.data["owner"]
+            if not owner_username or owner_username == self.request.user.username:
                 owner = self.request.user
             elif self.request.user.can_create_on_behalf_of_others:
                 User = get_user_model()
-                owner, _ = User.objects.get_or_create(username=self.request.data["owner"])
+                owner, _ = User.objects.get_or_create(username=owner_username)
+                if (
+                    settings.SOCIAL_AUTH_GITHUB_KEY
+                    and not UserSocialAuth.objects.filter(user=owner, provider="github").exists()
+                ):
+                    # if this does not succeed, we will return a 500
+                    try:
+                        github_user_data = get_github_user_data(owner_username)
+                    except HTTPError as err:
+                        logger.error(
+                            "Error getting information for user %s from github: %s",
+                            request.user.username,
+                            err,
+                        )
+                        raise APIException(
+                            "Error getting github user data for user %s".format(owner_username)
+                        )
+                    UserSocialAuth.objects.get_or_create(
+                        user=owner, provider="github", defaults={"uid": github_user_data["id"]}
+                    )
             else:
                 raise PermissionDenied
         else:
@@ -57,13 +83,12 @@ class NotebookViewSet(viewsets.ModelViewSet):
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        with transaction.atomic():
-            notebook = serializer.save(owner=owner, forked_from=forked_from)
-            NotebookRevision.objects.create(
-                notebook=notebook,
-                title=self.request.data["title"],
-                content=self.request.data["content"],
-            )
+        notebook = serializer.save(owner=owner, forked_from=forked_from)
+        NotebookRevision.objects.create(
+            notebook=notebook,
+            title=self.request.data["title"],
+            content=self.request.data["content"],
+        )
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/server/openidc/middleware.py
+++ b/server/openidc/middleware.py
@@ -40,6 +40,9 @@ class OpenIDCAuthMiddleware(object):
 
         try:
             user = self.User.objects.get(username=openidc_email)
+            if not user.email:
+                user.email = openidc_email
+                user.save()
         except self.User.DoesNotExist:
             user = self.User(username=openidc_email, email=openidc_email)
             user.save()

--- a/server/openidc/middleware.py
+++ b/server/openidc/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.http import HttpResponse
 from django.urls import Resolver404, resolve
 from rest_framework.authentication import SessionAuthentication
@@ -41,11 +42,13 @@ class OpenIDCAuthMiddleware(object):
         try:
             user = self.User.objects.get(username=openidc_email)
             if not user.email:
-                user.email = openidc_email
-                user.save()
+                with transaction.atomic():
+                    user.email = openidc_email
+                    user.save()
         except self.User.DoesNotExist:
             user = self.User(username=openidc_email, email=openidc_email)
-            user.save()
+            with transaction.atomic():
+                user.save()
 
         request.user = user
 

--- a/server/openidc/tests/test_middleware.py
+++ b/server/openidc/tests/test_middleware.py
@@ -71,3 +71,24 @@ class OpenIDCAuthMiddlewareTests(TestCase):
 
         self.assertEqual(request.user.email, user_email)
         self.assertFalse(request.user.is_staff)
+
+    def test_add_email_when_not_present(self):
+        user_email = "user@example.com"
+        User = get_user_model()
+        User.objects.create(username=user_email)
+
+        request = mock.Mock()
+        request.path = "/foo/"
+        request.META = {settings.OPENIDC_EMAIL_HEADER: user_email}
+
+        with self.settings(OPENIDC_AUTH_WHITELIST=[]):
+            response = self.middleware(request)
+
+        self.assertEqual(response, self.response)
+
+        # should not create any extra users
+        self.assertEqual(User.objects.all().count(), 1)
+
+        # user should now have email address
+        self.assertEqual(request.user.email, user_email)
+        self.assertFalse(request.user.is_staff)

--- a/server/settings.py
+++ b/server/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "social_django",
     "rest_framework",
     "rest_framework.authtoken",
     "server.base",
@@ -126,7 +127,6 @@ if USE_OPENIDC_AUTH:
     INSTALLED_APPS.append("server.openidc")
     MIDDLEWARE.append("server.openidc.middleware.OpenIDCAuthMiddleware")
 elif SOCIAL_AUTH_GITHUB_KEY:
-    INSTALLED_APPS.append("social_django")
     MIDDLEWARE.extend(
         [
             "social_django.middleware.SocialAuthExceptionMiddleware",

--- a/server/tests/test_notebook_api.py
+++ b/server/tests/test_notebook_api.py
@@ -1,6 +1,10 @@
+import json
+
 import pytest
+import responses
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from social_django.models import UserSocialAuth
 
 from helpers import get_rest_framework_time_string
 from server.notebooks.models import Notebook, NotebookRevision
@@ -119,21 +123,51 @@ def test_create_notebook_for_another_user(
         assert NotebookRevision.objects.count() == 0
 
 
+@responses.activate
+@pytest.mark.parametrize("github_auth", [None, "valid", "error"])
 def test_create_notebook_for_another_user_who_does_not_yet_exist(
-    fake_user, client, notebook_post_blob
+    fake_user, client, notebook_post_blob, settings, github_auth
 ):
     uncreated_username = "uncreated_user"
+    if github_auth:
+        settings.SOCIAL_AUTH_GITHUB_KEY = "1234"
+        fake_github_uid = 4321
+        if github_auth == "valid":
+            responses.add(
+                responses.GET,
+                f"https://api.github.com/users/{uncreated_username}",
+                body=json.dumps({"id": fake_github_uid}),
+                status=200,
+            )
+        else:
+            # testing case where we can't access github
+            responses.add(
+                responses.GET,
+                f"https://api.github.com/users/{uncreated_username}",
+                body="failed!!!!!",
+                status=500,
+            )
+
     post_blob = {**notebook_post_blob, **{"owner": uncreated_username}}
     fake_user.can_create_on_behalf_of_others = True
     fake_user.save()
     client.force_login(user=fake_user)
     resp = client.post(reverse("notebooks-list"), post_blob)
-    assert resp.status_code == 201
-    assert Notebook.objects.count() == 1
-    notebook = Notebook.objects.first()
-    assert notebook.title == post_blob["title"]
-    created_user = get_user_model().objects.get(username=uncreated_username)
-    assert notebook.owner == created_user
+    if github_auth == "error":
+        assert resp.status_code == 500
+        assert Notebook.objects.count() == 0
+        assert UserSocialAuth.objects.count() == 0
+    else:
+        assert resp.status_code == 201
+        assert Notebook.objects.count() == 1
+        notebook = Notebook.objects.first()
+        assert notebook.title == post_blob["title"]
+        created_user = get_user_model().objects.get(username=uncreated_username)
+        assert notebook.owner == created_user
+        if github_auth:
+            # should have a placeholder social auth object created
+            social_auth = UserSocialAuth.objects.get(user=created_user, provider="github")
+            assert social_auth.uid == str(fake_github_uid)
 
 
 def test_delete_notebook_not_logged_in(test_notebook, client):


### PR DESCRIPTION
We should allow users with correct privileges to create notebooks on behalf of
users that do not yet exist. This fixes an issue we had with our "explore query
in iodide" redash plugin, which failed for users who had not logged into iodide
before.

This fixes an issue that was reported on slack a week or so ago (link requires Mozilla-internal access):

https://mozilla.slack.com/archives/C4D5ZA91B/p1567000606003300

/cc @openjck @rafrombrc 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
