### PR TITLE
Support bytes fetch type (fixes #1786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Report more specific errors in console when executing fetch cell (fixes #1853) (#2475)
 - Better onboarding around the use of the "run all" button (#2471)
 - Automatically prune revision history (fixes #2451) (#2461)
+- Add `bytes` fetch to fetch chunks (see docs) (fixes #1786)
 
 # 0.15.1 (2019-11-06)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -167,8 +167,9 @@ available to [fetch chunks](https://iodide-project.github.io/docs/iomd/#fetch-ch
 
 - `json` (load this file as json and parse into a javascript object),
 - `text` (load this file as text),
-- `arrayBuffer` (load this file into an Array Buffer, especially useful when working with typed arrays) and
-- `blob` (load this file as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)).
+- `arrayBuffer` (load this file into an Array Buffer, especially useful when working with typed arrays)
+- `blob` (load this file as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)) and
+- `bytes` (load this file into an Array Buffer then convert it to [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) TODO:**Add more description here?**)
 
 These match the `serializerType` in `iodide.file.save` – if you save with a certain `serializerType`, it is recommended to load it with the same `fetchType`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -169,7 +169,7 @@ available to [fetch chunks](https://iodide-project.github.io/docs/iomd/#fetch-ch
 - `text` (load this file as text),
 - `arrayBuffer` (load this file into an Array Buffer, especially useful when working with typed arrays)
 - `blob` (load this file as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)) and
-- `bytes` (load this file into an Array Buffer then convert it to [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) TODO:**Add more description here?**)
+- `bytes` (load this file into an Array Buffer then convert it to [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), especially useful when working with APIs that expect a typed array of bytes)
 
 These match the `serializerType` in `iodide.file.save` – if you save with a certain `serializerType`, it is recommended to load it with the same `fetchType`.
 

--- a/docs/iomd.md
+++ b/docs/iomd.md
@@ -122,7 +122,7 @@ Each line in a fetch cell must specify:
 1. the "fetch type", one of `js`, `css`, `json`, `text`, `arrayBuffer`, `blob`, or `plugin`
 2. the url from which the resource will be fetched
 
-Additionally, data fetches (`json`, `text`, `blob`, `arrayBuffer`, `bytes`) must specify the variable name into which the data will be stored.
+Additionally, data fetches (`json`, `text`, `blob`, `arrayBuffer`, and `bytes`) must specify the variable name into which the data will be stored.
 
 This example demonstrates how a fetch chunk is used.
 
@@ -135,7 +135,7 @@ text: csvDataString = https://www.exmpl.co/a_csv_file.csv
 arrayBuffer: bigDataframe = https://www.exmpl.co/a_binary.arrow
 json: jsonData = https://www.exmpl.co/a_json_file.json
 blob: blobData = https://www.exmpl.co/a_binary_blob.arrow
-bytes: blobData = https://www.exmpl.co/a_binary_blob.arrow
+bytes: binaryData = https://www.exmpl.co/a_binary_file.hdf5
 ```
 
 All of the requested resources are downloaded in parallel (asynchronously), but if several evaluations are queued, following chunks will not be evaluated until all the resources are available. This allows you to manage the retrieval of assets in a more synchronous workflow, without having to deal with the asynchronous nature of Web APIs (of course, you are free to manage that complexity with JavaScript code and using those APIs if you need that extra control).

--- a/docs/iomd.md
+++ b/docs/iomd.md
@@ -122,7 +122,7 @@ Each line in a fetch cell must specify:
 1. the "fetch type", one of `js`, `css`, `json`, `text`, `arrayBuffer`, `blob`, or `plugin`
 2. the url from which the resource will be fetched
 
-Additionally, data fetches (`json`, `text` or `blob`) must specify the variable name into which the data will be stored.
+Additionally, data fetches (`json`, `text`, `blob`, `arrayBuffer`, `bytes`) must specify the variable name into which the data will be stored.
 
 This example demonstrates how a fetch chunk is used.
 
@@ -135,6 +135,7 @@ text: csvDataString = https://www.exmpl.co/a_csv_file.csv
 arrayBuffer: bigDataframe = https://www.exmpl.co/a_binary.arrow
 json: jsonData = https://www.exmpl.co/a_json_file.json
 blob: blobData = https://www.exmpl.co/a_binary_blob.arrow
+bytes: blobData = https://www.exmpl.co/a_binary_blob.arrow
 ```
 
 All of the requested resources are downloaded in parallel (asynchronously), but if several evaluations are queued, following chunks will not be evaluated until all the resources are available. This allows you to manage the retrieval of assets in a more synchronous workflow, without having to deal with the asynchronous nature of Web APIs (of course, you are free to manage that complexity with JavaScript code and using those APIs if you need that extra control).
@@ -149,6 +150,7 @@ In the case of data fetches, which have the syntax `{TYPE}: {VAR_NAME} = {RESOUR
 - `text` - returns a raw string,
 - `arrayBuffer` - returns an [Array Buffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) object,
 - `blob` - returns a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) object
+- `bytes` - returns a [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) object
 
 It is also possible to use a fetch chunk to load files that you have saved to your Iodide notebook by way of the the [Iodide Files UI](workflows.md#getting-data-into-an-iodide-notebook) or the `iodide.file.save` function in the [Iodide API](api.md#iodidefile).
 

--- a/src/editor/actions/__tests__/fetch-cell-parser.test.js
+++ b/src/editor/actions/__tests__/fetch-cell-parser.test.js
@@ -268,7 +268,8 @@ describe("validate fetch url", () => {
     "css: /path/to/file.css",
     "json: varname = path/to/file.json",
     "text: varname=path/to/file.text",
-    "arrayBuffer: varname = https://valid-ホスト.com/file.arrow"
+    "arrayBuffer: varname = https://valid-ホスト.com/file.arrow",
+    "bytes: varname = https://valid-ホスト.com/file.arrow"
   ];
   validLines.forEach(testCase => {
     it(`IS a valid fetch url"${testCase}"`, () => {

--- a/src/editor/actions/fetch-cell-parser.js
+++ b/src/editor/actions/fetch-cell-parser.js
@@ -4,6 +4,7 @@ const URL_FETCH_TYPES = ["css", "js"];
 const VALID_FETCH_TYPES = URL_FETCH_TYPES.concat([
   "arrayBuffer",
   "blob",
+  "bytes",
   "json",
   "text",
   "plugin"
@@ -86,7 +87,7 @@ export function validFetchUrl(line) {
     Assume fetch type and variable name are valid,
     For script fetch (css & js), valid fetch content is:
       "<fetch-url>"
-    For data fetch (arrayBuffer, blob, json & text), valid fetch content is:
+    For data fetch (arrayBuffer, blob, bytes, json & text), valid fetch content is:
       "<variable-name> = <fetch-url>"
   */
   const fetchType = line.split(": ")[0];
@@ -150,6 +151,7 @@ export function parseFetchCellLine(lineWithComments) {
     case "json":
     case "arrayBuffer":
     case "blob":
+    case "bytes":
       return Object.assign(
         {},
         { fetchType },

--- a/src/editor/actions/sagas/fetch-cell-saga.js
+++ b/src/editor/actions/sagas/fetch-cell-saga.js
@@ -52,7 +52,7 @@ function* handleValidFetch(fetchInfo, historyId, lineIndex) {
     throw new Error(`failed to fetch file; halting eval queue`);
   }
 
-  if (["text", "json", "blob", "arrayBuffer"].includes(fetchType)) {
+  if (["text", "json", "blob", "arrayBuffer", "bytes"].includes(fetchType)) {
     yield call(triggerEvalFrameTask, "ASSIGN_VARIABLE", {
       name: varName,
       value: fetchedFile

--- a/src/editor/components/iomd-editor/__tests__/fetch-line-suggestion.test.js
+++ b/src/editor/components/iomd-editor/__tests__/fetch-line-suggestion.test.js
@@ -3,6 +3,7 @@ import { fetchLineSuggestion } from "../fetch-line-suggestion";
 const nonFileNameSuggestionLabels = [
   "arrayBuffer",
   "blob",
+  "bytes",
   "css",
   "javascript",
   "js",

--- a/src/editor/components/iomd-editor/fetch-line-suggestion.js
+++ b/src/editor/components/iomd-editor/fetch-line-suggestion.js
@@ -50,6 +50,11 @@ export const fetchLineSuggestion = (lineSoFar, fileNames) => {
         label: "blob",
         detail: "Blob data fetch statement",
         insertText: "blob: ${1:varName} = ${2:fileOrUrl}"
+      },
+      {
+        label: "bytes",
+        detail: "bytes data fetch statement",
+        insertText: "bytes: ${1:varName} = ${2:fileOrUrl}"
       }
       /* eslint-enable */
     ].map(itemProps => ({

--- a/src/editor/state-schemas/state-schema.js
+++ b/src/editor/state-schemas/state-schema.js
@@ -12,10 +12,17 @@ export const FETCH_CHUNK_TYPES = [
   "blob",
   "json",
   "arrayBuffer",
+  "bytes",
   "plugin"
 ];
 
-export const IODIDE_API_LOAD_TYPES = ["text", "blob", "json", "arrayBuffer"];
+export const IODIDE_API_LOAD_TYPES = [
+  "text",
+  "blob",
+  "json",
+  "arrayBuffer",
+  "bytes"
+];
 export const FILE_SOURCE_INPUT_STATUS_TYPES = [
   "NONE",
   "LOADING",

--- a/src/shared/utils/__test__/generic-fetch.test.js
+++ b/src/shared/utils/__test__/generic-fetch.test.js
@@ -1,0 +1,59 @@
+import isArrayBuffer from "lodash/isArrayBuffer";
+
+import { genericFetch } from "../fetch-tools";
+
+describe("fetch raw data as correct type", () => {
+  it("should convert arrayBuffer into bytes if fetch is `bytes`", async () => {
+    const mockResponse = {
+      arrayBuffer: () => new ArrayBuffer(8),
+      ok: true
+    };
+    const mockFetch = () => Promise.resolve(mockResponse);
+    jest.spyOn(global, "fetch").mockImplementationOnce(mockFetch);
+
+    const data = await genericFetch("some-path", "bytes");
+
+    expect(data.byteLength).toEqual(8);
+    expect(isArrayBuffer(data.buffer)).toBe(true);
+  });
+
+  it("should fetch correctly if fetch is `arrayBuffer`", async () => {
+    const mockResponse = {
+      arrayBuffer: () => new ArrayBuffer(8),
+      ok: true
+    };
+    const mockFetch = () => Promise.resolve(mockResponse);
+    jest.spyOn(global, "fetch").mockImplementationOnce(mockFetch);
+
+    const data = await genericFetch("some-path", "arrayBuffer");
+
+    expect(data.byteLength).toEqual(8);
+    expect(isArrayBuffer(data)).toBe(true);
+  });
+
+  const fetchTypes = [
+    "css",
+    "js",
+    "json",
+    "plugin",
+    "text",
+    "arrayBuffer",
+    "blob",
+    "bytes"
+  ];
+  fetchTypes.forEach(fetchType => {
+    it(`should reject "${fetchType}" fetch promise if http response not ok`, async () => {
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        statusText: "Bad request"
+      };
+      const mockFetch = () => Promise.resolve(mockResponse);
+      jest.spyOn(global, "fetch").mockImplementationOnce(mockFetch);
+
+      const badPromise = genericFetch("some-path", fetchType);
+
+      await expect(badPromise).rejects.toThrow("400 Bad request (some-path)");
+    });
+  });
+});

--- a/src/shared/utils/fetch-tools.js
+++ b/src/shared/utils/fetch-tools.js
@@ -2,13 +2,21 @@ export const getResponseTypeFromFetchType = fetchEntry => {
   if (fetchEntry === "css") return "text";
   if (fetchEntry === "js") return "blob";
   if (fetchEntry === "plugin") return "text";
+  if (fetchEntry === "bytes") return "arrayBuffer";
   return fetchEntry;
 };
 
 export function genericFetch(path, fetchType) {
   const responseType = getResponseTypeFromFetchType(fetchType);
-  return fetch(path).then(r => {
-    if (!r.ok) throw new Error(`${r.status} ${r.statusText} (${path})`);
-    return r[responseType]();
-  });
+  return fetch(path)
+    .then(r => {
+      if (!r.ok) throw new Error(`${r.status} ${r.statusText} (${path})`);
+      return r[responseType]();
+    })
+    .then(r => {
+      if (fetchType === "bytes") {
+        return new Uint8Array(r);
+      }
+      return r;
+    });
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

This PR should fix #1786 

This PR is created based on my understanding of the issue after following the discussion on the issue itself & issue #1686 ie we need a new data fetch type called `bytes` that works the same way as `arrayBuffer`:
```
%% fetch
bytes: some_data = https://some-valid-host.com/some-data.some-binary-type
```

So this PR will:
1. Convert arrayBuffer to uint8Array on fetch bytes
2. Add `bytes` to valid fetch types
3. Support syntax highlight & auto-suggest for `bytes`

Some questions:
1. I am not very familiar with Javascript typed array nor Python memoryview nor data science in general that I couldn't find a sample binary data that I can test out on the notebook. The links in the issues are all not working anymore. Can someone provide me with a sample url?
2. I added a TODO flag in the documentation whereby I tried to describe the benefit of introducing this `bytes` fetch type. As I understand, it is so common for data scientists to convert ArrayBuffer into Uint8Array before doing something on it in Python world that it is worth shortcutting that with this new fetch type. Is that correct? I would appreciate some help with this so I can add a better description to the docs.
