### PR TITLE
Unescape hexadecimal quotes in iomd (fixes #2524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Unescape hexadecimal quotes in iomd (fixes #2524) (#2525)
+
 # 0.16.0 (2019-12-05)
 
 - Remove redundant description metadata for link previews (#2448)

--- a/src/editor/initialization/__tests__/handle-initial-iomd.test.js
+++ b/src/editor/initialization/__tests__/handle-initial-iomd.test.js
@@ -75,7 +75,7 @@ blah blah
 describe("handleInitialIomd unescapes #iomd elt content", () => {
   const iomdString = `
 %% js
-blah &lt;&gt;&#39;&quot;&amp; blah
+blah &lt;&gt;&#39;&quot;&amp; &#x27;blah&#x27;
     `;
   let store;
 
@@ -92,7 +92,7 @@ blah &lt;&gt;&#39;&quot;&amp; blah
 
   const unescapedIomdString = `
 %% js
-blah <>'"& blah
+blah <>'"& 'blah'
     `;
   it("iomd is correct", () => {
     handleInitialIomd(store);

--- a/src/editor/initialization/handle-initial-iomd.js
+++ b/src/editor/initialization/handle-initial-iomd.js
@@ -4,6 +4,8 @@ import { updateIomdContent } from "../actions/editor-actions";
 export default function handleInitialIomd(store) {
   const iomdElt = document.getElementById("iomd");
   if (iomdElt && iomdElt.innerHTML) {
-    store.dispatch(updateIomdContent(_.unescape(iomdElt.innerHTML)));
+    store.dispatch(
+      updateIomdContent(_.unescape(iomdElt.innerHTML).replace(/&#x27;/g, "'"))
+    );
   }
 }


### PR DESCRIPTION
Django 3.0 escapes quotes in hexadecimal format
(https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.html.escape),
so our unescaping function needs to handle those sequences too.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
