### PR TITLE
Make test_post_to_file_api stable (fixes #2497)

### DIFF
--- a/server/tests/test_file_api.py
+++ b/server/tests/test_file_api.py
@@ -29,9 +29,10 @@ def test_post_to_file_api(fake_user, client, test_notebook):
         resp = post_file(f, client, test_notebook)
         assert resp.status_code == 201
         assert File.objects.count() == 1
-        created_file = File.objects.get(id=1)
+        resp_json = resp.json()
+        created_file = File.objects.get(id=resp_json["id"])
         assert created_file.content.tobytes() == b"hello"
-        assert resp.json() == {
+        assert resp_json == {
             "id": created_file.id,
             "last_updated": get_rest_framework_time_string(created_file.last_updated),
             "filename": "my cool file.csv",


### PR DESCRIPTION
This is to fix test_post_to_file_api test, make it stable.

Related issue: #2497 