### PR TITLE
hack to fix pandas scrolling on ff. fixes #2485

### DIFF
--- a/src/editor/style/jupyter-rendered-html-styles.css
+++ b/src/editor/style/jupyter-rendered-html-styles.css
@@ -4,6 +4,13 @@
   color: black;
   /* any extras will just be numbers: */
 }
+
+@supports (-moz-appearance: meterbar) and (display: flex) {
+  .rendered_html {
+    padding-right: 18px;
+  }
+}
+
 .rendered_html em {
   font-style: italic;
 }

--- a/src/editor/style/jupyter-rendered-html-styles.css
+++ b/src/editor/style/jupyter-rendered-html-styles.css
@@ -5,6 +5,7 @@
   /* any extras will just be numbers: */
 }
 
+/* Workaround for bug in Firefox that causes some html to incorrectly overflow with horizontal scrollbars: see https://github.com/iodide-project/iodide/issues/2458 */
 @supports (-moz-appearance: meterbar) and (display: flex) {
   .rendered_html {
     padding-right: 18px;


### PR DESCRIPTION
#2458 appears to be because of a rendering bug in FF:
https://stackoverflow.com/a/59050187
https://stackoverflow.com/questions/39738265/firefox-displays-unnecessary-horizontal-scrollbar

this PR adds a hacky CSS thing from http://browserhacks.com/#fx , which kind of sucks, but it fixes the problem and looked like the best option from some poking around on stackoverflow



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
