### PR TITLE
Remove APP_VERSION_STRING and all its use from all generated webpack files

### DIFF
--- a/server/notebooks/middleware.py
+++ b/server/notebooks/middleware.py
@@ -13,7 +13,7 @@ class NotebookEvalFrameMiddleware(object):
     """
 
     MIDDLEWARE_PATHS = set(
-        [reverse("eval-frame-view"), "iodide.eval-frame.dev.css", "iodide.eval-frame.dev.js"]
+        [reverse("eval-frame-view"), "iodide.eval-frame.css", "iodide.eval-frame.js"]
     )
 
     def __init__(self, get_response):

--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block head %}
-<link rel="stylesheet" type="text/css" href="/iodide.dev.css">
+<link rel="stylesheet" type="text/css" href="/iodide.css">
 <base target="_blank" rel="noopener noreferrer">
 {% endblock %}
 {% block content %}
@@ -20,5 +20,5 @@
 <script>
   window.evalFrameOrigin = "{{ eval_frame_origin }}";
 </script>
-<script src="/iodide.dev.js"></script>
+<script src="/iodide.js"></script>
 {% endblock %}

--- a/server/notebooks/templates/notebook_eval_frame.html
+++ b/server/notebooks/templates/notebook_eval_frame.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" type="text/css" href="/iodide.eval-frame.dev.css" />
+    <link rel="stylesheet" type="text/css" href="/iodide.eval-frame.css" />
     <base target="_blank" rel="noopener noreferrer" />
   </head>
   <body>
@@ -11,6 +11,6 @@
     <script>
       window.editorOrigin = "{{ editor_origin }}";
     </script>
-    <script src="/iodide.eval-frame.dev.js"></script>
+    <script src="/iodide.eval-frame.js"></script>
   </body>
 </html>

--- a/server/settings.py
+++ b/server/settings.py
@@ -39,7 +39,6 @@ SITE_HOSTNAME = furl(SITE_URL).host
 EVAL_FRAME_ORIGIN = env.str("EVAL_FRAME_ORIGIN", SITE_URL)
 EVAL_FRAME_HOSTNAME = furl(EVAL_FRAME_ORIGIN).host
 ALLOWED_HOSTS = list(set([SITE_HOSTNAME, EVAL_FRAME_HOSTNAME]))
-APP_VERSION_STRING = env.str("APP_VERSION_STRING", "dev")
 
 # Special settings so staging servers can redirect to production
 IS_STAGING = env.bool("IS_STAGING", default=False)

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% block head %}
-<link rel="stylesheet" type="text/css" href="/server.home.dev.css">
+<link rel="stylesheet" type="text/css" href="/server.home.css" />
 {% endblock %}
 {% block content %}
 <div id="page"></div>
 {{ page_data|json_script:"pageData" }}
-<script src="/server.home.dev.js"></script>
+<script src="/server.home.js"></script>
 {% endblock %}

--- a/src/editor/static.html
+++ b/src/editor/static.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>iodide test notebook</title>
-    <link rel="stylesheet" type="text/css" href="/iodide.dev.css" />
+    <link rel="stylesheet" type="text/css" href="/iodide.css" />
     <base target="_blank" rel="noopener noreferrer" />
   </head>
   <body>
@@ -23,6 +23,6 @@ This is an environment designed to help you test changes to the Iodide editor. Y
     <script>
       window.evalFrameOrigin = "<%= EVAL_FRAME_ORIGIN %>";
     </script>
-    <script src="/iodide.dev.js"></script>
+    <script src="/iodide.js"></script>
   </body>
 </html>

--- a/src/eval-frame/static.html
+++ b/src/eval-frame/static.html
@@ -3,7 +3,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" type="text/css" href="/iodide.eval-frame.dev.css" />
+    <link rel="stylesheet" type="text/css" href="/iodide.eval-frame.css" />
     <base target="_blank" rel="noopener noreferrer" />
   </head>
   <body>
@@ -12,6 +12,6 @@
     <script>
       window.editorOrigin = "<%= EDITOR_ORIGIN %>";
     </script>
-    <script src="/iodide.eval-frame.dev.js"></script>
+    <script src="/iodide.eval-frame.js"></script>
   </body>
 </html>

--- a/src/reps/serialization/__tests__/error-handler.test.js
+++ b/src/reps/serialization/__tests__/error-handler.test.js
@@ -12,163 +12,162 @@ describe("errorHandler getErrorStackString trims stacks as expected", () => {
         fileName: "cell",
         functionName: "eval",
         source:
-          "@http://localhost:8000/iodide.eval-frame.dev.js line 103208 > eval:1:7"
+          "@http://localhost:8000/iodide.eval-frame.js line 103208 > eval:1:7"
       },
       {
         columnNumber: 40,
         lineNumber: 103208,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "runCodeWithLanguage/<",
         source:
-          "runCodeWithLanguage/<@http://localhost:8000/iodide.eval-frame.dev.js:103208:40"
+          "runCodeWithLanguage/<@http://localhost:8000/iodide.eval-frame.js:103208:40"
       },
       {
         columnNumber: 10,
         lineNumber: 103206,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "runCodeWithLanguage",
         source:
-          "runCodeWithLanguage@http://localhost:8000/iodide.eval-frame.dev.js:103206:10"
+          "runCodeWithLanguage@http://localhost:8000/iodide.eval-frame.js:103206:10"
       },
       {
         columnNumber: 147,
         lineNumber: 102695,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "evaluateCode/</<",
         source:
-          "evaluateCode/</<@http://localhost:8000/iodide.eval-frame.dev.js:102695:147"
+          "evaluateCode/</<@http://localhost:8000/iodide.eval-frame.js:102695:147"
       },
       {
         columnNumber: 121,
         lineNumber: 102695,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "promise callback*evaluateCode/<",
         source:
-          "promise callback*evaluateCode/<@http://localhost:8000/iodide.eval-frame.dev.js:102695:121"
+          "promise callback*evaluateCode/<@http://localhost:8000/iodide.eval-frame.js:102695:121"
       },
       {
         columnNumber: 18,
         lineNumber: 97655,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "createThunkMiddleware/</</<",
         source:
-          "createThunkMiddleware/</</<@http://localhost:8000/iodide.eval-frame.dev.js:97655:18"
+          "createThunkMiddleware/</</<@http://localhost:8000/iodide.eval-frame.js:97655:18"
       },
       {
         columnNumber: 18,
         lineNumber: 98297,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "dispatch",
-        source:
-          "dispatch@http://localhost:8000/iodide.eval-frame.dev.js:98297:18"
+        source: "dispatch@http://localhost:8000/iodide.eval-frame.js:98297:18"
       },
       {
         columnNumber: 52,
         lineNumber: 102713,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "evaluateText/</evaluationQueue<",
         source:
-          "evaluateText/</evaluationQueue<@http://localhost:8000/iodide.eval-frame.dev.js:102713:52"
+          "evaluateText/</evaluationQueue<@http://localhost:8000/iodide.eval-frame.js:102713:52"
       },
       {
         columnNumber: 25,
         lineNumber: 102713,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "promise callback*evaluateText/<",
         source:
-          "promise callback*evaluateText/<@http://localhost:8000/iodide.eval-frame.dev.js:102713:25"
+          "promise callback*evaluateText/<@http://localhost:8000/iodide.eval-frame.js:102713:25"
       },
       {
         columnNumber: 18,
         lineNumber: 97655,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "createThunkMiddleware/</</<",
         source:
-          "createThunkMiddleware/</</<@http://localhost:8000/iodide.eval-frame.dev.js:97655:18"
+          "createThunkMiddleware/</</<@http://localhost:8000/iodide.eval-frame.js:97655:18"
       },
       {
         columnNumber: 11,
         lineNumber: 104803,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "receiveMessage",
         source:
-          "receiveMessage@http://localhost:8000/iodide.eval-frame.dev.js:104803:11"
+          "receiveMessage@http://localhost:8000/iodide.eval-frame.js:104803:11"
       },
       {
         columnNumber: 1,
         lineNumber: 104820,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "EventHandlerNonNull*./src/eval-frame/port-to-editor.js",
         source:
-          "EventHandlerNonNull*./src/eval-frame/port-to-editor.js@http://localhost:8000/iodide.eval-frame.dev.js:104820:1"
+          "EventHandlerNonNull*./src/eval-frame/port-to-editor.js@http://localhost:8000/iodide.eval-frame.js:104820:1"
       },
       {
         columnNumber: 12,
         lineNumber: 20,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "__webpack_require__",
         source:
-          "__webpack_require__@http://localhost:8000/iodide.eval-frame.dev.js:20:12"
+          "__webpack_require__@http://localhost:8000/iodide.eval-frame.js:20:12"
       },
       {
         columnNumber: 73,
         lineNumber: 102746,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "./src/eval-frame/actions/eval-frame-tasks.js",
         source:
-          "./src/eval-frame/actions/eval-frame-tasks.js@http://localhost:8000/iodide.eval-frame.dev.js:102746:73"
+          "./src/eval-frame/actions/eval-frame-tasks.js@http://localhost:8000/iodide.eval-frame.js:102746:73"
       },
       {
         columnNumber: 12,
         lineNumber: 20,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "__webpack_require__",
         source:
-          "__webpack_require__@http://localhost:8000/iodide.eval-frame.dev.js:20:12"
+          "__webpack_require__@http://localhost:8000/iodide.eval-frame.js:20:12"
       },
       {
         columnNumber: 83,
         lineNumber: 104724,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "./src/eval-frame/keybindings.js",
         source:
-          "./src/eval-frame/keybindings.js@http://localhost:8000/iodide.eval-frame.dev.js:104724:83"
+          "./src/eval-frame/keybindings.js@http://localhost:8000/iodide.eval-frame.js:104724:83"
       },
       {
         columnNumber: 12,
         lineNumber: 20,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "__webpack_require__",
         source:
-          "__webpack_require__@http://localhost:8000/iodide.eval-frame.dev.js:20:12"
+          "__webpack_require__@http://localhost:8000/iodide.eval-frame.js:20:12"
       },
       {
         columnNumber: 71,
         lineNumber: 104342,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "./src/eval-frame/index.jsx",
         source:
-          "./src/eval-frame/index.jsx@http://localhost:8000/iodide.eval-frame.dev.js:104342:71"
+          "./src/eval-frame/index.jsx@http://localhost:8000/iodide.eval-frame.js:104342:71"
       },
       {
         columnNumber: 12,
         lineNumber: 20,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
         functionName: "__webpack_require__",
         source:
-          "__webpack_require__@http://localhost:8000/iodide.eval-frame.dev.js:20:12"
+          "__webpack_require__@http://localhost:8000/iodide.eval-frame.js:20:12"
       },
       {
         columnNumber: 18,
         lineNumber: 84,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
-        source: "@http://localhost:8000/iodide.eval-frame.dev.js:84:18"
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
+        source: "@http://localhost:8000/iodide.eval-frame.js:84:18"
       },
       {
         columnNumber: 11,
         lineNumber: 1,
-        fileName: "http://localhost:8000/iodide.eval-frame.dev.js",
-        source: "@http://localhost:8000/iodide.eval-frame.dev.js:1:11"
+        fileName: "http://localhost:8000/iodide.eval-frame.js",
+        source: "@http://localhost:8000/iodide.eval-frame.js:1:11"
       }
     ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,6 @@ const { IODIDE_PUBLIC } = process.env || false;
 const { USE_LOCAL_PYODIDE } = process.env || false;
 const { SOURCE_VERSION } = process.env;
 
-const APP_VERSION_STRING = process.env.APP_VERSION_STRING || "dev";
-
 const IS_PRODUCTION = process.env.NODE_ENV !== "dev";
 
 const APP_DIR = path.resolve(__dirname, "src/");
@@ -54,7 +52,7 @@ module.exports = env => {
     },
     output: {
       path: BUILD_DIR,
-      filename: `[name].${APP_VERSION_STRING}.js`
+      filename: `[name].js`
     },
     devtool: "source-map",
     resolve: {
@@ -91,7 +89,7 @@ module.exports = env => {
         },
         {
           test: /\.(woff|woff2|eot|ttf|otf|svg)$/,
-          loader: `file-loader?name=iodide.${APP_VERSION_STRING}.fonts/[name].[ext]`
+          loader: `file-loader?name=iodide.fonts/[name].[ext]`
         }
       ]
     },
@@ -124,7 +122,7 @@ module.exports = env => {
       }),
       new webpack.EnvironmentPlugin(["NODE_ENV"]),
       new webpack.DefinePlugin({
-        "process.env.IODIDE_VERSION": JSON.stringify(APP_VERSION_STRING),
+        "process.env.IODIDE_VERSION": JSON.stringify("dev"),
         "process.env.IODIDE_REDUX_LOG_MODE": JSON.stringify(reduxLogMode),
         "process.env.USE_LOCAL_PYODIDE": JSON.stringify(USE_LOCAL_PYODIDE),
         "process.env.USE_OPENIDC_AUTH": JSON.stringify(USE_OPENIDC_AUTH),
@@ -139,7 +137,7 @@ module.exports = env => {
         )
       }),
       new MiniCssExtractPlugin({
-        filename: `[name].${APP_VERSION_STRING}.css`
+        filename: `[name].css`
       }),
       new WriteFilePlugin()
     ],


### PR DESCRIPTION
Originally envisioned as a way to "version" iodide client side code,
it is not useful in Iodide's current incarnation. We may want to bring
something like it back in the future, but it will probably take a different
form.