### PR TITLE
Switch to JsDelivr CDN for pyodide 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # (Unreleased; add upcoming change notes here)
 
 - Wait for database before running migrations (#2935)
+- Switched to the jsDelivr CDN for pyodide 0.15.0 (#3020)
 
 # 0.20.2 (2020-07-16)
 

--- a/src/editor/state-schemas/language-definitions.js
+++ b/src/editor/state-schemas/language-definitions.js
@@ -12,7 +12,7 @@ export const jsLanguageDefinition = {
 
 const PYODIDE_URL = process.env.USE_LOCAL_PYODIDE
   ? "/pyodide/pyodide.js"
-  : "https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js";
+  : "https://cdn.jsdelivr.net/v0.15.0/full/pyodide.js";
 
 const pyLanguageDefinition = {
   languageId: "py",

--- a/src/editor/state-schemas/language-definitions.js
+++ b/src/editor/state-schemas/language-definitions.js
@@ -12,7 +12,7 @@ export const jsLanguageDefinition = {
 
 const PYODIDE_URL = process.env.USE_LOCAL_PYODIDE
   ? "/pyodide/pyodide.js"
-  : "https://cdn.jsdelivr.net/v0.15.0/full/pyodide.js";
+  : "https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js";
 
 const pyLanguageDefinition = {
   languageId: "py",


### PR DESCRIPTION
This switches to JsDelivr CDN while still using pyodide 0.15.0, in order to reduce usage of previous CDN endpoint.

The only thing I'm not sure about is whether iodide would set `windows.languagePluginUrl` to `https://cdn.jsdelivr.net/v0.15.0/full/` in this case before loading `pyodide.js`. It does seem to be set [here](https://github.com/iodide-project/iodide/blob/700441e14be3e06613a011a4ec4b07f8641e53a1/src/eval-frame/actions/language-actions.js#L40) but I could be missing something. This is a requirement, otherwise packages will still be loaded from the previous CDN which is hardcoded in `pyodide.js`.

It we update to pyodide 0.16.1, which should also be compatible with iodide, this should no longer be be an issue, though it includes Python 3.8 and updated packages so there is a slightly higher risk of it breaking something in existing notebooks.
