### PR TITLE
Wait for database before running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
+- Wait for database before running migrations (#2935)
+
 # 0.20.2 (2020-07-16)
 
 - Allow new windows opened from iodide to submit forms (#2919)

--- a/bin/run
+++ b/bin/run
@@ -34,6 +34,7 @@ tests() {
 
 case $1 in
   dev)
+    bash -c "while ! echo > /dev/tcp/db/5432 > /dev/null 2>&1; do sleep 1 && echo waiting for db; done"
     python manage.py migrate --noinput
     exec python manage.py runserver 0.0.0.0:${PORT}
     ;;


### PR DESCRIPTION
This prevents a race condition while launching the containers for
local development, whereby the migrations script is sometimes being
executed before the database is ready to accept connections.

This borrows the approach currently used in the CI pipeline, as suggested by @wlach 

https://github.com/iodide-project/iodide/blob/5c38c734420edb37ccff5ea3243d6125a498be8c/.circleci/config.yml#L140

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Documentation**: Not sure if this needs to be documented
- [ ] **Changelog**: Infrastructure related change, so probably does not apply 
- [ ] **Tests**: Infrastructure related change, so probably does not apply
