### PR TITLE
Upgrade circle node image from 8 -> 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ save_javascript_cache: &save_javascript_cache
     paths:
       - ~/cache/npm
       - node_modules
-    key: v1-javascript-dependencies-{{ checksum "package.json" }}
+    key: v2-javascript-dependencies-{{ checksum "package.json" }}
 
 restore_javascript_cache: &restore_javascript_cache
   restore_cache:
     keys:
-      - v1-javascript-dependencies-{{ checksum "package.json" }}
-      - v1-javascript-dependencies-
+      - v2-javascript-dependencies-{{ checksum "package.json" }}
+      - v2-javascript-dependencies-
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   test-javascript:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/iodide
     environment:
       npm_config_cache: ~/cache/npm
@@ -40,7 +40,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/iodide
     environment:
       npm_config_cache: ~/cache/npm
@@ -144,7 +144,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/iodide
     steps:
       - setup_remote_docker

--- a/src/editor/actions/__tests__/server-save-actions.test.js
+++ b/src/editor/actions/__tests__/server-save-actions.test.js
@@ -59,6 +59,7 @@ describe("saveNotebookToServer", () => {
     const store = mockStore({
       ...initialState(false)
     });
+    createNotebookRequest.mockReset();
     createNotebookRequest.mockResolvedValue({
       id: 1,
       latest_revision: {

--- a/src/editor/actions/server-save-actions.js
+++ b/src/editor/actions/server-save-actions.js
@@ -93,7 +93,7 @@ export function saveNotebookToServer(forceSave = false) {
     try {
       // no notebook exists yet on server, need to create one
       if (!notebookInServer) {
-        dispatch(createNewNotebookOnServer());
+        await dispatch(createNewNotebookOnServer());
         return;
       }
       // save existing revision


### PR DESCRIPTION
8 is long-since deprecated, 12 is the current lts



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [ ] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
