### PR TITLE
Await script load before continuing evaluation in iodide (fixes #1278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Await script load before continuing evaluation in iodide (fixes #1278)
+
 # 0.15.0 (2019-11-04)
 
 - Use Spinach task scheduler instead of Celery: simpler, and eliminates the need for a worker beat node (#2381)

--- a/src/eval-frame/actions/fetch-cell-eval-actions.js
+++ b/src/eval-frame/actions/fetch-cell-eval-actions.js
@@ -8,10 +8,11 @@ export function loadScriptFromBlob(blob) {
   return new Promise((resolve, reject) => {
     const script = document.createElement("script");
     const url = URL.createObjectURL(blob);
-    script.onload = () => resolve(`scripted loaded`);
-    script.onerror = err => reject(new Error(err));
     script.src = url;
     document.head.appendChild(script);
+
+    script.onload = () => resolve(`scripted loaded`);
+    script.onerror = err => reject(new Error(err));
   });
 }
 

--- a/src/eval-frame/port-to-editor.js
+++ b/src/eval-frame/port-to-editor.js
@@ -117,7 +117,7 @@ async function receiveMessage(event) {
       case "LOAD_SCRIPT": {
         const { script } = message;
         try {
-          loadScriptFromBlob(script);
+          await loadScriptFromBlob(script);
           sendStatusResponseToEditor("SUCCESS", message.taskId);
         } catch {
           sendStatusResponseToEditor("ERROR", message.taskId);


### PR DESCRIPTION
We were already waiting for the network, but should also be waiting
for the DOM event that the script has been evaluated.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
