### PR TITLE
Allow users to make a copy of any notebook (fixes #1621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Allow users to make a copy of any notebook (fixes #1621)
+
 # 0.17.0 (2019-12-19)
 
 - Further refine escaping iomd returned by iodide server (#2526)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # (Unreleased; add upcoming change notes here)
 
-- Allow users to make a copy of any notebook (fixes #1621)
+- Allow users to make a copy of any notebook (fixes #1621) (#2593)
 
 # 0.17.0 (2019-12-19)
 

--- a/src/editor/actions/__tests__/server-save-actions.test.js
+++ b/src/editor/actions/__tests__/server-save-actions.test.js
@@ -156,6 +156,8 @@ describe("saveNotebookToServer", () => {
 describe("createNewNotebookOnServer", () => {
   [true, false].forEach(forked => {
     it(forked ? "forked" : "not forked", async () => {
+      global.open = jest.fn();
+
       const state = initialState(forked);
       const store = mockStore(state);
       createNotebookRequest.mockClear();
@@ -170,24 +172,32 @@ describe("createNewNotebookOnServer", () => {
       );
       expect(createNotebookRequest.mock.calls).toEqual(
         forked
-          ? [[state.title, state.iomd, { forked_from: 1 }]]
+          ? [[`Copy of "${state.title}"`, state.iomd, { forked_from: 1 }]]
           : [[state.title, state.iomd, {}]]
       );
-
-      expect(store.getActions()).toEqual([
-        {
-          notebookInfo: {
-            notebook_id: forked ? 2 : 1,
-            revision_id: forked ? 2 : 1,
-            revision_is_latest: true,
-            serverSaveStatus: "OK",
-            tryItMode: false,
-            user_can_save: true,
-            username: "this-user"
-          },
-          type: "UPDATE_NOTEBOOK_INFO"
-        }
-      ]);
+      if (forked) {
+        expect(global.open).toBeCalled();
+      } else {
+        expect(global.open).not.toBeCalled();
+      }
+      expect(store.getActions()).toEqual(
+        forked
+          ? []
+          : [
+              {
+                notebookInfo: {
+                  notebook_id: 1,
+                  revision_id: 1,
+                  revision_is_latest: true,
+                  serverSaveStatus: "OK",
+                  tryItMode: false,
+                  user_can_save: true,
+                  username: "this-user"
+                },
+                type: "UPDATE_NOTEBOOK_INFO"
+              }
+            ]
+      );
     });
   });
 

--- a/src/editor/components/menu/editor-toolbar-menu.jsx
+++ b/src/editor/components/menu/editor-toolbar-menu.jsx
@@ -13,7 +13,8 @@ import {
 export class EditorToolbarMenuUnconnected extends React.Component {
   static propTypes = {
     isServer: PropTypes.bool.isRequired,
-    canUpload: PropTypes.bool,
+    isLoggedIn: PropTypes.bool,
+    canModifyNotebook: PropTypes.bool,
     isTrialNotebook: PropTypes.bool
   };
 
@@ -22,12 +23,17 @@ export class EditorToolbarMenuUnconnected extends React.Component {
       <NotebookIconMenu>
         {this.props.isServer && <NotebookMenuItem task={tasks.newNotebook} />}
         <NotebookMenuItem
+          task={tasks.makeCopy}
+          disabled={!this.props.isLoggedIn}
+        />
+        <NotebookMenuItem
           task={tasks.toggleHistoryModal}
           disabled={this.props.isTrialNotebook}
         />
-        {this.props.canUpload && (
-          <NotebookMenuItem task={tasks.toggleFileModal} />
-        )}
+        <NotebookMenuItem
+          task={tasks.toggleFileModal}
+          disabled={!this.props.canModifyNotebook}
+        />
         <NotebookMenuItem task={tasks.clearVariables} />
         <NotebookMenuItem task={tasks.toggleHelpModal} />
       </NotebookIconMenu>
@@ -41,7 +47,8 @@ export function mapStateToProps(state) {
   return {
     isServer,
     isTrialNotebook: isServer && notebookIsATrial(state),
-    canUpload: isServer && Boolean(state.notebookInfo.user_can_save)
+    isLoggedIn: isServer && state.userData.name,
+    canModifyNotebook: isServer && Boolean(state.notebookInfo.user_can_save)
   };
 }
 

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -12,6 +12,7 @@ import {
   toggleHistoryModal
 } from "../actions/modal-actions";
 import { clearVariables } from "../actions/notebook-actions";
+import { createNewNotebookOnServer } from "../actions/server-save-actions";
 
 // FIXME: remove requirement to import store in this file by attaching
 // keypress handling to store in initializeDefaultKeybindings() --
@@ -80,6 +81,13 @@ tasks.saveNotebook = new UserTask({
   keybindings: ["ctrl+s", "meta+s"],
   preventDefaultKeybinding: true,
   callback() {}
+});
+
+tasks.makeCopy = new UserTask({
+  title: "Make a Copy",
+  callback() {
+    store.dispatch(createNewNotebookOnServer());
+  }
 });
 
 tasks.clearVariables = new UserTask({


### PR DESCRIPTION
This includes their own notebook, which is a relatively common use
case (e.g. when creating a template). As part of this, open
up a copy of a notebook in a new tab, preserving a reference
to the original notebook in history.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
