### PR TITLE
Move "clear declared variables" to workspace pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Handle cases where coalescing revisions results in no change (fixes #2517)
 - Allow users to make a copy of any notebook (fixes #1621) (#2593)
 - Allow viewing files when not logged in (fixes #2562) (#2575)
+- Move "clear declared variables" to workspace pane (#2621)
 
 # 0.17.0 (2019-12-19)
 

--- a/src/editor/components/menu/editor-toolbar-menu.jsx
+++ b/src/editor/components/menu/editor-toolbar-menu.jsx
@@ -32,7 +32,6 @@ export class EditorToolbarMenuUnconnected extends React.Component {
         {this.props.isServer && (
           <NotebookMenuItem task={tasks.toggleFileModal} />
         )}
-        <NotebookMenuItem task={tasks.clearVariables} />
         <NotebookMenuItem task={tasks.toggleHelpModal} />
       </NotebookIconMenu>
     );

--- a/src/editor/components/panes/declared-variable.jsx
+++ b/src/editor/components/panes/declared-variable.jsx
@@ -1,7 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "@emotion/styled";
 
 import { WindowValueRenderer } from "../remote-reps/remote-value-renderer";
+
+const DeclaredVariableContainer = styled("div")`
+  padding-bottom: 15px;
+`;
+
+const DeclaredVariableName = styled("div")`
+  font-size: 14px;
+  font-family: monospace;
+  background: #f9f9f9;
+  border: 1px solid #f1f1f1;
+  padding: 1px 10px;
+  color: #000;
+`;
+
+const DeclaredVariableValue = styled("div")`
+  padding-left: 20px;
+  overflow-x: auto;
+`;
 
 export class DeclaredVariable extends React.Component {
   static propTypes = {
@@ -9,12 +28,12 @@ export class DeclaredVariable extends React.Component {
   };
   render() {
     return (
-      <div className="declared-variable">
-        <div className="declared-variable-name">{this.props.varName} = </div>
-        <div className="declared-variable-value">
+      <DeclaredVariableContainer>
+        <DeclaredVariableName>{this.props.varName} = </DeclaredVariableName>
+        <DeclaredVariableValue>
           <WindowValueRenderer valueKey={this.props.varName} />
-        </div>
-      </div>
+        </DeclaredVariableValue>
+      </DeclaredVariableContainer>
     );
   }
 }

--- a/src/editor/components/panes/declared-variables-pane.jsx
+++ b/src/editor/components/panes/declared-variables-pane.jsx
@@ -2,13 +2,32 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { isEqual } from "lodash";
+import styled from "@emotion/styled";
 
 import { DeclaredVariable } from "./declared-variable";
+import { OutlineButton } from "../../../shared/components/buttons";
+import { clearVariables } from "../../actions/notebook-actions";
+
+const DeclaredVariables = styled("div")`
+  padding: 15px;
+`;
+
+const HeaderContainer = styled("div")`
+  padding: 15px 15px 0px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  div:last-child {
+    padding-left: 8px;
+  }
+`;
 
 export class DeclaredVariablesPaneUnconnected extends React.Component {
   static propTypes = {
     userDefinedVarNames: PropTypes.arrayOf(PropTypes.string),
-    paneVisible: PropTypes.bool.isRequired
+    paneVisible: PropTypes.bool.isRequired,
+    clearVariables: PropTypes.func.isRequired
   };
 
   shouldComponentUpdate(nextProps) {
@@ -21,16 +40,29 @@ export class DeclaredVariablesPaneUnconnected extends React.Component {
   render() {
     return (
       <div className="pane-content">
-        <div className="declared-variables-list">
-          <h3>User Defined Variables</h3>
+        <HeaderContainer>
+          <div>
+            <h3>User Defined Variables</h3>
+          </div>
+          <div>
+            <OutlineButton onClick={this.props.clearVariables}>
+              Clear
+            </OutlineButton>
+          </div>
+        </HeaderContainer>
+        <DeclaredVariables>
           {this.props.userDefinedVarNames.map(varName => (
             <DeclaredVariable varName={varName} key={varName} />
           ))}
-        </div>
+        </DeclaredVariables>
       </div>
     );
   }
 }
+
+const mapDispatchToProps = {
+  clearVariables
+};
 
 export function mapStateToProps(state) {
   return {
@@ -39,4 +71,7 @@ export function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(DeclaredVariablesPaneUnconnected);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DeclaredVariablesPaneUnconnected);

--- a/src/editor/style/side-panes.css
+++ b/src/editor/style/side-panes.css
@@ -3,25 +3,3 @@
   height: 100%;
   overflow: auto;
 }
-
-div.declared-variables-list {
-  padding: 15px;
-}
-
-div.declared-variable {
-  padding-bottom: 15px;
-}
-
-div.declared-variable-name {
-  font-size: 14px;
-  font-family: monospace;
-  background: #f9f9f9;
-  border: 1px solid #f1f1f1;
-  padding: 1px 10px;
-  color: #000;
-}
-
-div.declared-variable-value {
-  padding-left: 20px;
-  overflow-x: auto;
-}

--- a/src/editor/user-tasks/task-definitions.js
+++ b/src/editor/user-tasks/task-definitions.js
@@ -11,7 +11,6 @@ import {
   toggleHelpModal,
   toggleHistoryModal
 } from "../actions/modal-actions";
-import { clearVariables } from "../actions/notebook-actions";
 import { createNewNotebookOnServer } from "../actions/server-save-actions";
 
 // FIXME: remove requirement to import store in this file by attaching
@@ -87,14 +86,6 @@ tasks.makeCopy = new UserTask({
   title: "Make a Copy",
   callback() {
     store.dispatch(createNewNotebookOnServer());
-  }
-});
-
-tasks.clearVariables = new UserTask({
-  title: "Clear Variables",
-  preventDefaultKeybinding: true,
-  callback() {
-    store.dispatch(clearVariables());
   }
 });
 


### PR DESCRIPTION
After doing this, it is a bit unclear to me whether we should keep this
functionality or just remove it altogether -- it's a bit of a footgun,
doesn't work as advertised (e.g. #2101) and doesn't seem that useful even
on its own terms (I have never actually tried to use it outside of testing
this PR). But in any case, this seems like a more logical place for the action
than the menu.