### PR TITLE
Allow creation of new or tryit notebook from iomd template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # (Unreleased; add upcoming change notes here)
 
+- Can now specify notebook iomd via a URL parameter with new or
+  tryit endpoints (fixes #2565) (#2676)
+
 # 0.18.0 (2020-01-22)
 
 - Center "Help" and "Play" icons in some browsers (fixes #2567) (#2570)


### PR DESCRIPTION
Partially fixes #2565, currently this is limited to creating a notebook with a specific iomd-- ideally we would also allow attaching files to the payload as well, but that will require handling these as POST requests (which is considerably more technically involved)

This also needs tests and documentation.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
