### PR TITLE
Use consistent schema for passing file data in redux (fixes #2287)

### DIFF
--- a/src/editor/actions/__tests__/file-actions.test.js
+++ b/src/editor/actions/__tests__/file-actions.test.js
@@ -1,0 +1,46 @@
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+
+import { getFiles } from "../file-actions";
+import * as FILE_OPS from "../../../shared/utils/file-operations";
+
+const mockStore = configureMockStore([thunk]);
+const initialState = () => {
+  return {
+    userData: { name: "this-user" },
+    notebookInfo: {
+      connectionMode: "SERVER",
+      username: "this-user"
+    }
+  };
+};
+
+describe("getFiles (editor action)", () => {
+  it("translates a response from the server as expected", async () => {
+    const getFilesMock = jest.spyOn(FILE_OPS, "getFilesForNotebookFromServer");
+    getFilesMock.mockImplementation(() => {
+      return Promise.resolve([
+        {
+          id: 1,
+          filename: "test.csv",
+          notebook_id: 0,
+          last_updated: "a-date-string"
+        }
+      ]);
+    });
+    const store = mockStore(initialState());
+
+    const request = store.dispatch(getFiles());
+
+    await expect(request).resolves.toBe(undefined);
+
+    expect(getFilesMock).toHaveBeenCalledTimes(1);
+
+    expect(store.getActions()).toEqual([
+      {
+        type: "UPDATE_FILES_FROM_SERVER",
+        files: [{ filename: "test.csv", id: 1, lastUpdated: "a-date-string" }]
+      }
+    ]);
+  });
+});

--- a/src/editor/actions/file-actions.js
+++ b/src/editor/actions/file-actions.js
@@ -6,7 +6,11 @@ export function getFiles() {
     const files = await getFilesForNotebookFromServer(notebookID);
     dispatch({
       type: "UPDATE_FILES_FROM_SERVER",
-      files
+      files: files.map(file => ({
+        id: file.id,
+        filename: file.filename,
+        lastUpdated: file.last_updated
+      }))
     });
   };
 }

--- a/src/editor/state-schemas/state-schema.js
+++ b/src/editor/state-schemas/state-schema.js
@@ -80,8 +80,7 @@ export const fileSchema = {
   properties: {
     filename: { type: "string" },
     id: { type: "integer" },
-    notebook_id: { type: "integer" },
-    last_updated: { type: "string" }
+    lastUpdated: { type: "string" }
   },
   additionalProperties: false
 };


### PR DESCRIPTION
We were sometimes using the snake case format used by the server,
other times using camel case. The confusion caused issue #2287. Fix
by converting the snake case response from the server and using
camel case everywhere.

No changelog entry because this broke since the last release.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [N/A] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
