### PR TITLE
Allow running simple-serve from a port other than 8000 (fixes #2444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Allow running simple-serve from a port other than 8000
+
 # 0.15.1 (2019-11-06)
 
 - Await script load before continuing evaluation in iodide (fixes #1278) (#2411)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # (Unreleased; add upcoming change notes here)
 
-- Allow running simple-serve from a port other than 8000
+- Allow running simple-serve from a port other than 8000 (fixes #2444)
 
 # 0.15.1 (2019-11-06)
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -27,6 +27,7 @@ version of the editing environment you can access at [http://localhost:8000/](ht
 
 The command runs in watch mode, so changes to files will be detected and bundled automatically, but you will need to refresh the page in your browser manually to see the changes -- we have disabled "hot reloading" because automatically refreshing the browser would cause any active notebooks to lose their evaluation state.
 
+If you want to use another port number (e.g `9999`), you can use the command `npm run simple-serve -- --port=9999`
 If you require verbose Redux logging, you can use the command `REDUX_LOGGING=VERBOSE npm run simple-serve`
 
 ### Server mode

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const webpack = require("webpack");
 const path = require("path");
 const fs = require("fs");
+const minimist = require('minimist')
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require('terser-webpack-plugin');
 const GitRevisionPlugin = require("git-revision-webpack-plugin");
@@ -15,7 +16,8 @@ const reduxLogMode = process.env.REDUX_LOGGING
   ? process.env.REDUX_LOGGING
   : "SILENT";
 
-const DEV_SERVER_PORT = 8000;
+const ARGV = minimist(process.argv.slice(2));
+const DEV_SERVER_PORT = ARGV.port || 8000;
 
 const BUILD_DIR = path.resolve(__dirname, "build/");
 


### PR DESCRIPTION
Allow running simple-serve from a port other than 8000
https://github.com/iodide-project/iodide/issues/2444

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - tested manually, this is just a configuration change, doesn't need unit test for this.
