### PR TITLE
Enable user to clear console history with a click (#1015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Vertically align text in language selector(fixes #2446)
 - Allow running simple-serve from a port other than 8000 (fixes #2444)
 - Allow blank content on notebook revision creation (fixes #2445) (#2455)
+- Enable user to clear console history with a click (#1015)
 
 # 0.15.1 (2019-11-06)
 

--- a/src/editor/console/history/__tests__/reducer.test.js
+++ b/src/editor/console/history/__tests__/reducer.test.js
@@ -6,18 +6,6 @@ describe("console/history/CLEAR", () => {
     state = {
       history: [
         {
-          content: "Loading Python language plugin",
-          historyId: "wrmhklxskc",
-          historyType: "CONSOLE_MESSAGE",
-          level: "LOG"
-        },
-        {
-          content: "Python plugin ready",
-          historyId: "xqtol9pck6",
-          historyType: "CONSOLE_MESSAGE",
-          level: "LOG"
-        },
-        {
           content: "1+2",
           historyId: "7k77hjno1d",
           historyType: "CONSOLE_INPUT",

--- a/src/editor/console/history/__tests__/reducer.test.js
+++ b/src/editor/console/history/__tests__/reducer.test.js
@@ -2,7 +2,6 @@ import reducer from "../reducer";
 
 describe("console/history/CLEAR", () => {
   let state;
-
   beforeEach(() => {
     state = {
       history: [
@@ -31,12 +30,9 @@ describe("console/history/CLEAR", () => {
       ]
     };
   });
-
   it("empties out the history array in the state", () => {
     const action = { type: "console/history/CLEAR" };
-
     const nextState = reducer(state, action);
-
     expect(nextState.history).toEqual([]);
   });
 });

--- a/src/editor/console/history/__tests__/reducer.test.js
+++ b/src/editor/console/history/__tests__/reducer.test.js
@@ -1,0 +1,42 @@
+import reducer from "../reducer"
+
+describe("console/history/CLEAR", () => {
+  let state
+
+  beforeEach(() => {
+    state = {
+      history: [
+        {
+          content: "Loading Python language plugin",
+          historyId: "wrmhklxskc",
+          historyType: "CONSOLE_MESSAGE",
+          level: "LOG"
+        },
+        {
+          content: "Python plugin ready",
+          historyId: "xqtol9pck6",
+          historyType: "CONSOLE_MESSAGE",
+          level: "LOG"
+        },
+        {
+          content: "1+2",
+          historyId: "7k77hjno1d",
+          historyType: "CONSOLE_INPUT",
+          language: "py"
+        },
+        {
+          historyId: "6316fcv86c",
+          historyType: "CONSOLE_OUTPUT"
+        }
+      ]
+    }
+  })
+
+  it("empties out the history array in the state", () => {
+    const action = { type: "console/history/CLEAR" }
+
+    const nextState = reducer(state, action)
+
+    expect(nextState.history).toEqual([])
+  })
+})

--- a/src/editor/console/history/__tests__/reducer.test.js
+++ b/src/editor/console/history/__tests__/reducer.test.js
@@ -1,7 +1,7 @@
-import reducer from "../reducer"
+import reducer from "../reducer";
 
 describe("console/history/CLEAR", () => {
-  let state
+  let state;
 
   beforeEach(() => {
     state = {
@@ -29,14 +29,14 @@ describe("console/history/CLEAR", () => {
           historyType: "CONSOLE_OUTPUT"
         }
       ]
-    }
-  })
+    };
+  });
 
   it("empties out the history array in the state", () => {
-    const action = { type: "console/history/CLEAR" }
+    const action = { type: "console/history/CLEAR" };
 
-    const nextState = reducer(state, action)
+    const nextState = reducer(state, action);
 
-    expect(nextState.history).toEqual([])
-  })
-})
+    expect(nextState.history).toEqual([]);
+  });
+});

--- a/src/editor/console/history/actions.js
+++ b/src/editor/console/history/actions.js
@@ -36,6 +36,8 @@ export const addPluginParseErrorToHistory = errorMessage =>
     level: "ERROR"
   });
 
+export const clearHistory = () => ({ type: "console/history/CLEAR" });
+
 export const updateHistoryEntryLevel = (historyId, level) => ({
   type: "console/history/UPDATE",
   historyItem: { historyId, level }

--- a/src/editor/console/history/reducer.js
+++ b/src/editor/console/history/reducer.js
@@ -7,7 +7,7 @@ export default function reducer(state, action) {
       return Object.assign({}, state, { history });
     }
     case "console/history/CLEAR": {
-      return Object.assign({}, state, { history: [] })
+      return Object.assign({}, state, { history: [] });
     }
     case "console/history/UPDATE": {
       const actionCopy = Object.assign({}, action);

--- a/src/editor/console/history/reducer.js
+++ b/src/editor/console/history/reducer.js
@@ -6,6 +6,9 @@ export default function reducer(state, action) {
       const history = [...state.history, actionCopy];
       return Object.assign({}, state, { history });
     }
+    case "console/history/CLEAR": {
+      return Object.assign({}, state, { history: [] })
+    }
     case "console/history/UPDATE": {
       const actionCopy = Object.assign({}, action);
       const history = [...state.history.slice()];

--- a/src/editor/console/input/components/__tests__/console-language-menu.test.js
+++ b/src/editor/console/input/components/__tests__/console-language-menu.test.js
@@ -50,7 +50,7 @@ describe("ConsoleLanguageMenu mapStateToProps", () => {
   });
 });
 
-describe("ConsoleLanguageMenu mapStateToProps", () => {
+describe("ConsoleLanguageMenu clearConsoleHistory", () => {
   let props;
   beforeEach(() => {
     props = {

--- a/src/editor/console/input/components/__tests__/console-language-menu.test.js
+++ b/src/editor/console/input/components/__tests__/console-language-menu.test.js
@@ -1,4 +1,10 @@
-import { mapStateToProps } from "../console-language-menu";
+import React from "react";
+import { shallow } from "enzyme";
+
+import {
+  ConsoleLanguageMenuUnconnected,
+  mapStateToProps
+} from "../console-language-menu";
 
 describe("ConsoleLanguageMenu mapStateToProps", () => {
   let state;
@@ -41,5 +47,31 @@ describe("ConsoleLanguageMenu mapStateToProps", () => {
     expect(mapStateToProps(state).shouldDisplayClearConsoleAction).toEqual(
       false
     );
+  });
+});
+
+describe("ConsoleLanguageMenu mapStateToProps", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      availableLanguages: [
+        {
+          languageId: "py",
+          displayName: "Python"
+        }
+      ],
+      clearConsoleHistory: jest.fn(),
+      currentLanguage: "py",
+      setConsoleLanguageProp: jest.fn(),
+      shouldDisplayClearConsoleAction: true
+    };
+  });
+  it("calls correct action when 'Clear console' item is clicked", () => {
+    const wrapper = shallow(<ConsoleLanguageMenuUnconnected {...props} />, {
+      context: {}
+    });
+    expect(props.clearConsoleHistory).toHaveBeenCalledTimes(0);
+    wrapper.findWhere(c => c.key() === "clear-history").simulate("click");
+    expect(props.clearConsoleHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/editor/console/input/components/__tests__/console-language-menu.test.js
+++ b/src/editor/console/input/components/__tests__/console-language-menu.test.js
@@ -4,6 +4,11 @@ describe("ConsoleLanguageMenu mapStateToProps", () => {
   let state;
   beforeEach(() => {
     state = {
+      history: [
+        { historyId: "wrmhklxskc" },
+        { historyId: "xqtol9pck6" },
+        { historyId: "7k77hjno1d" }
+      ],
       languageDefinitions: {
         js: { languageId: "js", displayName: "JavaScript" },
         py: { languageId: "py", displayName: "Python" }
@@ -24,6 +29,17 @@ describe("ConsoleLanguageMenu mapStateToProps", () => {
     );
     expect(new Set(props.availableLanguages.map(d => d.displayName))).toEqual(
       new Set(["JavaScript", "Python", "Julia"])
+    );
+  });
+  it("sets shouldDisplayClearConsoleAction prop as true when history not empty", () => {
+    expect(mapStateToProps(state).shouldDisplayClearConsoleAction).toEqual(
+      true
+    );
+  });
+  it("sets shouldDisplayClearConsoleAction prop as false when history empty", () => {
+    state.history = [];
+    expect(mapStateToProps(state).shouldDisplayClearConsoleAction).toEqual(
+      false
     );
   });
 });

--- a/src/editor/console/input/components/console-language-menu.jsx
+++ b/src/editor/console/input/components/console-language-menu.jsx
@@ -13,6 +13,7 @@ import { TextButton } from "../../../../shared/components/buttons";
 import BaseIcon from "../../base-icon";
 
 import { setConsoleLanguage } from "../actions";
+import { clearHistory } from "../../history/actions";
 
 const ArrowDropUp = styled(BaseIcon(ArrowDropUpIcon))`
   display: inline-block;
@@ -71,6 +72,7 @@ const DeleteIcon = styled(Delete)`
 
 const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
+  clearConsoleHistory,
   currentLanguage,
   setConsoleLanguageProp
 }) => {
@@ -98,10 +100,7 @@ const ConsoleLanguageMenuUnconnected = ({
             </MenuItem>
           ))}
           <Divider light />
-          <MenuItem
-            key="clear-history"
-            onClick={() => console.log("clear-console-history")}
-          >
+          <MenuItem key="clear-history" onClick={() => clearConsoleHistory()}>
             <LanguageName>Clear history</LanguageName>
             <LanguageShort>
               <DeleteIcon />
@@ -120,6 +119,7 @@ ConsoleLanguageMenuUnconnected.propTypes = {
       languageId: PropTypes.string.isRequired
     })
   ).isRequired,
+  clearConsoleHistory: PropTypes.func.isRequired,
   currentLanguage: PropTypes.string.isRequired,
   setConsoleLanguageProp: PropTypes.func.isRequired
 };
@@ -133,7 +133,10 @@ export function mapStateToProps(state) {
     availableLanguages
   };
 }
-const mapDispatchToProps = { setConsoleLanguageProp: setConsoleLanguage };
+const mapDispatchToProps = {
+  clearConsoleHistory: clearHistory,
+  setConsoleLanguageProp: setConsoleLanguage
+};
 
 export default connect(
   mapStateToProps,

--- a/src/editor/console/input/components/console-language-menu.jsx
+++ b/src/editor/console/input/components/console-language-menu.jsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import ArrowDropUpIcon from "@material-ui/icons/ArrowDropUp";
+import Divider from "@material-ui/core/Divider";
+import Delete from "@material-ui/icons/Delete";
 import Popover from "../../../../shared/components/popover";
 import Menu from "../../../../shared/components/menu";
 import MenuItem from "../../../../shared/components/menu-item";
@@ -61,6 +63,12 @@ const LanguageSelect = styled("div")`
   align-items: center;
 `;
 
+const DeleteIcon = styled(Delete)`
+  margin-left: -2px;
+  margin-top: 5px;
+  width: 16px !important;
+`;
+
 const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
   currentLanguage,
@@ -89,6 +97,16 @@ const ConsoleLanguageMenuUnconnected = ({
               <LanguageShort>{language.languageId}</LanguageShort>
             </MenuItem>
           ))}
+          <Divider light />
+          <MenuItem
+            key="clear-history"
+            onClick={() => console.log("clear-console-history")}
+          >
+            <LanguageName>Clear history</LanguageName>
+            <LanguageShort>
+              <DeleteIcon />
+            </LanguageShort>
+          </MenuItem>
         </Menu>
       </Popover>
     </React.Fragment>

--- a/src/editor/console/input/components/console-language-menu.jsx
+++ b/src/editor/console/input/components/console-language-menu.jsx
@@ -70,7 +70,7 @@ const DeleteIcon = styled(Delete)`
   width: 16px !important;
 `;
 
-const ConsoleLanguageMenuUnconnected = ({
+export const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
   clearConsoleHistory,
   currentLanguage,

--- a/src/editor/console/input/components/console-language-menu.jsx
+++ b/src/editor/console/input/components/console-language-menu.jsx
@@ -74,7 +74,8 @@ const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
   clearConsoleHistory,
   currentLanguage,
-  setConsoleLanguageProp
+  setConsoleLanguageProp,
+  shouldDisplayClearConsoleAction
 }) => {
   return (
     <React.Fragment>
@@ -100,12 +101,14 @@ const ConsoleLanguageMenuUnconnected = ({
             </MenuItem>
           ))}
           <Divider light />
-          <MenuItem key="clear-history" onClick={() => clearConsoleHistory()}>
-            <LanguageName>Clear history</LanguageName>
-            <LanguageShort>
-              <DeleteIcon />
-            </LanguageShort>
-          </MenuItem>
+          {shouldDisplayClearConsoleAction && (
+            <MenuItem key="clear-history" onClick={() => clearConsoleHistory()}>
+              <LanguageName>Clear history</LanguageName>
+              <LanguageShort>
+                <DeleteIcon />
+              </LanguageShort>
+            </MenuItem>
+          )}
         </Menu>
       </Popover>
     </React.Fragment>
@@ -121,16 +124,20 @@ ConsoleLanguageMenuUnconnected.propTypes = {
   ).isRequired,
   clearConsoleHistory: PropTypes.func.isRequired,
   currentLanguage: PropTypes.string.isRequired,
-  setConsoleLanguageProp: PropTypes.func.isRequired
+  setConsoleLanguageProp: PropTypes.func.isRequired,
+  shouldDisplayClearConsoleAction: PropTypes.bool
 };
 
 export function mapStateToProps(state) {
   const availableLanguages = Object.values(
     Object.assign({}, state.languageDefinitions, state.loadedLanguages)
   );
+  const shouldDisplayClearConsoleAction =
+    state.history && state.history.length > 0;
   return {
     currentLanguage: state.languageLastUsed,
-    availableLanguages
+    availableLanguages,
+    shouldDisplayClearConsoleAction
   };
 }
 const mapDispatchToProps = {


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

This PR should implement feature #1015 
* Add a clear history item to the list of drop down next to console input
* Add separator line between clear console action and language selection in the drop-down
* Clear the console history on clicking the clear console drop-down item

### Screenshots: Before Change

![Screenshot from 2019-11-19 00-08-05](https://user-images.githubusercontent.com/5580715/69118258-bb13da00-0a60-11ea-9834-1b567d86323a.png)


### Screenshots: After Change

#### Before clear history

![Screenshot from 2019-11-18 23-25-36](https://user-images.githubusercontent.com/5580715/69118176-6e300380-0a60-11ea-8e80-e8b42b6586a5.png)


#### After clear history

![Screenshot from 2019-11-18 23-25-14](https://user-images.githubusercontent.com/5580715/69118123-3923b100-0a60-11ea-84c6-bdaa89ef27ea.png)


