### PR TITLE
Use pyodide v0.15, from the new cloudflare CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   a new `/from-template/` endpoint (fixes #2681) (#2849)
 - Don't warn unnecessarily when navigating away from a notebook (fixes #2537) (#2855)
 - Allow attaching files to a trial notebook (or when unauthenticated) (fixes #2680) (#2727)
+- Use pyodide v0.15, fetching from cloudflare CDN (#2874)
 
 # 0.19.1 (2020-04-06)
 

--- a/src/editor/state-schemas/language-definitions.js
+++ b/src/editor/state-schemas/language-definitions.js
@@ -12,7 +12,7 @@ export const jsLanguageDefinition = {
 
 const PYODIDE_URL = process.env.USE_LOCAL_PYODIDE
   ? "/pyodide/pyodide.js"
-  : "https://pyodide.cdn.iodide.io/pyodide.js";
+  : "https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js";
 
 const pyLanguageDefinition = {
   languageId: "py",


### PR DESCRIPTION
This fortunately/unfortunately removes the ability of us to
upgrade pyodide seamlessly-- a change on iodide is now required.
See iodide-project/pyodide#669 for more information.




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [N/A] **Tests**: This PR includes thorough tests or an explanation of why it does not