### PR TITLE
allow pre-attached template and data file (#issue2681)

### DIFF
--- a/server/notebooks/templates/notebook_uploaded_files.html
+++ b/server/notebooks/templates/notebook_uploaded_files.html
@@ -7,7 +7,11 @@
 <div id="notebook-header"></div>
 <div id="editor-react-root"></div>
 <script id="iomd" type="text/iomd">{{ iomd|escape }}</script>
-<script id="file0" type="text">{{datafile|safe}}</script>
+
+{% for data in datalist %}
+<script id="file{{forloop.counter0}}" type="text">{{data|safe}}</script>
+{% endfor %}
+
 <iframe
   id="eval-frame"
   src="{{ iframe_src|safe }}"

--- a/server/notebooks/templates/notebook_uploaded_files.html
+++ b/server/notebooks/templates/notebook_uploaded_files.html
@@ -7,7 +7,7 @@
 <div id="notebook-header"></div>
 <div id="editor-react-root"></div>
 <script id="iomd" type="text/iomd">{{ iomd|escape }}</script>
-<script id="file0" type="application/json">{{datafile|escape}}</script>
+<script id="file0" type="text">{{datafile|safe}}</script>
 <iframe
   id="eval-frame"
   src="{{ iframe_src|safe }}"

--- a/server/notebooks/templates/notebook_uploaded_files.html
+++ b/server/notebooks/templates/notebook_uploaded_files.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block head %}
+<link rel="stylesheet" type="text/css" href="/iodide.css">
+<base target="_blank" rel="noopener noreferrer">
+{% endblock %}
+{% block content %}
+<div id="notebook-header"></div>
+<div id="editor-react-root"></div>
+<script id="iomd" type="text/iomd">{{ iomd|escape }}</script>
+<script id="file0" type="application/json">{{datafile|escape}}</script>
+<iframe
+  id="eval-frame"
+  src="{{ iframe_src|safe }}"
+  sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
+  allowfullscreen="true"
+  allowvr="yes"
+  allow="microphone"
+></iframe>
+{{ user_info|json_script:"userData" }}
+{{ notebook_info|json_script:"notebookInfo" }}
+<script>
+  window.evalFrameOrigin = "{{ eval_frame_origin }}";
+</script>
+<script src="/iodide.js"></script>
+{% endblock %}

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
-from django.template import Template
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -134,7 +133,6 @@ def _get_new_notebook_content(iomd):
     if iomd:
         return iomd
     # default is to create a new notebook from our default template
-    print(get_template("new_notebook_content.iomd").backend)
     return get_template("new_notebook_content.iomd").render()
 
 
@@ -170,10 +168,10 @@ def tryit_view(request):
     If user is logged in, redirect to `/new/`
     """
     iomd = request.GET.get("iomd")
+
     if request.user.is_authenticated:
         return redirect(reverse(new_notebook_view) + _get_iomd_params(iomd))
 
-    print(_get_new_notebook_content(iomd))
     return render(
         request,
         "notebook.html",

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -196,18 +196,25 @@ def tryit_view(request):
 def customize_view(request):
 
     if request.method == "POST":
+        if 'template' in request.FILES and 'data' in request.FILES:
+            postedTemplate = request.FILES['template']
+            postedData = request.FILES['data']
+            
+            print("received data")
+            print(len(postedData))
         
-        postedTemplate = request.FILES['template']
-        postedData = request.FILES['data']
-    
-        template = postedTemplate.read().decode()
-        data = postedData.read().decode()
+            iomd = postedTemplate.read().decode()
+            data = postedData.read().decode()
+        else:
+            iomd = None
+            data = None 
+        
 
-        iomd = template + data
+        
 
         return render(
         request,
-        "notebook.html",
+        "notebook_uploaded_files.html",
         {
             "user_info": {},
             "notebook_info": {
@@ -216,6 +223,7 @@ def customize_view(request):
                 "title": "POST SUCCESS",
             },
             "iomd": _get_new_notebook_content(iomd),
+            "datafile": data,
             "iframe_src": _get_iframe_src(),
             "eval_frame_origin": EVAL_FRAME_ORIGIN,
         },

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -194,23 +194,20 @@ def tryit_view(request):
 '''
 @csrf_exempt
 def customize_view(request):
+    iomd = None
+    data = None
 
     if request.method == "POST":
-        if 'template' in request.FILES and 'data' in request.FILES:
+        if 'template' in request.FILES :
             postedTemplate = request.FILES['template']
-            postedData = request.FILES['data']
-            
-            print("received data")
-            print(len(postedData))
-        
             iomd = postedTemplate.read().decode()
+        if 'data' in request.FILES:
+            postedData = request.FILES['data']
             data = postedData.read().decode()
-        else:
-            iomd = None
-            data = None 
-        
-
-        
+        if 'data[]' in request.FIELS:
+            datalist = request.FILES.getlist('data[]')
+            # add multiple <script id="fileNumber"> in
+            # default template files.
 
         return render(
         request,
@@ -227,4 +224,6 @@ def customize_view(request):
             "iframe_src": _get_iframe_src(),
             "eval_frame_origin": EVAL_FRAME_ORIGIN,
         },
-    )
+        )
+    else:
+        return new_notebook_view(request)

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -208,7 +208,7 @@ def from_template_view(request):
         iomd = postedTemplate.read().decode()
     # Support posting template through a textarea.
     # for mach-perftest-notebook
-    if "template" in request.POST:
+    elif "template" in request.POST:
         postedTemplate = request.POST.get("template")
         iomd = postedTemplate
     # receives only 1 data file.
@@ -216,25 +216,27 @@ def from_template_view(request):
         postedData = request.FILES["data"]
         data.append(postedData.read().decode())
     # receives multiple data files
-    if "data[]" in request.FILES:
+    elif "data[]" in request.FILES:
         for datafile in request.FILES.getlist("data[]"):
             data.append(datafile.read().decode())
-
-        return render(
-            request,
-            "notebook_uploaded_files.html",
-            {
-                "user_info": {},
-                "notebook_info": {
-                    "connectionMode": "SERVER",
-                    "tryItMode": True,
-                    "title": "Customized Template",
-                },
-                "iomd": _get_new_notebook_content(iomd),
-                "datalist": data,
-                "iframe_src": _get_iframe_src(),
-                "eval_frame_origin": EVAL_FRAME_ORIGIN,
-            },
-        )
-    else:
+    # if user posted nothing at all,
+    # return new empty notebook
+    if iomd is None and len(data) == 0:
         return new_notebook_view(request)
+
+    return render(
+        request,
+        "notebook_uploaded_files.html",
+        {
+            "user_info": {},
+            "notebook_info": {
+                "connectionMode": "SERVER",
+                "tryItMode": True,
+                "title": "Customized Template",
+            },
+            "iomd": _get_new_notebook_content(iomd),
+            "datalist": data,
+            "iframe_src": _get_iframe_src(),
+            "eval_frame_origin": EVAL_FRAME_ORIGIN,
+        },
+    )

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -204,7 +204,7 @@ def customize_view(request):
         if 'data' in request.FILES:
             postedData = request.FILES['data']
             data = postedData.read().decode()
-        if 'data[]' in request.FIELS:
+        if 'data[]' in request.FILES:
             datalist = request.FILES.getlist('data[]')
             # add multiple <script id="fileNumber"> in
             # default template files.

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import ensure_csrf_cookie,csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
 from ..base.models import User
@@ -188,11 +188,14 @@ def tryit_view(request):
         },
     )
 
-'''
+
+"""
     Let user use his own template file and data file.
     Data file must be posted via enctype="multipart/form-data"
     Supports multiple data file
-'''
+"""
+
+
 @require_http_methods(["POST"])
 @csrf_exempt
 def from_template_view(request):
@@ -200,40 +203,38 @@ def from_template_view(request):
     data = []
 
     # Support posting template through uploading files
-    if 'template' in request.FILES :
-        postedTemplate = request.FILES['template']
+    if "template" in request.FILES:
+        postedTemplate = request.FILES["template"]
         iomd = postedTemplate.read().decode()
     # Support posting template through a textarea.
     # for mach-perftest-notebook
-    if 'template' in request.POST:
-        postedTemplate = request.POST.get('template')
+    if "template" in request.POST:
+        postedTemplate = request.POST.get("template")
         iomd = postedTemplate
-    # receives only 1 data file. 
-    if 'data' in request.FILES:
-        postedData = request.FILES['data']
+    # receives only 1 data file.
+    if "data" in request.FILES:
+        postedData = request.FILES["data"]
         data.append(postedData.read().decode())
     # receives multiple data files
-    if 'data[]' in request.FILES:
-        for datafile in request.FILES.getlist('data[]'):
+    if "data[]" in request.FILES:
+        for datafile in request.FILES.getlist("data[]"):
             data.append(datafile.read().decode())
-            
-        
 
         return render(
-        request,
-        "notebook_uploaded_files.html",
-        {
-            "user_info": {},
-            "notebook_info": {
-                "connectionMode": "SERVER",
-                "tryItMode": True,
-                "title": "Customized Template",
+            request,
+            "notebook_uploaded_files.html",
+            {
+                "user_info": {},
+                "notebook_info": {
+                    "connectionMode": "SERVER",
+                    "tryItMode": True,
+                    "title": "Customized Template",
+                },
+                "iomd": _get_new_notebook_content(iomd),
+                "datalist": data,
+                "iframe_src": _get_iframe_src(),
+                "eval_frame_origin": EVAL_FRAME_ORIGIN,
             },
-            "iomd": _get_new_notebook_content(iomd),
-            "datalist": data,
-            "iframe_src": _get_iframe_src(),
-            "eval_frame_origin": EVAL_FRAME_ORIGIN,
-        },
         )
     else:
         return new_notebook_view(request)

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -6,8 +6,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
 from django.urls import reverse
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import ensure_csrf_cookie,csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from ..base.models import User

--- a/server/notebooks/views.py
+++ b/server/notebooks/views.py
@@ -204,6 +204,9 @@ def customize_view(request):
         if 'data' in request.FILES:
             postedData = request.FILES['data']
             data = postedData.read().decode()
+            print(type(data))
+            print(data[:20])
+
         if 'data[]' in request.FILES:
             datalist = request.FILES.getlist('data[]')
             # add multiple <script id="fileNumber"> in

--- a/server/urls.py
+++ b/server/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r"^notebooks/", include("server.notebooks.urls")),
     url(r"^new/?", server.notebooks.views.new_notebook_view, name="new-notebook"),
     url(r"^tryit/?", server.notebooks.views.tryit_view, name="try-it"),
+    url(r"^customize/?", server.notebooks.views.customize_view, name="try-it"),
     # various views to help with the authentication pipeline
     url(r"^oauth/", include("social_django.urls", namespace="social")),
     url(r"^login_success/$", server.views.login_success, name="login_success"),

--- a/server/urls.py
+++ b/server/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     url(r"^notebooks/", include("server.notebooks.urls")),
     url(r"^new/?", server.notebooks.views.new_notebook_view, name="new-notebook"),
     url(r"^tryit/?", server.notebooks.views.tryit_view, name="try-it"),
-    url(r"^customize/?", server.notebooks.views.customize_view, name="customize"),
+    url(r"^from-template/?", server.notebooks.views.from_template_view, name="from-template"),
     # various views to help with the authentication pipeline
     url(r"^oauth/", include("social_django.urls", namespace="social")),
     url(r"^login_success/$", server.views.login_success, name="login_success"),

--- a/server/urls.py
+++ b/server/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     url(r"^notebooks/", include("server.notebooks.urls")),
     url(r"^new/?", server.notebooks.views.new_notebook_view, name="new-notebook"),
     url(r"^tryit/?", server.notebooks.views.tryit_view, name="try-it"),
-    url(r"^customize/?", server.notebooks.views.customize_view, name="try-it"),
+    url(r"^customize/?", server.notebooks.views.customize_view, name="customize"),
     # various views to help with the authentication pipeline
     url(r"^oauth/", include("social_django.urls", namespace="social")),
     url(r"^login_success/$", server.views.login_success, name="login_success"),


### PR DESCRIPTION
Adds a function that returns a iodide page with customized template file and data
parameter: httpPostRequest
returns: iodide Django view with data attached to customized template.

file uploads must be done through POST like this:
<form action= " addressToIodide/customize">:
<input name = "template"> for template file  
<input name = "data"> for data file


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
