### PR TITLE
Always show clear history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Can now specify notebook iomd via a URL parameter with new or
   tryit endpoints (fixes #2565) (#2676)
+- "Clear history" button is always shown in the Console dropdown
 
 # 0.18.0 (2020-01-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Can now specify notebook iomd via a URL parameter with new or
   tryit endpoints (fixes #2565) (#2676)
-- "Clear history" button is always shown in the Console dropdown
+- Always show "Clear history" button in the Console dropdown (#2707)
 
 # 0.18.0 (2020-01-22)
 

--- a/src/editor/console/input/components/__tests__/console-input-field.test.js
+++ b/src/editor/console/input/components/__tests__/console-input-field.test.js
@@ -3,8 +3,32 @@ import React from "react";
 
 import {
   ConsoleInputUnconnected,
+  getTextAreaPosition,
   mapStateToProps
 } from "../console-input-field";
+
+describe("getTextAreaPosition", () => {
+  it("should return currentLine & totalLines", () => {
+    const tests = [
+      [0, "foo\nbar\nbat", 1, 3],
+      [3, "foo\nbar\nbat", 1, 3],
+      [4, "foo\nbar\nbat", 2, 3],
+      [7, "foo\nbar\nbat", 2, 3],
+      [8, "foo\nbar\nbat", 3, 3],
+      [11, "foo\nbar\nbat", 3, 3],
+      [99, "foo\nbar\nbat", 3, 3]
+    ]
+    tests.forEach(([selectionStart, value, currentLine, totalLines]) => {
+      const textArea = {
+        selectionStart,
+        value
+      }
+      const position = getTextAreaPosition(textArea)
+      expect(position.currentLine).toBe(currentLine)
+      expect(position.totalLines).toBe(totalLines)
+    })
+  })
+})
 
 describe("ConsoleInputUnconnected React component", () => {
   let props;

--- a/src/editor/console/input/components/__tests__/console-input-field.test.js
+++ b/src/editor/console/input/components/__tests__/console-input-field.test.js
@@ -17,18 +17,18 @@ describe("getTextAreaPosition", () => {
       [8, "foo\nbar\nbat", 3, 3],
       [11, "foo\nbar\nbat", 3, 3],
       [99, "foo\nbar\nbat", 3, 3]
-    ]
+    ];
     tests.forEach(([selectionStart, value, currentLine, totalLines]) => {
       const textArea = {
         selectionStart,
         value
-      }
-      const position = getTextAreaPosition(textArea)
-      expect(position.currentLine).toBe(currentLine)
-      expect(position.totalLines).toBe(totalLines)
-    })
-  })
-})
+      };
+      const position = getTextAreaPosition(textArea);
+      expect(position.currentLine).toBe(currentLine);
+      expect(position.totalLines).toBe(totalLines);
+    });
+  });
+});
 
 describe("ConsoleInputUnconnected React component", () => {
   let props;

--- a/src/editor/console/input/components/__tests__/console-language-menu.test.js
+++ b/src/editor/console/input/components/__tests__/console-language-menu.test.js
@@ -63,3 +63,33 @@ describe("ConsoleLanguageMenu clearConsoleHistory", () => {
     expect(props.clearConsoleHistory).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ConsoleLanguageMenu setConsoleLanguageProp", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      availableLanguages: [
+        {
+          languageId: "js",
+          displayName: "JavaScript"
+        },
+        {
+          languageId: "py",
+          displayName: "Python"
+        }
+      ],
+      clearConsoleHistory: jest.fn(),
+      currentLanguage: "js",
+      setConsoleLanguageProp: jest.fn()
+    };
+  });
+  it("calls correct action when a language is clicked", () => {
+    const wrapper = shallow(<ConsoleLanguageMenuUnconnected {...props} />, {
+      context: {}
+    });
+    expect(props.setConsoleLanguageProp).toHaveBeenCalledTimes(0);
+    wrapper.findWhere(c => c.key() === "py").simulate("click");
+    expect(props.setConsoleLanguageProp).toHaveBeenCalledTimes(1);
+    expect(props.setConsoleLanguageProp).toBeCalledWith("py");
+  });
+});

--- a/src/editor/console/input/components/__tests__/console-language-menu.test.js
+++ b/src/editor/console/input/components/__tests__/console-language-menu.test.js
@@ -37,17 +37,6 @@ describe("ConsoleLanguageMenu mapStateToProps", () => {
       new Set(["JavaScript", "Python", "Julia"])
     );
   });
-  it("sets shouldDisplayClearConsoleAction prop as true when history not empty", () => {
-    expect(mapStateToProps(state).shouldDisplayClearConsoleAction).toEqual(
-      true
-    );
-  });
-  it("sets shouldDisplayClearConsoleAction prop as false when history empty", () => {
-    state.history = [];
-    expect(mapStateToProps(state).shouldDisplayClearConsoleAction).toEqual(
-      false
-    );
-  });
 });
 
 describe("ConsoleLanguageMenu clearConsoleHistory", () => {
@@ -62,8 +51,7 @@ describe("ConsoleLanguageMenu clearConsoleHistory", () => {
       ],
       clearConsoleHistory: jest.fn(),
       currentLanguage: "py",
-      setConsoleLanguageProp: jest.fn(),
-      shouldDisplayClearConsoleAction: true
+      setConsoleLanguageProp: jest.fn()
     };
   });
   it("calls correct action when 'Clear console' item is clicked", () => {

--- a/src/editor/console/input/components/console-input-field.jsx
+++ b/src/editor/console/input/components/console-input-field.jsx
@@ -83,15 +83,13 @@ export class ConsoleInputUnconnected extends React.Component {
   }
 
   handleKeyDown(event) {
-    if (event.key === "ArrowUp" || event.key === "ArrowDown") {
-      if (event.key === "ArrowUp" && this.onFirstLine()) {
-        this.props.updateConsoleText(this.textAreaRef.current.value);
-        this.props.consoleHistoryStepBack(1);
-      }
-      if (event.key === "ArrowDown" && this.onLastLine()) {
-        this.props.updateConsoleText(this.textAreaRef.current.value);
-        this.props.consoleHistoryStepBack(-1);
-      }
+    if (event.key === "ArrowUp" && this.onFirstLine()) {
+      this.props.updateConsoleText(this.textAreaRef.current.value);
+      this.props.consoleHistoryStepBack(1);
+    }
+    if (event.key === "ArrowDown" && this.onLastLine()) {
+      this.props.updateConsoleText(this.textAreaRef.current.value);
+      this.props.consoleHistoryStepBack(-1);
     }
     if (event.key === "Enter" && !event.shiftKey) {
       this.props.evalConsoleInput(this.textAreaRef.current.value);

--- a/src/editor/console/input/components/console-language-menu.jsx
+++ b/src/editor/console/input/components/console-language-menu.jsx
@@ -74,8 +74,7 @@ export const ConsoleLanguageMenuUnconnected = ({
   availableLanguages,
   clearConsoleHistory,
   currentLanguage,
-  setConsoleLanguageProp,
-  shouldDisplayClearConsoleAction
+  setConsoleLanguageProp
 }) => {
   return (
     <React.Fragment>
@@ -101,14 +100,12 @@ export const ConsoleLanguageMenuUnconnected = ({
             </MenuItem>
           ))}
           <Divider light />
-          {shouldDisplayClearConsoleAction && (
-            <MenuItem key="clear-history" onClick={() => clearConsoleHistory()}>
-              <LanguageName>Clear history</LanguageName>
-              <LanguageShort>
-                <DeleteIcon />
-              </LanguageShort>
-            </MenuItem>
-          )}
+          <MenuItem key="clear-history" onClick={() => clearConsoleHistory()}>
+            <LanguageName>Clear history</LanguageName>
+            <LanguageShort>
+              <DeleteIcon />
+            </LanguageShort>
+          </MenuItem>
         </Menu>
       </Popover>
     </React.Fragment>
@@ -124,20 +121,16 @@ ConsoleLanguageMenuUnconnected.propTypes = {
   ).isRequired,
   clearConsoleHistory: PropTypes.func.isRequired,
   currentLanguage: PropTypes.string.isRequired,
-  setConsoleLanguageProp: PropTypes.func.isRequired,
-  shouldDisplayClearConsoleAction: PropTypes.bool
+  setConsoleLanguageProp: PropTypes.func.isRequired
 };
 
 export function mapStateToProps(state) {
   const availableLanguages = Object.values(
     Object.assign({}, state.languageDefinitions, state.loadedLanguages)
   );
-  const shouldDisplayClearConsoleAction =
-    state.history && state.history.length > 0;
   return {
     currentLanguage: state.languageLastUsed,
-    availableLanguages,
-    shouldDisplayClearConsoleAction
+    availableLanguages
   };
 }
 const mapDispatchToProps = {


### PR DESCRIPTION
Always show the "Clear history" button in the _Console_ dropdown.

In my opinion, hiding the "Clear history" button is a bad UX since:
- It changes the user expectation of the dropdown. Let say the user opens the dropdown when the history is empty, the user will put in his/her mind that the last button in the dropdown is some button. When the user opens the dropdown again, his/her expectation should be that the last button is the same button. But, depending on the history the user expectation will be violated. Also, it's hard to establish a habit since the brain needs to figure out the pattern first. If the dropdowns remain the same, it's much more intuitive & easier for the brain to develop a habit. For example, some developers liked _clearing_ an already _cleared_ console since they developed that habit.
- It makes it hard for new users to discover the "Clear history" functionality.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
