### PR TITLE
Check latest local autosave against latest save (fixes #2259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
  # (Unreleased; add upcoming change notes here)
 
+- Fixes undesired behavior caused by reliance on existence of local autosave [#2259](https://github.com/iodide-project/iodide/issues/2259)
 - Adds a new feature, file sources, which allows notebook authors to    
   schedule the fetching of files from URLs. This feature is available in the notebook menu (click _Menu > Manage Files_)
 - Add multi stage docker builds for smaller docker images (#2156)

--- a/src/editor/actions/history-modal-actions.js
+++ b/src/editor/actions/history-modal-actions.js
@@ -72,21 +72,13 @@ export function getNotebookRevisionList() {
       .then(revisionList => {
         getLocalAutosave(getState())
           .then(localAutosaveState => {
-            let hasLocalOnlyChanges = false;
-            if (
+            const hasLocalOnlyChanges =
               "revisionContent" in getState().notebookHistory &&
-              "iomd" in localAutosaveState
-            ) {
-              if (
-                revisionList[0].id in getState().notebookHistory.revisionContent
-              ) {
-                hasLocalOnlyChanges =
-                  localAutosaveState.iomd !==
-                  getState().notebookHistory.revisionContent[
-                    revisionList[0].id
-                  ];
-              }
-            }
+              "iomd" in localAutosaveState &&
+              revisionList[0].id in
+                getState().notebookHistory.revisionContent &&
+              localAutosaveState.iomd !==
+                getState().notebookHistory.revisionContent[revisionList[0].id];
             dispatch({
               type: "UPDATE_NOTEBOOK_HISTORY",
               hasLocalOnlyChanges,


### PR DESCRIPTION
Fix for https://github.com/iodide-project/iodide/issues/2259

# Explanation
The current implementation shows unsaved changes whenever local autosave entry is created, which is never reduced back when there are no changes (e.g., create a new line and remove it immediately). This new implementation further checks the local autosave with the latest revision to ensure that there are no changes.