### PR TITLE
Add printing support for reports that are longer than one page

### DIFF
--- a/src/editor/components/menu/view-mode-toggle-button.jsx
+++ b/src/editor/components/menu/view-mode-toggle-button.jsx
@@ -16,7 +16,15 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
   };
   constructor(props) {
     super(props);
+    this.printReport = this.printReport.bind(this);
     this.toggleViewMode = this.toggleViewMode.bind(this);
+  }
+
+  printReport() {
+    if (this.props.isReportView) {
+      document.getElementById("eval-frame").contentWindow.focus();
+      document.getElementById("eval-frame").contentWindow.print();
+    }
   }
 
   toggleViewMode() {
@@ -33,14 +41,26 @@ export class ViewModeToggleButtonUnconnected extends React.Component {
         classes={{ tooltip: "iodide-tooltip" }}
         title={this.props.tooltipText}
       >
-        <Button
-          style={this.props.style}
-          onClick={this.toggleViewMode}
-          variant="text"
-          mini
-        >
-          {this.props.buttonText}
-        </Button>
+        <div>
+          {this.props.isReportView && (
+            <Button
+              style={this.props.style}
+              onClick={this.printReport}
+              variant="text"
+              mini
+            >
+              Print
+            </Button>
+          )}
+          <Button
+            style={this.props.style}
+            onClick={this.toggleViewMode}
+            variant="text"
+            mini
+          >
+            {this.props.buttonText}
+          </Button>
+        </div>
       </Tooltip>
     );
   }

--- a/src/shared/components/fixed-position-container.jsx
+++ b/src/shared/components/fixed-position-container.jsx
@@ -53,6 +53,12 @@ export function mapStateToProps(state, ownProps) {
       width: "100%",
       height: "100%"
     };
+
+    if (state.viewMode === "REPORT_VIEW") {
+      style.position = "static";
+      style.border = "none";
+      style.overflow = "visible";
+    }
   }
   return {
     style


### PR DESCRIPTION
Aims to fix https://github.com/iodide-project/iodide/issues/2563 issue.

This pull request adds a printing button that calls printing from iframe to the left of `EXPLORE` when using report view and changes the styling of the fixed container when in report view to make it possible to print a clean page without undesired bordering and page limiting.