### PR TITLE
Switch from react-helmet to react-helmet-async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Extend Python test harness to run linting and coverage as part of test suite (#2305)
 - Fix coloring of history modal's title (#2301)
-- Fix console warning by switching from react-helmet to react-helmet-async
+- Fix console warning by switching from react-helmet to react-helmet-async (#2315)
 
 # 0.12.0 (2019-09-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Extend Python test harness to run linting and coverage as part of test suite (#2305)
 - Fix coloring of history modal's title (#2301)
+- Fix console warning by switching from react-helmet to react-helmet-async
 
 # 0.12.0 (2019-09-25)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13225,22 +13225,10 @@
         "react-clientside-effect": "^1.2.0"
       }
     },
-    "react-helmet": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
-      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-fast-compare": "^2.0.2",
-        "react-side-effect": "^1.1.0"
-      }
-    },
     "react-helmet-async": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.3.tgz",
       "integrity": "sha512-hthnzAPasSX0ZU0adR1YW51xtMhwQuMwxtyjb/OeS2Gu2bzqFnCtt2h93nENE0+97NPeUS0+YHOriEMX8j/W0w==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "7.3.4",
         "invariant": "2.2.4",
@@ -13394,14 +13382,6 @@
         "raf": "^3.4.0",
         "react-input-autosize": "^2.2.1",
         "react-transition-group": "^2.2.1"
-      }
-    },
-    "react-side-effect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
-      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
-      "requires": {
-        "shallowequal": "^1.0.1"
       }
     },
     "react-sizeme": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react": "16.10.1",
     "react-diff-viewer": "2.0.1",
     "react-dom": "16.10.1",
-    "react-helmet": "5.2.1",
+    "react-helmet-async": "1.0.3",
     "react-jss": "8.6.1",
     "react-popper": "1.3.4",
     "react-redux": "7.1.1",

--- a/src/editor/components/menu/editor-mode-title.jsx
+++ b/src/editor/components/menu/editor-mode-title.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
-import Helmet from "react-helmet";
+import { Helmet, HelmetProvider } from "react-helmet-async";
 
 import { connect } from "react-redux";
 
@@ -37,7 +37,9 @@ export class TitleUnconnected extends React.Component {
   render() {
     const elem = (
       <TitleContainer>
-        <Helmet title={this.props.pageTitle} />
+        <HelmetProvider>
+          <Helmet title={this.props.pageTitle} />
+        </HelmetProvider>
         <InputElement
           titleColor={this.props.titleColor}
           value={this.props.notebookTitle}


### PR DESCRIPTION
Fixes a console error by implicitly removing the dependency on react-side-effect
(see nfl/react-helmet#465).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [N/A] **Tests**: This PR includes thorough tests or an explanation of why it does not
