### PR TITLE
Make it more clear what the "go to report" button does

### DIFF
--- a/src/editor/components/menu/__tests__/view-mode-toggle-button.test.js
+++ b/src/editor/components/menu/__tests__/view-mode-toggle-button.test.js
@@ -76,8 +76,7 @@ describe("ViewModeToggleButton mapStateToProps", () => {
     state.viewMode = "not_REPORT_VIEW";
     expect(mapStateToProps(state)).toEqual({
       isReportView: false,
-      buttonText: "Report",
-      tooltipText: "Go to Report view",
+      buttonText: "View as Report",
       style: { color: "#fafafa" }
     });
   });

--- a/src/editor/components/menu/view-mode-toggle-button.jsx
+++ b/src/editor/components/menu/view-mode-toggle-button.jsx
@@ -51,8 +51,8 @@ export function mapStateToProps(state) {
   const isReportView = state.viewMode === "REPORT_VIEW";
   return {
     isReportView,
-    buttonText: isReportView ? "Explore" : "Report",
-    tooltipText: isReportView ? "Explore this notebook" : "Go to Report view",
+    buttonText: isReportView ? "Explore" : "View as Report",
+    tooltipText: isReportView ? "Explore this notebook" : undefined,
     style: isReportView
       ? { backgroundColor: "#eee", border: "1px solid #ccc", color: "black" }
       : { color: "#fafafa" }


### PR DESCRIPTION
Just "report" is a bit ambiguous (is it to file a bug report?). We have enough
space to use a small verb phrase ("view as report"), so let's just do that.