### PR TITLE
Store coverage results in Docker volume so we can submit to Codecov from CircleCI host.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,13 @@ jobs:
           command: docker load -i /tmp/docker.tar
 
       - run:
+          name: Install Docker Compose
+          command: |
+            curl -L https://github.com/docker/compose/releases/download/1.24.1/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
+            chmod +x ~/docker-compose
+            sudo mv ~/docker-compose /usr/local/bin/docker-compose
+
+      - run:
           name: Lint code
           command: |
             cp .env-dist .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run test-coverage -- --runInBand
-      - run: bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json -Z
+      - run: bash <(curl -s https://codecov.io/bash) -f .coverage/coverage-final.json -Z
 
   build:
     docker:
@@ -127,7 +127,6 @@ jobs:
           name: Test Code
           command: |
             set -x
-            export CI_ENV=`bash <(curl -s https://codecov.io/env)`
             cp .env-dist .env
             # we need to wait for the db to come up
             docker-compose up -d
@@ -135,7 +134,12 @@ jobs:
             # we need to re-collect static as docker-compose mounts the checkout directory over what we have in the image
             chmod 777 . # make sure we have permission to write the files in our volume
             # run the actual tests
-            docker-compose run --rm $(CI_ENV) -e CI -e CIRCLECI -e CIRCLE_BRANCH -e CIRCLE_BUILD_NUM -e CIRCLE_NODE_INDEX -e CIRCLE_PR_NUMBER -e CIRCLE_SHA1 server ci
+            docker-compose run --rm server ci
+            bash <(curl -s https://codecov.io/bash) \
+              # look for coverage results in the volume created by docker-compose
+              -s .coverage \
+              # exit with 1 if not successful
+              -Z
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,11 +142,7 @@ jobs:
             chmod 777 . # make sure we have permission to write the files in our volume
             # run the actual tests
             docker-compose run --rm server ci
-            bash <(curl -s https://codecov.io/bash) \
-              # look for coverage results in the volume created by docker-compose
-              -s .coverage \
-              # exit with 1 if not successful
-              -Z
+            bash <(curl -s https://codecov.io/bash) -f .coverage/coverage.xml -Z
 
   deploy:
     docker:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 source = server
 branch = True
-data_file = /tmp/.coverage
+data_file = /app/.coverage/data
 
 [report]
 show_missing = True
@@ -12,4 +12,4 @@ omit =
     *management/commands*
 
 [xml]
-output = /tmp/coverage.xml
+output = /app/.coverage/coverage.xml

--- a/bin/run
+++ b/bin/run
@@ -29,6 +29,7 @@ wait_for() {
 wait_for db 5432
 
 tests() {
+  mkdir -p /app/.coverage
   python manage.py check
   python -m pytest "$@"  # skips linter checks
 }
@@ -51,7 +52,6 @@ case $1 in
   ci)
     shift
     tests "--lean" "$@"
-    bash <(curl -s https://codecov.io/bash) -s /tmp -Z
     ;;
   *)
     exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,30 @@
-version: '3'
+version: '3.4'
+
+x-app:
+  &app
+  build:
+    context: .
+  env_file: .env
+  volumes:
+    - $PWD:/app
+  links:
+    - db
+    - redis
+  command: dev
+
+
 services:
   server:
-    build:
-      context: .
-    env_file: .env
-    depends_on:
-      - db
-      - redis
-    links:
-      - db
-      - redis
+    <<: *app
     ports:
       - "8000:8000"
-    volumes:
-      - .:/app
-    command: dev
 
   worker:
-    build:
-      context: .
-    env_file: .env
-    depends_on:
-      - db
-      - redis
-    links:
-      - db
-      - redis
-    volumes:
-      - .:/app
+    <<: *app
     command: worker
 
   beat:
-    build:
-      context: .
-    env_file: .env
-    depends_on:
-      - db
-      - redis
-    links:
-      - db
-      - redis
-    volumes:
-      - .:/app
+    <<: *app
     command: beat
 
   db:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build-storybook": "build-storybook"
   },
   "jest": {
+    "coverageDirectory": ".coverage",
     "setupFilesAfterEnv": [
       "<rootDir>/test/setupTests.js"
     ],


### PR DESCRIPTION
This should fix #2303 

By using the `/app/.coverage` folder we don't have to create an additional volume just for the coverage data.