### PR TITLE
Use django.utils.timezone.now instead of datetime.now for timez…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add test coverage reporting with Codecov. (#2322)
 
+- Fix use of naive datetime in favor of timezone-aware datetime objects. (#2323)
+
 # 0.13.0 (2019-10-01)
 
 - Extend Python test harness to run linting and coverage as part of test suite (#2305)

--- a/server/files/tasks.py
+++ b/server/files/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 import requests
 from django.conf import settings
+from django.utils import timezone
 
 from ..celery import celery
 from .models import File, FileSource, FileUpdateOperation
@@ -16,7 +17,7 @@ def execute_file_update_operation(update_operation_id):
 
     # set status to RUNNING
     update_operation.status = FileUpdateOperation.RUNNING
-    update_operation.started_at = datetime.datetime.now()
+    update_operation.started_at = timezone.now()
     update_operation.save()
 
     # actually run the query against the URL
@@ -41,7 +42,7 @@ def execute_file_update_operation(update_operation_id):
         update_operation.status = FileUpdateOperation.FAILED
         update_operation.failure_reason = str(e)
 
-    update_operation.ended_at = datetime.datetime.now()
+    update_operation.ended_at = timezone.now()
     update_operation.save()
 
 

--- a/server/tests/test_file_update_operations.py
+++ b/server/tests/test_file_update_operations.py
@@ -142,7 +142,7 @@ def test_post_file_update_operation(fake_user, test_notebook, test_file_source, 
         file_update_operation = FileUpdateOperation.objects.first()
         assert file_update_operation.file_source_id == test_file_source.id
         assert file_update_operation.status == FileUpdateOperation.PENDING
-        assert file_update_operation.scheduled_at.replace(tzinfo=None) == timezone.now()
+        assert file_update_operation.scheduled_at == timezone.now()
         assert file_update_operation.started_at is None
         assert file_update_operation.ended_at is None
 

--- a/server/tests/test_file_update_operations.py
+++ b/server/tests/test_file_update_operations.py
@@ -141,7 +141,7 @@ def test_post_file_update_operation(fake_user, test_notebook, test_file_source, 
         file_update_operation = FileUpdateOperation.objects.first()
         assert file_update_operation.file_source_id == test_file_source.id
         assert file_update_operation.status == FileUpdateOperation.PENDING
-        assert file_update_operation.scheduled_at.replace(tzinfo=None) == datetime.datetime.now()
+        assert file_update_operation.scheduled_at.replace(tzinfo=None) == timezone.now()
         assert file_update_operation.started_at is None
         assert file_update_operation.ended_at is None
 

--- a/server/tests/test_file_update_operations.py
+++ b/server/tests/test_file_update_operations.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 import pytest
 import responses
 from django.urls import reverse
+from django.utils import timezone
 from freezegun import freeze_time
 
 from server.files.models import File, FileSource, FileUpdateOperation


### PR DESCRIPTION
We should make sure to always use `django.utils.timezone.now` instead of `datetime.datetime.now` so datetimes for database content are timezone-aware. datetimes created by `datetime.datetime.now` don't have any tzinfo and are basically creating race conditions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- **Tests**: This PR includes thorough tests or an explanation of why it does not
