### PR TITLE
Update Julia/JS integration tier

### DIFF
--- a/docs/language_plugins.md
+++ b/docs/language_plugins.md
@@ -30,7 +30,7 @@ levels of support to make it easier to know what to expect.
 | [AssemblyScript](https://alpha.iodide.io/notebooks/1234) | AssemblyScript | ✓       | ✓       |         |         |          |
 | [Lua](https://alpha.iodide.io/notebooks/1416/)            | Lua            | ✓       | ✓       |         |         |          |
 | [Opal](https://alpha.iodide.io/notebooks/1453/)           | Ruby           | ✓       | ✓       |         |         |          |
-| [Julide](https://github.com/keno/julia-wasm)                                                                        | Julia           | ✓        |         |         |         |          |
+| [Julide](https://github.com/keno/julia-wasm)                                                                        | Julia           | ✓        | ✓       | ✓       |         |          |
 | [Domical](https://github.com/louisabraham/domical)                              | OCaml          | ✓       |         |         |         |          |
 | [PlantUml](https://github.com/six42/iodide-plantuml-plugin)                              | PlantUml          | ✓       |         |         |         |          |
 


### PR DESCRIPTION
As of https://github.com/JuliaLang/julia/pull/34016, when compiled to wasm, Julia supports integrating with and calling javascript class instances from within Julia code, which makes it Level 3 by the support level defined in this document. Of course the Julia/wasm integration is still quite a bit less mature than the python integration, so maybe that should be noted somewhere, but it does work at least.

cc @vchuravy