### PR TITLE
Add Spinach worker fixture.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ norecursedirs = .git .* static __pycache__ build
 DJANGO_SETTINGS_MODULE = server.tests.settings
 python_files = tests.py test_*.py *_tests.py
 testpaths = server
-addopts = -rsxX --showlocals --tb=native --nomigrations --flake8 --staticfiles --isort --cov-report term --cov-report xml --cov server
+addopts = -rsxX --showlocals --tb=native --reuse-db --nomigrations --flake8 --staticfiles --isort --cov-report term --cov-report xml --cov server
 env =
     GITHUB_CLIENT_ID=
     GITHUB_CLIENT_SECRET=

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,11 +1,16 @@
 import datetime
+import logging
+import time
 
 import pytest
 from rest_framework.test import APIClient
+from spinach.contrib.spinachd.apps import spin
 
 from server.base.models import User
 from server.files.models import File, FileSource
 from server.notebooks.models import Notebook, NotebookRevision
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_configure(config):
@@ -14,6 +19,19 @@ def pytest_configure(config):
         "markers",
         "freeze_time(timestamp): freeze time to the given timestamp for the duration of the test.",
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def spinach_worker(request):
+    spin.start_workers(number=1, block=False)
+    logger.info("Starting Spinach workers.")
+
+    def stop_workers():
+        spin.stop_workers()
+        logging.info("Stopping Spinach workers.")
+        time.sleep(2)
+
+    request.addfinalizer(stop_workers)
 
 
 @pytest.fixture


### PR DESCRIPTION
This basically launches an in-memory worker (not using Redis) once
per test session and and stops it at the end again. I'm re-using the
test database since there is no need to throw it away all the time.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not