### PR TITLE
Don't use CODECOV_TOKEN environment variables (fixes #2330)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             # we need to re-collect static as docker-compose mounts the checkout directory over what we have in the image
             chmod 777 . # make sure we have permission to write the files in our volume
             # run the actual tests
-            docker-compose run --rm $(CI_ENV) server ci
+            docker-compose run --rm $(CI_ENV) -e CI -e CIRCLECI -e CIRCLE_BRANCH -e CIRCLE_BUILD_NUM -e CIRCLE_NODE_INDEX -e CIRCLE_PR_NUMBER -e CIRCLE_SHA1 server ci
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             # we need to re-collect static as docker-compose mounts the checkout directory over what we have in the image
             chmod 777 . # make sure we have permission to write the files in our volume
             # run the actual tests
-            docker-compose run --rm $(CI_ENV) -e CODECOV_TOKEN server ci
+            docker-compose run --rm $(CI_ENV) server ci
 
   deploy:
     docker:

--- a/bin/run
+++ b/bin/run
@@ -51,7 +51,7 @@ case $1 in
   ci)
     shift
     tests "--lean" "$@"
-    bash <(curl -s https://codecov.io/bash) -s /tmp
+    bash <(curl -s https://codecov.io/bash) -s /tmp -Z
     ;;
   *)
     exec "$@"

--- a/bin/run
+++ b/bin/run
@@ -51,7 +51,7 @@ case $1 in
   ci)
     shift
     tests "--lean" "$@"
-    bash <(curl -s https://codecov.io/bash) -s /tmp -Z
+    bash <(curl -s https://codecov.io/bash) -s /tmp
     ;;
   *)
     exec "$@"


### PR DESCRIPTION
It should not be required for public projects like Iodide.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
