### PR TITLE
Fix coloring of History Modal title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # (Unreleased; add upcoming change notes here)
 
-- Fixes coloring of history modal's title
+- Fix coloring of history modal's title (#2301)
 
 # 0.12.0 (2019-09-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Fixes coloring of history modal's title
+
 # 0.12.0 (2019-09-25)
 
 - Fix spurious "unsaved changes" changeset in revision browser (#2259)

--- a/src/editor/components/modals/title-bar.jsx
+++ b/src/editor/components/modals/title-bar.jsx
@@ -11,12 +11,14 @@ const TitleBar = styled(AppBar)`
   background: ${THEME.clientModal.background};
 `;
 
+const Title = styled(Typography)`
+  color: #fff !important;
+`;
+
 const RenderedTitleBar = props => (
   <TitleBar position="static">
     <Toolbar>
-      <Typography variant="title" style={{ color: "#fff" }}>
-        {props.title}
-      </Typography>
+      <Title variant="title">{props.title}</Title>
     </Toolbar>
   </TitleBar>
 );

--- a/src/editor/components/modals/title-bar.jsx
+++ b/src/editor/components/modals/title-bar.jsx
@@ -11,14 +11,12 @@ const TitleBar = styled(AppBar)`
   background: ${THEME.clientModal.background};
 `;
 
-const Title = styled(Typography)`
-  color: #fff;
-`;
-
 const RenderedTitleBar = props => (
   <TitleBar position="static">
     <Toolbar>
-      <Title variant="title">{props.title}</Title>
+      <Typography variant="title" style={{ color: "#fff" }}>
+        {props.title}
+      </Typography>
     </Toolbar>
   </TitleBar>
 );


### PR DESCRIPTION
This pull request attempts to fix coloring of typography in the title of history modal. Using `styled`, it appeared black, not utilizing the `color: #fff` given to it. When the style is directly applied using a `style={{ color: #fff }}`, the title is white as desired.