### PR TITLE
Allow popups from iodide iframe to escape sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Allow new windows opened from iodide to submit forms (#2919)
+
 # 0.20.1 (2020-05-28)
 
 - Fix one last case where the user might be warned unnecessarily when navigating

--- a/server/notebooks/templates/notebook.html
+++ b/server/notebooks/templates/notebook.html
@@ -10,7 +10,7 @@
 <iframe
   id="eval-frame"
   src="{{ iframe_src|safe }}"
-  sandbox="allow-scripts allow-same-origin allow-modals allow-popups"
+  sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-popups-to-escape-sandbox"
   allowfullscreen="true"
   allowvr="yes"
   allow="microphone"

--- a/src/editor/static.html
+++ b/src/editor/static.html
@@ -16,7 +16,7 @@ This is an environment designed to help you test changes to the Iodide editor. Y
     <iframe
       id="eval-frame"
       src="/eval-frame/"
-      sandbox="allow-scripts allow-modals allow-same-origin"
+      sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-popups-to-escape-sandbox"
       allowfullscreen="true"
       allowvr="yes"
     ></iframe>


### PR DESCRIPTION
This makes sure forms from pages opened from an iodide
report still work. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1652980




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: If this feature has or requires documentation, the relevant docs have been updated.
- [x] **Changelog**: This PR updates the [changelog](https://github.com/iodide-project/iodide/blob/master/CHANGELOG.md) with any user-visible changes.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not