### PR TITLE
Add an empty coverage directory to the checkout

### DIFF
--- a/.coverage/.gitignore
+++ b/.coverage/.gitignore
@@ -1,0 +1,2 @@
+coverage.xml
+data

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,6 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
-# coverage.py
-.coverage
-coverage.xml
-
 # nyc test coverage
 .nyc_output
 

--- a/bin/run
+++ b/bin/run
@@ -27,7 +27,6 @@ wait_for() {
 wait_for db 5432
 
 tests() {
-  mkdir -p /app/.coverage
   python manage.py check
   python -m pytest "$@"  # skips linter checks
 }


### PR DESCRIPTION
This removes the need for the tests to create a directory, and also
ensures that running the tests via the console works.